### PR TITLE
Ensure symbol access for session during action unit tests

### DIFF
--- a/lib/hanami/action/base_params.rb
+++ b/lib/hanami/action/base_params.rb
@@ -15,6 +15,18 @@ module Hanami
       # @since 0.7.0
       ROUTER_PARAMS = 'router.params'.freeze
 
+      # The key that returns Rack session params from the Rack env
+      # Please note that this is used only when an action is unit tested.
+      #
+      # @since x.x.x
+      # @api private
+      #
+      # @example
+      #   # action unit test
+      #   action.call('rack.session' => { 'foo' => 'bar' })
+      #   action.session[:foo] # => "bar"
+      RACK_SESSION = 'rack.session'.freeze
+
       # @attr_reader env [Hash] the Rack env
       #
       # @since 0.7.0
@@ -143,7 +155,13 @@ module Hanami
       # @since 0.7.0
       # @api private
       def _router_params(fallback = {})
-        env.fetch(ROUTER_PARAMS, fallback)
+        env.fetch(ROUTER_PARAMS) do
+          if session = fallback.delete(RACK_SESSION) # rubocop:disable Lint/AssignmentInCondition
+            fallback[RACK_SESSION] = Utils::Hash.new(session).symbolize!.to_hash
+          end
+
+          fallback
+        end
       end
     end
   end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -22,6 +22,13 @@ describe Hanami::Action do
 
       action.exposures[:session].must_equal(session)
     end
+
+    it 'allows value access via symbols' do
+      action = SessionAction.new
+      action.call({'rack.session' => { 'foo' => 'bar' }})
+
+      action.session[:foo].must_equal('bar')
+    end
   end
 
   describe 'flash' do


### PR DESCRIPTION
Based on initial implementation by @createdbypete (see #188).
Closes #185 