### PR TITLE
Do not send file outside of public directory

### DIFF
--- a/lib/hanami/action/glue.rb
+++ b/lib/hanami/action/glue.rb
@@ -59,7 +59,7 @@ module Hanami
       #
       # @since 0.4.3
       def sending_file?
-        @_body&.first.is_a?(::Rack::File)
+        @_body.is_a?(::Rack::File::Iterator)
       end
     end
   end

--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -282,7 +282,7 @@ module Hanami
       #     end
       #   end
       def send_file(path)
-        result = File.new(path).call(@_env)
+        result = File.new(path, self.class.configuration.public_directory).call(@_env)
         headers.merge!(result[1])
         halt result[0], result[2]
       end

--- a/lib/hanami/action/rack/file.rb
+++ b/lib/hanami/action/rack/file.rb
@@ -21,8 +21,8 @@ module Hanami
         #
         # @since 0.4.3
         # @api private
-        def initialize(path)
-          @file = ::Rack::File.new(Dir.pwd)
+        def initialize(path, root)
+          @file = ::Rack::File.new(root)
           @path = path
         end
 

--- a/lib/hanami/controller/configuration.rb
+++ b/lib/hanami/controller/configuration.rb
@@ -26,6 +26,14 @@ module Hanami
       # @api private
       DEFAULT_ERROR_CODE = 500
 
+      # Default public directory
+      #
+      # It serves as base root for file downloads
+      #
+      # @since x.x.x
+      # @api private
+      DEFAULT_PUBLIC_DIRECTORY = 'public'.freeze
+
       # Default Mime type to format mapping
       #
       # @since 0.2.0
@@ -631,6 +639,14 @@ module Hanami
         @formats.key(format)
       end
 
+      def public_directory(value = nil)
+        if value.nil?
+          @public_directory
+        else
+          @public_directory = Pathname.new(Dir.pwd).join(value).to_s
+        end
+      end
+
       # Duplicate by copying the settings in a new instance.
       #
       # @return [Hanami::Controller::Configuration] a copy of the configuration
@@ -648,6 +664,7 @@ module Hanami
           c.default_response_format = default_response_format
           c.default_charset         = default_charset
           c.default_headers         = default_headers.dup
+          c.public_directory        = public_directory
           c.cookies = cookies.dup
         end
       end
@@ -677,6 +694,7 @@ module Hanami
         @default_charset         = nil
         @default_headers         = {}
         @cookies                 = {}
+        @public_directory        = ::File.join(Dir.pwd, "public")
         @action_module           = ::Hanami::Action
       end
 
@@ -722,6 +740,7 @@ module Hanami
       attr_writer :default_charset
       attr_writer :default_headers
       attr_writer :cookies
+      attr_writer :public_directory
     end
   end
 end

--- a/test/action/glue_test.rb
+++ b/test/action/glue_test.rb
@@ -7,7 +7,7 @@ describe Hanami::Action::Glue do
       let(:action) { Glued::SendFile.new }
 
       it "isn't renderable while sending file" do
-        action.call({})
+        action.call('REQUEST_METHOD' => 'GET')
         action.wont_be :renderable?
       end
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -360,6 +360,49 @@ describe Hanami::Controller::Configuration do
     end
   end
 
+  describe "#public_directory" do
+    describe "when not previously set" do
+      it "returns default value" do
+        expected = ::File.join(Dir.pwd, 'public')
+        actual   = @configuration.public_directory
+
+        # NOTE: For Rack compatibility it's important to have a string as public directory
+        actual.must_be_kind_of(String)
+        actual.must_equal(expected)
+      end
+    end
+
+    describe "when set with relative path" do
+      before do
+        @configuration.public_directory 'static'
+      end
+
+      it "returns the value" do
+        expected = ::File.join(Dir.pwd, 'static')
+        actual   = @configuration.public_directory
+
+        # NOTE: For Rack compatibility it's important to have a string as public directory
+        actual.must_be_kind_of(String)
+        actual.must_equal(expected)
+      end
+    end
+
+    describe "when set with absolute path" do
+      before do
+        @configuration.public_directory ::File.join(Dir.pwd, 'absolute')
+      end
+
+      it "returns the value" do
+        expected = ::File.join(Dir.pwd, 'absolute')
+        actual   = @configuration.public_directory
+
+        # NOTE: For Rack compatibility it's important to have a string as public directory
+        actual.must_be_kind_of(String)
+        actual.must_equal(expected)
+      end
+    end
+  end
+
   describe 'duplicate' do
     before do
       @configuration.reset!
