### PR TITLE
Resolve Content-Type from custom and common MIME types via Accept header

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -215,7 +215,7 @@ module Hanami
         return @content_type if @content_type
 
         if accept_header?
-          type = get_mime_type_from_accept_header
+          type = mime_type_from_accept_header
           return type if type
         end
 
@@ -471,7 +471,7 @@ module Hanami
       # @see Hanami::Controller::Configuration#format
       #
       # @api private
-      def get_mime_type_from_accept_header
+      def mime_type_from_accept_header
         all_types = (MIME_TYPES + configuration.format_mime_types).uniq
         best_q_match(accept, all_types)
       end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -435,10 +435,19 @@ module Hanami
         @accept ||= @_env[HTTP_ACCEPT] || DEFAULT_ACCEPT
       end
 
-      # @since 0.1.0
+      # Look at the Accept header for the current request and see if it
+      # matches any of the common MIME Types (see Hanami::Action::Mime#MIME_TYPES).
+      #
+      # @return [Nil] when the Accept header does not match any known (common)
+      # MIME Types.
+      # @return [String] the charset of the request.
+      #
+      # @since 0.7.0
+      #
+      # @see Hanami::Action::Mime#MIME_TYPES
+      #
       # @api private
-      def accepts
-        unless accept == DEFAULT_ACCEPT
+      def get_common_mime_type_from_accept_header
           best_q_match(accept, MIME_TYPES)
         end
       end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -450,6 +450,25 @@ module Hanami
       def get_common_mime_type_from_accept_header
           best_q_match(accept, MIME_TYPES)
         end
+
+      # Look at the Accept header for the current request and see if it
+      # matches any of the custom registered MIME Types
+      # (see Hanami::Controller::Configuration#format).
+      #
+      # @return [Nil] when there is not an Accept header, or the Accept header
+      # does not match any known (common) MIME Type.
+      # @return [String] the charset of the request.
+      #
+      # @since 0.7.0
+      #
+      # @see Hanami::Controller::Configuration#format
+      #
+      # @api private
+      def get_custom_mime_type_from_accept_header
+        # If the Accept header doesn't match any custom MIME types, return nil.
+        return nil unless custom_type = configuration.format_for(accept)
+        # Return the MIME type for the custom content "type" from the configuration.
+        configuration.mime_type_for(custom_type)
       end
 
       # @since 0.5.0

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -435,6 +435,16 @@ module Hanami
         @accept ||= @_env[HTTP_ACCEPT] || DEFAULT_ACCEPT
       end
 
+      # Checks if there is an Accept header for the current request.
+      #
+      # @return [Boolean] true if there's an Accept header to look at
+      #
+      # @since 0.7.0
+      # @api private
+      def accept_header?
+        accept != DEFAULT_ACCEPT
+      end
+
       # Look at the Accept header for the current request and see if it
       # matches any of the common MIME Types (see Hanami::Action::Mime#MIME_TYPES).
       #

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -449,7 +449,8 @@ module Hanami
 
       # Checks if there is an Accept header for the current request.
       #
-      # @return [Boolean] true if there's an Accept header to look at
+      # @return [Boolean] True if there is an Accept header in the current
+      #   request.
       #
       # @since 0.7.0
       # @api private
@@ -458,12 +459,12 @@ module Hanami
       end
 
       # Look at the Accept header for the current request and see if it
-      # matches any of the common MIME Types (see Hanami::Action::Mime#MIME_TYPES)
+      # matches any of the common MIME types (see Hanami::Action::Mime#MIME_TYPES)
       # or the custom registered ones (see Hanami::Controller::Configuration#format).
       #
-      # @return [Nil] when the Accept header does not match any known MIME
-      # Types.
-      # @return [String] the matched MIME type for the given Accept header.
+      # @return [Nil] When the Accept header does not match any known MIME
+      #   type.
+      # @return [String] The matched MIME type for the given Accept header.
       #
       # @since 0.7.0
       #

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -472,7 +472,7 @@ module Hanami
       #
       # @api private
       def mime_type_from_accept_header
