### PR TITLE
Use default content type when accepting `*/*`

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -487,9 +487,13 @@ module Hanami
       # @see https://github.com/hanami/controller/issues/104
       def best_q_match(q_value_header, available_mimes)
         values = ::Rack::Utils.q_values(q_value_header)
-
         values = values.map do |req_mime, quality|
-          match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
+          if req_mime == DEFAULT_ACCEPT
+             # See https://github.com/hanami/controller/issues/167
+             match = default_content_type
+          else
+             match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
+          end
           next unless match
           [match, quality]
         end.compact

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -489,10 +489,10 @@ module Hanami
         values = ::Rack::Utils.q_values(q_value_header)
         values = values.map do |req_mime, quality|
           if req_mime == DEFAULT_ACCEPT
-             # See https://github.com/hanami/controller/issues/167
-             match = default_content_type
+            # See https://github.com/hanami/controller/issues/167
+            match = default_content_type
           else
-             match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
+            match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
           end
           next unless match
           [match, quality]

--- a/test/action/format_test.rb
+++ b/test/action/format_test.rb
@@ -18,6 +18,16 @@ describe Hanami::Action do
         self.format = params[:format]
       end
     end
+    
+    class Configuration
+      include Hanami::Action
+
+      configuration.default_request_format :jpeg
+
+      def call(params)
+        self.body = format
+      end
+    end
   end
 
   describe '#format' do
@@ -58,6 +68,18 @@ describe Hanami::Action do
       headers['Content-Type'].must_equal 'text/html; charset=utf-8'
       status.must_equal                   200
     end
+    
+    # Bug
+    # See https://github.com/hanami/controller/issues/167
+    it "accepts '*/*' and returns configured default format" do
+      action = FormatController::Configuration.new
+      status, headers, _ = action.call({ 'HTTP_ACCEPT' => '*/*' })
+
+      action.format.must_equal    :jpeg
+      headers['Content-Type'].must_equal 'image/jpeg; charset=utf-8'
+      status.must_equal                   200
+    end
+    
 
     mime_types = ['application/octet-stream', 'text/html']
     Rack::Mime::MIME_TYPES.each do |format, mime_type|


### PR DESCRIPTION
`*/*` is being resolved as `application/vnd.lotus-1-2-3`, since it is
the first in the list of available mime types.

This sets it to the default content type in these situations

fixes #167