@@ -369,6 +412,7 @@ describe Hanami::Controller::Configuration do
       @configuration.default_response_format :html
       @configuration.default_charset 'latin1'
       @configuration.default_headers({ 'X-Frame-Options' => 'DENY' })
+      @configuration.public_directory 'static'
       @config = @configuration.duplicate
     end
 
@@ -383,6 +427,7 @@ describe Hanami::Controller::Configuration do
       @config.default_response_format.must_equal @configuration.default_response_format
       @config.default_charset.must_equal         @configuration.default_charset
       @config.default_headers.must_equal         @configuration.default_headers
+      @config.public_directory.must_equal        @configuration.public_directory
     end
 
     it "doesn't affect the original configuration" do
@@ -395,6 +440,7 @@ describe Hanami::Controller::Configuration do
       @config.default_response_format :json
       @config.default_charset 'utf-8'
       @config.default_headers({ 'X-Frame-Options' => 'ALLOW ALL' })
+      @config.public_directory 'pub'
 
       @config.handle_exceptions.must_equal           false
       @config.handled_exceptions.must_equal          Hash[ArgumentError => 400]
@@ -406,6 +452,7 @@ describe Hanami::Controller::Configuration do
       @config.default_response_format.must_equal      :json
       @config.default_charset.must_equal              'utf-8'
       @config.default_headers.must_equal              ({ 'X-Frame-Options' => 'ALLOW ALL' })
+      @config.public_directory.must_equal             ::File.join(Dir.pwd, 'pub')
 
       @configuration.handle_exceptions.must_equal  true
       @configuration.handled_exceptions.must_equal Hash[]
@@ -417,6 +464,7 @@ describe Hanami::Controller::Configuration do
       @configuration.default_response_format.must_equal :html
       @configuration.default_charset.must_equal    'latin1'
       @configuration.default_headers.must_equal    ({ 'X-Frame-Options' => 'DENY' })
+      @configuration.public_directory.must_equal   ::File.join(Dir.pwd, 'static')
     end
   end
 
@@ -431,6 +479,7 @@ describe Hanami::Controller::Configuration do
       @configuration.default_response_format :another
       @configuration.default_charset 'kor-1'
       @configuration.default_headers({ 'X-Frame-Options' => 'ALLOW DENY' })
+      @configuration.public_directory 'files'
 
       @configuration.reset!
     end
@@ -446,6 +495,7 @@ describe Hanami::Controller::Configuration do
       @configuration.default_response_format.must_be_nil
       @configuration.default_charset.must_be_nil
       @configuration.default_headers.must_equal({})
+      @configuration.public_directory.must_equal(::File.join(Dir.pwd, 'public'))
     end
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -940,9 +940,10 @@ module Glued
   class SendFile
     include Hanami::Action
     include Hanami::Action::Glue
+    configuration.public_directory "test"
 
     def call(params)
-      self.body = ::Rack::File.new(nil)
+      send_file "assets/test.txt"
     end
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1097,6 +1097,7 @@ end
 module SendFileTest
   Controller = Hanami::Controller.duplicate(self) do
     handle_exceptions false
+    public_directory  "test"
   end
 
   module Files
@@ -1107,11 +1108,13 @@ module SendFileTest
         id = params[:id]
         # This if statement is only for testing purpose
         if id == "1"
-          send_file Pathname.new('test/assets/test.txt')
+          send_file Pathname.new('assets/test.txt')
         elsif id == "2"
-          send_file Pathname.new('test/assets/hanami.png')
+          send_file Pathname.new('assets/hanami.png')
+        elsif id == "3"
+          send_file Pathname.new('Gemfile')
         else
-          send_file Pathname.new('test/assets/unknown.txt')
+          send_file Pathname.new('assets/unknown.txt')
         end
       end
     end
@@ -1120,7 +1123,7 @@ module SendFileTest
       include SendFileTest::Action
 
       def call(params)
-        send_file Pathname.new('test/assets/test.txt')
+        send_file Pathname.new('assets/test.txt')
         redirect_to '/'
       end
     end

--- a/test/integration/send_file_test.rb
+++ b/test/integration/send_file_test.rb
@@ -46,6 +46,12 @@ describe 'Full stack application' do
       last_response.headers.key?('Content-Type').must_equal false
       last_response.body.must_be :empty?
     end
+
+    it "doesn't send file outside of public directory" do
+      get '/files/3', {}
+
+      last_response.status.must_equal 404
+    end
   end
 
   describe "if file doesn't exist" do


### PR DESCRIPTION
This PR fixes two problems:

  * Don't let files outside of public directory to be sent
  * Fix the `#renderable?` check, which causes a server side error

This completes #201 

---

/cc @davydovanton @hanami/issues for review.