### PR TITLE
Let BaseParams#get to behave like Hash#dig

### DIFF
--- a/lib/hanami/action/base_params.rb
+++ b/lib/hanami/action/base_params.rb
@@ -61,13 +61,11 @@ module Hanami
       end
 
       # Get an attribute value associated with the given key.
-      # Nested attributes are reached with a dot notation.
+      # Nested attributes are reached by listing all the keys to get to the value.
       #
-      # @param key [String] the key
+      # @param key [Array<Symbol,Integer>] the key
       #
       # @return [Object,NilClass] return the associated value, if found
-      #
-      # @raise [NoMethodError] if key is nil
       #
       # @since 0.7.0
       #
@@ -79,28 +77,22 @@ module Hanami
       #       include Hanami::Action
       #
       #       def call(params)
-      #         params.get('customer_name')   # => "Luca"
-      #         params.get('uknown')          # => nil
+      #         params.get(:customer_name)     # => "Luca"
+      #         params.get(:uknown)            # => nil
       #
-      #         params.get('address.city')    # => "Rome"
-      #         params.get('address.unknown') # => nil
+      #         params.get(:address, :city)    # => "Rome"
+      #         params.get(:address, :unknown) # => nil
       #
-      #         params.get(nil)               # => nil
+      #         params.get(:tags, 0)           # => "foo"
+      #         params.get(:tags, 1)           # => "bar"
+      #         params.get(:tags, 999)         # => nil
+      #
+      #         params.get(nil)                # => nil
       #       end
       #     end
       #   end
-      def get(key)
-        key, *keys = key.to_s.split(GET_SEPARATOR)
-        return if key.nil?
-
-        result = self[_key_for_get(key)]
-
-        Array(keys).each do |k|
-          break if result.nil?
-          result = result[_key_for_get(k)]
-        end
-
-        result
+      def get(*keys)
+        @params.dig(*keys)
       end
 
       # Provide a common interface with Params
@@ -154,10 +146,6 @@ module Hanami
       # @api private
       def _router_params(fallback = {})
         env.fetch(ROUTER_PARAMS, fallback)
-      end
-
-      def _key_for_get(key)
-        key =~ /\A\d+\z/ ? key.to_i : key.to_sym
       end
     end
   end

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -235,7 +235,7 @@ describe Hanami::Action::Params do
         @params = TestParams.new(
           name: 'John',
           address: { line_one: '10 High Street', deep: { deep_attr: 1 } },
-          array: [{ name: 'Lenon' }, { name: 'Wayne' }]
+          array: [{ name: 'Lennon' }, { name: 'Wayne' }]
         )
       end
 
@@ -244,24 +244,24 @@ describe Hanami::Action::Params do
       end
 
       it 'returns nil for unknown param' do
-        @params.get('unknown').must_be_nil
+        @params.get(:unknown).must_be_nil
       end
 
       it 'allows to read top level param' do
-        @params.get('name').must_equal 'John'
+        @params.get(:name).must_equal 'John'
       end
 
       it 'allows to read nested param' do
-        @params.get('address.line_one').must_equal '10 High Street'
+        @params.get(:address, :line_one).must_equal '10 High Street'
       end
 
       it 'returns nil for uknown nested param' do
-        @params.get('address.unknown').must_be_nil
+        @params.get(:address, :unknown).must_be_nil
       end
 
       it 'allows to read datas under arrays' do
-        @params.get('array.0.name').must_equal 'Lenon'
-        @params.get('array.1.name').must_equal 'Wayne'
+        @params.get(:array, 0, :name).must_equal 'Lennon'
+        @params.get(:array, 1, :name).must_equal 'Wayne'
       end
     end
 
@@ -275,19 +275,19 @@ describe Hanami::Action::Params do
       end
 
       it 'returns nil for unknown param' do
-        @params.get('unknown').must_be_nil
+        @params.get(:unknown).must_be_nil
       end
 
       it 'returns nil for top level param' do
-        @params.get('name').must_be_nil
+        @params.get(:name).must_be_nil
       end
 
       it 'returns nil for nested param' do
-        @params.get('address.line_one').must_be_nil
+        @params.get(:address, :line_one).must_be_nil
       end
 
       it 'returns nil for uknown nested param' do
-        @params.get('address.unknown').must_be_nil
+        @params.get(:address, :unknown).must_be_nil
       end
     end
   end


### PR DESCRIPTION
Let `BaseParams#get` to behave like `Hash#dig` and accept a list of symbols instead a string with dot notation.

**This is a breaking change**

---

The reasons for this change are:

  * Performance
  * One less thing to learn for newcomers