### PR TITLE
allow action params to read into arrays

### DIFF
--- a/lib/hanami/action/base_params.rb
+++ b/lib/hanami/action/base_params.rb
@@ -93,11 +93,11 @@ module Hanami
         key, *keys = key.to_s.split(GET_SEPARATOR)
         return if key.nil?
 
-        result = self[key.to_sym]
+        result = self[_key_for_get(key)]
 
         Array(keys).each do |k|
           break if result.nil?
-          result = result[k.to_sym]
+          result = result[_key_for_get(k)]
         end
 
         result
@@ -145,6 +145,10 @@ module Hanami
       # @api private
       def _router_params(fallback = {})
         env.fetch(ROUTER_PARAMS, fallback)
+      end
+
+      def _key_for_get(key)
+        key =~ /\A\d+\z/ ? key.to_i : key.to_sym
       end
     end
   end

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -232,7 +232,11 @@ describe Hanami::Action::Params do
   describe '#get' do
     describe 'with data' do
       before do
-        @params = TestParams.new(name: 'John', address: { line_one: '10 High Street', deep: { deep_attr: 1 } })
+        @params = TestParams.new(
+          name: 'John',
+          address: { line_one: '10 High Street', deep: { deep_attr: 1 } },
+          array: [{ name: 'Lenon' }, { name: 'Wayne' }]
+        )
       end
 
       it 'returns nil for nil argument' do
@@ -253,6 +257,11 @@ describe Hanami::Action::Params do
 
       it 'returns nil for uknown nested param' do
         @params.get('address.unknown').must_be_nil
+      end
+
+      it 'allows to read datas under arrays' do
+        @params.get('array.0.name').must_equal 'Lenon'
+        @params.get('array.1.name').must_equal 'Wayne'
       end
     end
 
@@ -438,7 +447,7 @@ describe Hanami::Action::Params do
         actual[:address].must_be_kind_of(::Hash)
         actual[:address][:deep].must_be_kind_of(::Hash)
       end
-    
+
       it 'does not stringify values' do
         input = { 'name' => 123 }
         params = TestParams.new(input)

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -782,6 +782,14 @@ class TestParams < Hanami::Action::Params
         required(:deep_attr).filled(:str?)
       end
     end
+
+    optional(:array).maybe do
+      each do
+        schema do
+          required(:name).filled(:str?)
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Hey all,

Hash#dig method allows the following:

``` ruby
h = { foo: { array: [{ bar: 'foobar' }] }
h.dig(:foo, :array, 0, :bar) == 'foobar'
```

This PR aims at making BaseParams#get iso with Hash#dig:

``` ruby
h = Params.new(foo: { array: [ { bar: 'foobar' } ] })
h.get('foo.array.0.bar') == 'foobar'
```

This is required for the following PR: https://github.com/hanami/helpers/pull/74