-        all_types = (MIME_TYPES + configuration.format_mime_types).uniq
+        all_types = (MIME_TYPES + configuration.format_mime_types)
         best_q_match(accept, all_types)
       end
 

--- a/lib/hanami/controller/configuration.rb
+++ b/lib/hanami/controller/configuration.rb
@@ -406,6 +406,17 @@ module Hanami
           Utils::Kernel.Symbol(symbol)
       end
 
+      # Return the configured format's MIME types
+      #
+      # @since 0.7.0
+      #
+      # @see Hanami::Controller::Configuration#format
+      # @see Hanami::Action::Mime::MIME_TYPES
+      #
+      def format_mime_types
+        @formats.keys
+      end
+
       # Set a format as default fallback for all the requests without a strict
       # requirement for the mime type.
       #

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -187,6 +187,17 @@ describe Hanami::Controller::Configuration do
     end
   end
 
+  describe '#format_mime_types' do
+    before do
+      @configuration.format custom: 'custom/format'
+    end
+
+    it 'returns all known format MIME types' do
+      all = ["application/octet-stream", "*/*", "text/html", "custom/format"]
+      @configuration.format_mime_types.must_equal all
+    end
+  end
+
   describe '#default_request_format' do
     describe "when not previously set" do
       it 'returns nil' do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -192,7 +192,7 @@ describe Hanami::Controller::Configuration do
       @configuration.format custom: 'custom/format'
     end
 
-    it 'returns all known format MIME types' do
+    it 'returns all configured format MIME types' do
       all = ["application/octet-stream", "*/*", "text/html", "custom/format"]
       @configuration.format_mime_types.must_equal all
     end

--- a/test/integration/mime_type_test.rb
+++ b/test/integration/mime_type_test.rb
@@ -180,6 +180,18 @@ describe 'Content type' do
     end
 
     it 'sets "Content-Type" header according to "Accept"' do
