### PR TITLE
Return only non-stale flash values

### DIFF
--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -55,7 +55,7 @@ module Hanami
       # @api private
       def [](key)
         last_request_flash.merge(data).fetch(key) do
-          _values.find {|data| !data[key].nil? }
+          _available_values.find { |data| !data[key].nil? }
         end
       end
 
@@ -143,6 +143,16 @@ module Hanami
       # @api private
       def _values
         flash.values
+      end
+
+      # Values from all the non-stale stored requests
+      #
+      # @return [Array]
+      #
+      # @since x.x.x
+      # @api private
+      def _available_values
+        flash.select { |session_id, _| !delete?(session_id) }.values
       end
 
       # Determine if delete data from flash for the given Request ID


### PR DESCRIPTION
`Hanami::Action::Flash#[]` was taking into consideration stale values,
causing weird behaviors when fetching flash data after refreshing a
redirected page.

This commit fixes this issue by allowing only non-stale flash values to
be taken into consideration.

I'm not 100% sure if this is the right fix or not, since stale data should not be available in the `flash` object in the first place (I believe...). 

Fixes #196 