### PR TITLE
Add #parsed_request_body to Hanami::Action::Rack

### DIFF
--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -42,6 +42,9 @@ module Hanami
       # @api private
       HEAD = 'HEAD'.freeze
 
+      # The key that returns router parsed body from the Rack env
+      ROUTER_PARSED_BODY = 'router.parsed_body'.freeze
+
       # Override Ruby's hook for modules.
       # It includes basic Hanami::Action modules to the given class.
       #
@@ -200,6 +203,10 @@ module Hanami
       #   end
       def request
         @request ||= ::Hanami::Action::Request.new(@_env)
+      end
+
+      def parsed_request_body
+        @_env.fetch(ROUTER_PARSED_BODY, nil)
       end
 
       private

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -130,4 +130,25 @@ describe Hanami::Action do
       request.path.must_equal('/foo')
     end
   end
+
+  describe '#parsed_request_body' do
+    it 'exposes the body of the request parsed by router body parsers' do
+      action_class = Class.new do
+        include Hanami::Action
+
+        expose :request_body
+
+        def call(params)
+          @request_body = parsed_request_body
+        end
+      end
+
+      action = action_class.new
+      env = Rack::MockRequest.env_for('http://example.com/foo',
+                                      'router.parsed_body' => { 'a' => 'foo' })
+      action.call(env)
+      parsed_request_body = action.request_body
+      parsed_request_body.must_equal({ 'a' => 'foo' })
+    end
+  end
 end


### PR DESCRIPTION
I did this to expose the body parsed in https://github.com/hanami/router/pull/118.