+      response = @app.get('/custom_from_accept', 'HTTP_ACCEPT' => 'application/custom;q=0.9, application/json;q=0.5')
+      response.headers['Content-Type'].must_equal 'application/custom; charset=utf-8'
+      response.body.must_equal                    'custom'
+    end
+
+    it 'sets "Content-Type" header according to "Accept"' do
+      response = @app.get('/custom_from_accept', 'HTTP_ACCEPT' => 'application/custom;q=0.1, application/json;q=0.5')
+      response.headers['Content-Type'].must_equal 'application/json; charset=utf-8'
+      response.body.must_equal                    'json'
+    end
+
+    it 'sets "Content-Type" header according to "Accept"' do
       response = @app.get('/', 'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
       response.headers['Content-Type'].must_equal 'text/html; charset=utf-8'
       response.body.must_equal                    'html'

--- a/test/integration/mime_type_test.rb
+++ b/test/integration/mime_type_test.rb
@@ -169,37 +169,50 @@ describe 'Content type' do
   describe 'when Accept is sent' do
     it 'sets "Content-Type" header according to "Accept"' do
       response = @app.get('/', 'HTTP_ACCEPT' => '*/*')
-      response.headers['Content-Type'].must_equal 'application/octet-stream; charset=utf-8'
+      content_type = 'application/octet-stream; charset=utf-8'
+      response.headers['Content-Type'].must_equal content_type
       response.body.must_equal                    'all'
     end
 
     it 'sets "Content-Type" header according to "Accept"' do
-      response = @app.get('/custom_from_accept', 'HTTP_ACCEPT' => 'application/custom')
-      response.headers['Content-Type'].must_equal 'application/custom; charset=utf-8'
+      headers = {'HTTP_ACCEPT' => 'application/custom'}
+      response = @app.get('/custom_from_accept', headers)
+      content_type = 'application/custom; charset=utf-8'
+      response.headers['Content-Type'].must_equal content_type
       response.body.must_equal                    'custom'
     end
 
     it 'sets "Content-Type" header according to "Accept"' do
-      response = @app.get('/custom_from_accept', 'HTTP_ACCEPT' => 'application/custom;q=0.9, application/json;q=0.5')
-      response.headers['Content-Type'].must_equal 'application/custom; charset=utf-8'
+      accept = 'application/custom;q=0.9,application/json;q=0.5'
+      header = {'HTTP_ACCEPT' => accept}
+      response = @app.get('/custom_from_accept', headers)
+      content_type = 'application/custom; charset=utf-8'
+      response.headers['Content-Type'].must_equal content_type
       response.body.must_equal                    'custom'
     end
 
     it 'sets "Content-Type" header according to "Accept"' do
-      response = @app.get('/custom_from_accept', 'HTTP_ACCEPT' => 'application/custom;q=0.1, application/json;q=0.5')
-      response.headers['Content-Type'].must_equal 'application/json; charset=utf-8'
+      accept = 'application/custom;q=0.1, application/json;q=0.5'
+      headers = {'HTTP_ACCEPT' => accept}
+      response = @app.get('/custom_from_accept', headers)
+      content_type = 'application/json; charset=utf-8'
+      response.headers['Content-Type'].must_equal content_type
       response.body.must_equal                    'json'
     end
 
     it 'sets "Content-Type" header according to "Accept"' do
-      response = @app.get('/', 'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
+      accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+      response = @app.get('/', 'HTTP_ACCEPT' => accept)
       response.headers['Content-Type'].must_equal 'text/html; charset=utf-8'
       response.body.must_equal                    'html'
     end
 
     it 'sets "Content-Type" header according to "Accept" quality scale' do
-      response = @app.get('/', 'HTTP_ACCEPT' => 'application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8')
-      response.headers['Content-Type'].must_equal 'application/xml; charset=utf-8'
+      accept = 'application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8'
+      headers = {'HTTP_ACCEPT' => accept}
+      response = @app.get('/', headers)
+      content_type = 'application/xml; charset=utf-8'
+      response.headers['Content-Type'].must_equal content_type
       response.body.must_equal                    'xml'
     end
   end

--- a/test/integration/mime_type_test.rb
+++ b/test/integration/mime_type_test.rb
@@ -184,7 +184,7 @@ describe 'Content type' do
 
     it 'sets "Content-Type" header according to "Accept"' do
       accept = 'application/custom;q=0.9,application/json;q=0.5'
-      header = {'HTTP_ACCEPT' => accept}
+      headers = {'HTTP_ACCEPT' => accept}
       response = @app.get('/custom_from_accept', headers)
       content_type = 'application/custom; charset=utf-8'
       response.headers['Content-Type'].must_equal content_type


### PR DESCRIPTION
The `#content_type` method was not taking into account when we have a custom MIME type registered for a potential controller format - instead it was overlooking these values and simply skipping to the default content type.

Now, we honor the ordered preference of choosing which content type to use:
1. Explicit set value (from #format=)
2. Weighted value from Accept header (common MIME types _and_ registered custom MIME types)
3. Configured default content type
4. Hard-coded default content type

Examples:

Given the following controller:

``` ruby
module Web
  class Application < Hanami::Application
    configure do
      controller.format v1: 'application/vnd.custom.v1+json'
      controller.format v2: 'application/vnd.custom.v2+json'
      controller.prepare do
        accept :v1, :v2, :json
      end
    end
  end
end
```

_Before this PR_
When a request was made with `Accept: application/vnd.custom.v2+json` it would respond with `Content-Type: application/json`.

_With this PR_
When a request is made with `Accept: application/vnd.custom.v2+json`, it responds with `Content-Type: application/vnd.custom.v2+json`. Likewise, `v1` returns `v1`, and `application/json` returns `application/json`.

Weighting also works now for custom types:

_Before this PR_
When a request was made with `Accept: application/json; q=0.5, application/vnd.custom.v1+json; q=0.9`, it would respond with `Content-Type: application/json`.

_With this PR_
When a request is made with `Accept: application/json; q=0.5, application/vnd.custom.v1+json; q=0.9`, it responds with `Content-Type: application/vnd.custom.v1+json`. Likewise, a request made with `Accept: application/json; q=0.8, application/vnd.custom.v1+json; q=0.4` responds with `Content-Type: application/json`.
