### PR TITLE
Works well with empty cache

### DIFF
--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -56,7 +56,7 @@ module Hanami
         end
 
         def fresh?
-          modified_since && Time.httpdate(modified_since).to_i >= @value.to_i
+          modified_since && !modified_since.empty? && Time.httpdate(modified_since).to_i >= @value.to_i
         end
 
         def header

--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -56,7 +56,7 @@ module Hanami
         end
 
         def fresh?
-          modified_since && !modified_since.empty? && Time.httpdate(modified_since).to_i >= @value.to_i
+          !Hanami::Utils::Blank.blank?(modified_since) && Time.httpdate(modified_since).to_i >= @value.to_i
         end
 
         def header

--- a/test/integration/cache_test.rb
+++ b/test/integration/cache_test.rb
@@ -335,12 +335,26 @@ describe 'Fresh' do
           response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ''})
           response.status.must_equal 200
         end
+
+        it 'stays the Last-Modified header as time' do
+          Time.stub(:now, @modified_since) do
+            response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ''})
+            response.headers.fetch('Last-Modified').must_equal @modified_since.httpdate
+          end
+        end
       end
 
       describe 'and HTTP_IF_MODIFIED_SINCE contain space string' do
         it 'completes request' do
           response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ' '})
           response.status.must_equal 200
+        end
+
+        it 'stays the Last-Modified header as time' do
+          Time.stub(:now, @modified_since) do
+            response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ' '})
+            response.headers.fetch('Last-Modified').must_equal @modified_since.httpdate
+          end
         end
       end
 
@@ -349,12 +363,26 @@ describe 'Fresh' do
           response = @app.get('/last-modified', {'HTTP_IF_NONE_MATCH' => ''})
           response.status.must_equal 200
         end
+
+        it 'sets the ETag header is nil' do
+          Time.stub(:now, @modified_since) do
+            response = @app.get('/last-modified', {'HTTP_IF_NONE_MATCH' => ''})
+            response.headers['Last-Modified'].must_equal nil
+          end
+        end
       end
 
       describe 'and HTTP_IF_NONE_MATCH contain space string' do
         it 'completes request' do
           response = @app.get('/last-modified', {'HTTP_IF_NONE_MATCH' => ' '})
           response.status.must_equal 200
+        end
+
+        it 'sets the ETag header is nil' do
+          Time.stub(:now, @modified_since) do
+            response = @app.get('/last-modified', {'HTTP_IF_NONE_MATCH' => ' '})
+            response.headers['Last-Modified'].must_equal nil
+          end
         end
       end
     end

--- a/test/integration/cache_test.rb
+++ b/test/integration/cache_test.rb
@@ -330,9 +330,32 @@ describe 'Fresh' do
         @last_modified  = Time.new(2014, 2, 8, 0, 0, 0)
       end
 
-      it 'completes request' do
-        response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ''})
-        response.status.must_equal 200
+      describe 'and HTTP_IF_MODIFIED_SINCE empty' do
+        it 'completes request' do
+          response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ''})
+          response.status.must_equal 200
+        end
+      end
+
+      describe 'and HTTP_IF_MODIFIED_SINCE contain space string' do
+        it 'completes request' do
+          response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ' '})
+          response.status.must_equal 200
+        end
+      end
+
+      describe 'and HTTP_IF_NONE_MATCH empty' do
+        it 'completes request' do
+          response = @app.get('/last-modified', {'HTTP_IF_NONE_MATCH' => ''})
+          response.status.must_equal 200
+        end
+      end
+
+      describe 'and HTTP_IF_NONE_MATCH contain space string' do
+        it 'completes request' do
+          response = @app.get('/last-modified', {'HTTP_IF_NONE_MATCH' => ' '})
+          response.status.must_equal 200
+        end
       end
     end
   end

--- a/test/integration/cache_test.rb
+++ b/test/integration/cache_test.rb
@@ -323,5 +323,17 @@ describe 'Fresh' do
         end
       end
     end
+
+    describe 'when last modified is empty string' do
+      before do
+        @modified_since = Time.new(2014, 1, 8, 0, 0, 0)
+        @last_modified  = Time.new(2014, 2, 8, 0, 0, 0)
+      end
+
+      it 'completes request' do
+        response = @app.get('/last-modified', {'HTTP_IF_MODIFIED_SINCE' => ''})
+        response.status.must_equal 200
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why we need this changes?

I found that some middlewares use strange practice. They set `HTTP_IF_MODIFIED_SINCE` or `HTTP_IF_NONE_MATCH` as empty string.
Simple example: rack-mini-profiler, When I worked with this integration I found [this lines of code](https://github.com/MiniProfiler/rack-mini-profiler/blob/master/lib/mini_profiler/profiler.rb#L251-L254). As you can understand these lines break hanami cache. That's why I think we need to add the check to the empty line too.

WDYT?

/cc @hanami/core @hanami/ecosystem 
