### PR TITLE
Expose flash by default

### DIFF
--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -26,7 +26,7 @@ module Hanami
       # @api private
       def self.included(action)
         action.class_eval do
-          _expose :session
+          _expose :session, :flash
         end
       end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -485,6 +485,15 @@ class SessionAction
   end
 end
 
+class FlashAction
+  include Hanami::Action
+  include Hanami::Action::Session
+
+  def call(params)
+    flash[:error] = "ouch"
+  end
+end
+
 class RedirectAction
   include Hanami::Action
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -23,4 +23,16 @@ describe Hanami::Action do
       action.exposures[:session].must_equal(session)
     end
   end
+
+  describe 'flash' do
+    it 'exposes session' do
+      action = FlashAction.new
+      action.call({})
+
+      flash = action.exposures[:flash]
+
+      flash.must_be_kind_of(Hanami::Action::Flash)
+      flash[:error].must_equal "ouch"
+    end
+  end
 end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -25,7 +25,7 @@ describe Hanami::Action do
   end
 
   describe 'flash' do
-    it 'exposes session' do
+    it 'exposes flash' do
       action = FlashAction.new
       action.call({})
 


### PR DESCRIPTION
Reported by @nsheremet in chat.

There is a regression that prevents to expose `flash` outside of an action. This PR fixes the problem.

/cc @hanami/issues for review. Thanks 👍 