### PR TITLE
Raise error on reserved word exposure.

### DIFF
--- a/lib/hanami/action/exposable.rb
+++ b/lib/hanami/action/exposable.rb
@@ -1,3 +1,5 @@
+require 'hanami/action/exposable/guard'
+
 module Hanami
   module Action
     # Exposures API
@@ -18,7 +20,9 @@ module Hanami
       def self.included(base)
         base.class_eval do
           extend ClassMethods
-          expose :params
+          include Guard
+
+          _expose :params
         end
       end
 
@@ -67,6 +71,10 @@ module Hanami
             exposures.push(*names)
           end
         end
+
+        # Alias of #expose to be used in internal modules.
+        # #_expose is not watched by the Guard
+        alias _expose expose
 
         # Set of exposures attribute names
         #

--- a/lib/hanami/action/exposable/guard.rb
+++ b/lib/hanami/action/exposable/guard.rb
@@ -1,0 +1,99 @@
+module Hanami
+  module Action
+    module Exposable
+      # Guard for Exposures API.
+      # Prevents exposure of reserved words
+      #
+      # @since x.x.x
+      #
+      # @see Hanami::Action::Exposable::Guard::ClassMethods#expose
+      # @see Hanami::Action::Exposable::Guard::ClassMethods#reserved_word?
+      module Guard
+        # Override Ruby's hook for modules.
+        # It prepends a guard for the exposures logic
+        #
+        # @param base [Class] the target action
+        #
+        # @since x.x.x
+        # @api private
+        #
+        # @see http://www.ruby-doc.org/core-2.1.2/Module.html#method-i-included
+        def self.included(base)
+          class << base
+            prepend ClassMethods
+          end
+        end
+
+        # Exposure of reserved words
+        #
+        # @since x.x.x
+        class IllegalExposeError < ::StandardError
+        end
+
+        # Exposures API Guard class methods
+        #
+        # @since x.x.x
+        # @api private
+        module ClassMethods
+          # Prevents exposure if names contain a reserved word.
+          #
+          # @param names [Array<Symbol>] the name(s) of the attribute(s) to be
+          #   exposed
+          #
+          # @return [void]
+          #
+          # @since x.x.x
+          def expose(*names)
+            detect_reserved_words!(names)
+
+            super
+          end
+
+          private
+
+          # Raises error if given names  contain a reserved word.
+          #
+          # @param names [Array<Symbol>] a list of names to be checked.
+          #
+          # @return [void]
+          #
+          # @raise [IllegalExposeError] if names contain one or more of reserved
+          #   words
+          #
+          # @since x.x.x
+          # @api private
+          def detect_reserved_words!(names)
+            names.each do |name|
+              if reserved_word?(name)
+                error_text = "#{name} is a reserved word. It cannot be exposured"
+                raise IllegalExposeError, error_text
+              end
+            end
+          end
+
+          # Checks if a string is a reserved word
+          #
+          # Reserved word is a name of the method defined in one of the modules
+          # of a given namespace.
+          #
+          # @param name [Symbol] the word to be checked
+          # @param namespace [String] the namespace containing internal modules
+          #
+          # @return [true, false]
+          #
+          # @since x.x.x
+          # @api private
+          def reserved_word?(name, namespace = 'Hanami')
+            if method_defined?(name) || private_method_defined?(name)
+              method_owner = instance_method(name).owner
+
+              Utils::String.new(method_owner).namespace == namespace
+            else
+              false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/action/exposable/guard.rb
+++ b/lib/hanami/action/exposable/guard.rb
@@ -65,8 +65,8 @@ module Hanami
           def detect_reserved_words!(names)
             names.each do |name|
               if reserved_word?(name)
-                error_text = "#{name} is a reserved word. It cannot be exposured"
-                raise IllegalExposeError, error_text
+                raise IllegalExposeError,
+                      "#{name} is a reserved word. It cannot be exposed"
               end
             end
           end

--- a/lib/hanami/action/glue.rb
+++ b/lib/hanami/action/glue.rb
@@ -23,7 +23,7 @@ module Hanami
       # @api private
       # @since 0.3.0
       def self.included(base)
-        base.class_eval { expose(:format) if respond_to?(:expose) }
+        base.class_eval { _expose(:format) if respond_to?(:_expose) }
       end
 
       # Check if the current HTTP request is renderable.

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -26,7 +26,7 @@ module Hanami
       # @api private
       def self.included(action)
         action.class_eval do
-          expose :session
+          _expose :session
         end
       end
 

--- a/test/action/exposable_test.rb
+++ b/test/action/exposable_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+describe Hanami::Action::Exposable do
+  describe '#expose' do
+    it 'creates a getter for the given ivar' do
+      action = ExposeAction.new
+
+      response = action.call({})
+      response[0].must_equal 200
+
+      action.exposures.fetch(:film).must_equal '400 ASA'
+      action.exposures.fetch(:time).must_equal nil
+    end
+
+    describe 'when reserved word is used' do
+      subject { ExposeReservedWordAction.expose_reserved_word }
+
+      it 'should raise an exception' do
+        ->() { subject }.must_raise Hanami::Action::Exposable::Guard::IllegalExposeError
+      end
+    end
+
+    describe 'when reserved word is not used' do
+      let(:action_class) do
+        Class.new do
+          include Hanami::Action
+
+          include Module.new { def flash; end }
+
+          expose :flash
+        end
+      end
+
+      subject { action_class.new.exposures }
+
+      it 'adds a key to exposures list' do
+        subject.must_include :flash
+      end
+    end
+  end
+
+  describe '#_expose' do
+    describe 'when exposuring a reserved word' do
+      it 'does not fail' do
+        ExposeReservedWordAction.expose_reserved_word(using_internal_method: true)
+
+        action = ExposeReservedWordAction.new
+        action.call({})
+
+        action.exposures.must_include :flash
+      end
+    end
+  end
+end

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -98,18 +98,6 @@ describe Hanami::Action do
     end
   end
 
-  describe '#expose' do
-    it 'creates a getter for the given ivar' do
-      action = ExposeAction.new
-
-      response = action.call({})
-      response[0].must_equal 200
-
-      action.exposures.fetch(:film).must_equal '400 ASA'
-      action.exposures.fetch(:time).must_equal nil
-    end
-  end
-
   describe '#request' do
     it 'gets a Rack-like request object' do
       action_class = Class.new do

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -211,6 +211,19 @@ class ExposeAction
   end
 end
 
+class ExposeReservedWordAction
+  include Hanami::Action
+  include Hanami::Action::Session
+
+  def self.expose_reserved_word(using_internal_method: false)
+    if using_internal_method
+      _expose :flash
+    else
+      expose :flash
+    end
+  end
+end
+
 class ZMiddleware
   def initialize(app, &message)
     @app = app


### PR DESCRIPTION
Closes #158
(following text is extracted from [comment](https://github.com/hanami/controller/issues/158#issuecomment-234843765))

I think we can go with guard module. The idea behind is dead simple:
* Create a module implementing `#expose` method, which raises an exception if given list of words contains one or more reserved word. Otherwise it calls super.
* Prepend this module to an action.
* Introduce an alias method for `#expose` (`#expose!` or `#_expose`) for internal usage. This alias won't be watched by the guard so no exceptions are raised.
