### PR TITLE
Introduced Hanami::Action::Params#error_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 Complete, fast and testable actions for Rack
 
 ## v0.7.0 - (unreleased)
+### Added
+- [Luca Guidi] Introduced `Hanami::Action::Params#error_messages` which returns a flat collection of full error messages
+
 ### Fixed
 - [Luca Guidi] Params are deeply symbolized
 - [Artem Nistratov] Send only changed cookies in HTTP response
 
 ### Changed
-– [Luca Guidi] Drop support for Ruby 2.0 and 2.1. Official support for JRuby 9.0.5.0+.
+- [Luca Guidi] Drop support for Ruby 2.0 and 2.1. Official support for JRuby 9.0.5.0+.
 - [Luca Guidi] Param validations now require you to add `hanami-validations` in `Gemfile`.
 - [Luca Guidi] Removed "_indifferent access_" for params. Since now on, only symbols are allowed.
 - [Luca Guidi] Params are immutable

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -54,8 +54,33 @@ module Hanami
         @input
       end
 
+      # Returns structured error messages
+      #
+      # @return [Hash]
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   params.errors
+      #     # => {:email=>["is missing", "is in invalid format"], :name=>["is missing"], :tos=>["is missing"], :age=>["is missing"], :address=>["is missing"]}
       def errors
         @result.messages
+      end
+
+      # Returns flat collection of full error messages
+      #
+      # @return [Array]
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   params.error_messages
+      #     # => ["Email is missing", "Email is in invalid format", "Name is missing", "Tos is missing", "Age is missing", "Address is missing"]
+      def error_messages
+        errors.each_with_object([]) do |(key, messages), result|
+          k = Utils::String.new(key).titleize
+          result.concat messages.map { |message| "#{k} #{message}" }
+        end
       end
 
       def valid?

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -185,6 +185,8 @@ describe Hanami::Action::Params do
       params.errors.fetch(:name).must_equal    ['is missing']
       params.errors.fetch(:tos).must_equal     ['is missing']
       params.errors.fetch(:address).must_equal ['is missing']
+
+      params.error_messages.must_equal ['Email is missing', 'Email is in invalid format', 'Name is missing', 'Tos is missing', 'Age is missing', 'Address is missing']
     end
 
     it "is it valid when all the validation criteria are met" do
@@ -192,6 +194,7 @@ describe Hanami::Action::Params do
 
       params.valid?.must_equal true
       params.errors.must_be_empty
+      params.error_messages.must_be_empty
     end
 
     it "has input available through the hash accessor" do


### PR DESCRIPTION
Example:

```ruby
params.errors
  # => {:email=>["is missing", "is in invalid format"], :name=>["is missing"], :tos=>["is missing"], :age=>["is missing"], :address=>["is missing"]}


params.error_messages
  # => ["Email is missing", "Email is in invalid format", "Name is missing", "Tos is missing", "Age is missing", "Address is missing"]
```