### PR TITLE
Do not stringify params

### DIFF
--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -106,31 +106,8 @@ module Hanami
 
       private
 
-      # @since 0.7.0
-      # @api private
-      def _extract_params
-        # FIXME: this is required for dry-v whitelisting
-        stringify!(super)
-      end
-
       def _params
         @result.output.merge(_router_params)
-      end
-
-      def stringify!(result)
-        result.keys.each do |key|
-          value = result.delete(key)
-          result[key.to_s] = case value
-                             when ::Hash
-                               stringify!(value)
-                             when ::Array
-                               value.map(&:to_s)
-                             else
-                               value.to_s
-                             end
-        end
-
-        result
       end
     end
   end

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -109,7 +109,7 @@ describe Hanami::Action::Params do
         describe 'in testing mode' do
           it 'returns only the listed params' do
             _, _, body = @action.call(id: 23, unknown: 4, article: { foo: 'bar', tags: [:cool] })
-            body.must_equal [%({:id=>"23", :article=>{:tags=>["cool"]}})]
+            body.must_equal [%({:id=>23, :article=>{:tags=>[:cool]}})]
           end
 
           it "doesn't filter _csrf_token" do
@@ -217,7 +217,7 @@ describe Hanami::Action::Params do
       params = TestParams.new(name: 'John', address: { line_one: '10 High Street', deep: { deep_attr: 1 } })
       params[:name].must_equal 'John'
       params[:address][:line_one].must_equal '10 High Street'
-      params[:address][:deep][:deep_attr].must_equal '1'
+      params[:address][:deep][:deep_attr].must_equal 1
     end
   end
 
@@ -429,6 +429,12 @@ describe Hanami::Action::Params do
         actual.must_be_kind_of(::Hash)
         actual[:address].must_be_kind_of(::Hash)
         actual[:address][:deep].must_be_kind_of(::Hash)
+      end
+    
+      it 'does not stringify values' do
+        input = { 'name' => 123 }
+        params = TestParams.new(input)
+        params[:name].must_equal(123)
       end
     end
   end


### PR DESCRIPTION
The params do not need to be stringified for dry-v (and can cause issues with parameter types that should not be coerced).
See https://gitter.im/dry-rb/chat?at=579f20f5f1da4f376e1e9da9.