### PR TITLE
Wrapper to allow consistent session hash access

### DIFF
--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -1,4 +1,5 @@
 require 'hanami/action/flash'
+require 'hanami/action/session/session_hash'
 
 module Hanami
   module Action
@@ -58,7 +59,7 @@ module Hanami
       #     end
       #   end
       def session
-        @_env[SESSION_KEY] ||= {}
+        SessionHash.new(@_env[SESSION_KEY] || {})
       end
 
       # Read errors from flash or delegate to the superclass

--- a/lib/hanami/action/session/session_hash.rb
+++ b/lib/hanami/action/session/session_hash.rb
@@ -1,0 +1,30 @@
+module Hanami
+  module Action
+    module Session
+      # Wrapper around session hash to provide consistent key access.
+      #
+      # Since 0.8.0
+      class SessionHash < ::SimpleDelegator
+        def [](key)
+          __getobj__[key.to_s]
+        end
+        alias :fetch :[]
+
+        def has_key?(key)
+          __getobj__.has_key?(key.to_s)
+        end
+        alias :key? :has_key?
+        alias :include? :has_key?
+
+        def []=(key, value)
+          __getobj__[key.to_s] = value
+        end
+        alias :store :[]=
+
+        def delete(key)
+          __getobj__.delete(key.to_s)
+        end
+      end
+    end
+  end
+end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -22,5 +22,12 @@ describe Hanami::Action do
 
       action.exposures[:session].must_equal(session)
     end
+
+    it 'allows value access via symbolic keys' do
+      action = SessionAction.new
+      action.call({'rack.session' => { 'foo' => 'bar' }})
+
+      action.session[:foo].must_equal('bar')
+    end
   end
 end


### PR DESCRIPTION
Rack always [converts session keys to a string](https://github.com/rack/rack/blob/1-6-stable/lib/rack/session/abstract/id.rb#L23), however in Hanami Action unit tests the middleware is not invoked and the Rack `SessionHash` is not used and a plain Hash is passed in. 

This provided inconsistent accessor behaviour as Hanami prefers symbolic keys be used for access and Ruby's default `Hash` obviously does not convert the keys to strings by default.

The proposed new class `Hanami::Action::Session::SessionHash` attempts to intercept the accessor methods where the type conversion is important to ensure that occurs and delegate everything else to the original object (either the Rack `SessionHash` or the Ruby `Hash`).

Closes #185