### PR TITLE
Don't annotate exception in rack.env when exception handler handled the exception.

### DIFF
--- a/lib/hanami/controller/configuration.rb
+++ b/lib/hanami/controller/configuration.rb
@@ -192,16 +192,7 @@ module Hanami
       #
       # @see Hanami::Controller::Configuration#handle_exception
       def exception_handler(exception)
-        handler = nil
-
-        @handled_exceptions.each do |exception_class, h|
-          if exception.kind_of?(exception_class)
-            handler = h
-            break
-          end
-        end
-
-        handler || DEFAULT_ERROR_CODE
+        find_exception_handler(exception) || DEFAULT_ERROR_CODE
       end
 
       # Check if the given exception is handled.
@@ -213,8 +204,23 @@ module Hanami
       #
       # @see Hanami::Controller::Configuration#handle_exception
       def handled_exception?(exception)
-        handled_exceptions &&
-          !!@handled_exceptions.fetch(exception.class) { false }
+        handled_exceptions && !find_exception_handler(exception).nil?
+      end
+
+      # Finds configured handler for given exception, or nil if not found.
+      #
+      # @param exception [Exception] an exception
+      #
+      # @since x.x.x
+      # @api private
+      #
+      # @see Hanami::Controller::Configuration#handle_exception
+      def find_exception_handler(exception)
+        @handled_exceptions.each do |exception_class, handler|
+          return handler if exception.kind_of?(exception_class)
+        end
+
+        nil
       end
 
       # Specify which is the default action module to be included when we use

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -189,12 +189,12 @@ describe Hanami::Action::Params do
 
       params.valid?.must_equal false
 
-      params.errors.fetch(:email).must_equal   ['is missing', 'is in invalid format']
+      params.errors.fetch(:email).must_equal   ['is missing']
       params.errors.fetch(:name).must_equal    ['is missing']
       params.errors.fetch(:tos).must_equal     ['is missing']
       params.errors.fetch(:address).must_equal ['is missing']
 
-      params.error_messages.must_equal ['Email is missing', 'Email is in invalid format', 'Name is missing', 'Tos is missing', 'Age is missing', 'Address is missing']
+      params.error_messages.must_equal ['Email is missing', 'Name is missing', 'Tos is missing', 'Age is missing', 'Address is missing']
     end
 
     it "isn't valid with empty nested params" do

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1402,6 +1402,22 @@ class HandledRackExceptionAction
   end
 end
 
+class HandledRackExceptionSubclassAction
+  include Hanami::Action
+
+  class TestException < ::StandardError
+  end
+
+  class TestSubclassException < TestException
+  end
+
+  handle_exception TestException => 500
+
+  def call(params)
+    raise TestSubclassException.new
+  end
+end
+
 module SessionWithCookies
   Controller = Hanami::Controller.duplicate(self) do
     handle_exceptions false

--- a/test/integration/rack_exception_test.rb
+++ b/test/integration/rack_exception_test.rb
@@ -16,4 +16,11 @@ describe "Exception notifiers integration" do
 
     env['rack.exception'].must_be_nil
   end
+
+  it "doesn't reference  of an error in rack.exception if it's handled" do
+    action = HandledRackExceptionSubclassAction.new
+    action.call(env)
+
+    env['rack.exception'].must_be_nil
+  end
 end


### PR DESCRIPTION
We had defined in our Hanami app a handler for an exception class. A subclass of that exception was raised and the handler was correctly called, but the error was still logged to sentry (which integrates with rack [here](https://github.com/getsentry/raven-ruby/blob/5414217bfe0273ede358319503ae4a71db45be97/lib/raven/integrations/rack.rb#L58-L59).)

It seems to me that the exception was set on rack's env even when it was handled due to the fact that the `#handled_exception?` didn't check for subclasses as the `#exception_handler` did.

Fixed it by using the same code to figure out if we have a handler for exception class or not.