### PR TITLE
FIX: set only changed cookies

### DIFF
--- a/test/cookies_test.rb
+++ b/test/cookies_test.rb
@@ -14,7 +14,16 @@ describe Hanami::Action do
       _, headers, body = action.call({'HTTP_COOKIE' => 'foo=bar'})
 
       action.send(:cookies).must_include({foo: 'bar'})
-      headers.must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => 'foo=bar'})
+      headers.must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8'})
+      body.must_equal ['bar']
+    end
+
+    it 'change cookies' do
+      action   = ChangeCookiesAction.new
+      _, headers, body = action.call({'HTTP_COOKIE' => 'foo=bar'})
+
+      action.send(:cookies).must_include({foo: 'bar'})
+      headers.must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => 'foo=baz'})
       body.must_equal ['bar']
     end
 
@@ -38,7 +47,7 @@ describe Hanami::Action do
       action   = RemoveCookiesAction.new
       _, headers, _ = action.call({'HTTP_COOKIE' => 'foo=bar;rm=me'})
 
-      headers.must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => "foo=bar\nrm=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"})
+      headers.must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => "rm=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"})
     end
 
     describe 'with default cookies' do

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -482,6 +482,16 @@ class GetCookiesAction
   end
 end
 
+class ChangeCookiesAction
+  include Hanami::Action
+  include Hanami::Action::Cookies
+
+  def call(params)
+    self.body = cookies[:foo]
+    cookies[:foo] = 'baz'
+  end
+end
+
 class GetDefaultCookiesAction
   include Hanami::Action
   include Hanami::Action::Cookies


### PR DESCRIPTION
`Hanami::Action::CookieJar` sets up response header `Set-Cookie` for **all** incoming cookies at current path/domain.
And CookieJar apply same rules (`httponly` or `secure`) to all setted cookies, that unfortunately breaks some counters and third-party metrics.
I tried to avoid this side effect by setting only changed cookies in response.