### PR TITLE
Introduces #unsafe_send_file

### DIFF
--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -290,8 +290,6 @@ module Hanami
 
       # Send a file as response from anywhere in the file system.
       #
-      # It automatically handle the following cases:
-      #
       # @see Hanami::Action::Rack#send_file
       #
       # @param path [String, Pathname] path to the file to be sent

--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -257,6 +257,7 @@ module Hanami
       end
 
       # Send a file as response.
+      #  <tt>This method only sends files from the public directory</tt>
       #
       # It automatically handle the following cases:
       #
@@ -283,6 +284,34 @@ module Hanami
       #   end
       def send_file(path)
         result = File.new(path, self.class.configuration.public_directory).call(@_env)
+        headers.merge!(result[1])
+        halt result[0], result[2]
+      end
+
+      # Send a file as response from anywhere in the file system.
+      #
+      # It automatically handle the following cases:
+      #
+      # @see Hanami::Action::Rack#send_file
+      #
+      # @param path [String, Pathname] path to the file to be sent
+      # @return [void]
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require 'hanami/controller'
+      #
+      #   class Show
+      #     include Hanami::Action
+      #
+      #     def call(params)
+      #       # ...
+      #       unsafe_send_file Pathname.new('/tmp/path/to/file')
+      #     end
+      #   end
+      def unsafe_send_file(path)
+        result = File.new(path, Pathname.new(path).dirname).call(@_env)
         headers.merge!(result[1])
         halt result[0], result[2]
       end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1106,6 +1106,7 @@ module SendFileTest
       include SendFileTest::Action
 
       def call(params)
+        p params[:id]
         id = params[:id]
         # This if statement is only for testing purpose
         if id == "1"
@@ -1117,6 +1118,14 @@ module SendFileTest
         else
           send_file Pathname.new('assets/unknown.txt')
         end
+      end
+    end
+
+    class Unsafe
+      include SendFileTest::Action
+
+      def call(params)
+        unsafe_send_file Pathname.new('Gemfile')
       end
     end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1106,7 +1106,6 @@ module SendFileTest
       include SendFileTest::Action
 
       def call(params)
-        p params[:id]
         id = params[:id]
         # This if statement is only for testing purpose
         if id == "1"

--- a/test/integration/send_file_test.rb
+++ b/test/integration/send_file_test.rb
@@ -2,8 +2,9 @@ require 'test_helper'
 require 'rack/test'
 
 SendFileRoutes = Hanami::Router.new(namespace: SendFileTest) do
-  get '/files/flow', to: 'files#flow'
-  get '/files/:id',  to: 'files#show'
+  get '/files/flow',          to: 'files#flow'
+  get '/files/:id(.:format)', to: 'files#show'
+  get '/files/unsafe',        to: 'files#unsafe'
 end
 
 SendFileApplication = Rack::Builder.new do
@@ -15,6 +16,18 @@ describe 'Full stack application' do
 
   def app
     SendFileApplication
+  end
+
+  describe 'send files from anywhere in the system' do
+    it 'responds 200 when the file exists' do
+      get '/files/unsafe', {}
+      file = Pathname.new('Gemfile')
+
+      last_response.status.must_equal 200
+      last_response.headers['Content-Length'].to_i.must_equal file.size
+      last_response.headers['Content-Type'].must_equal 'text/plain'
+      last_response.body.size.must_equal(file.size)
+    end
   end
 
   describe 'when file exists, app responds 200' do


### PR DESCRIPTION
- We still provide send_file as a safe alternative, only sending files
located on the public directory
- `#unsafe_send_file` allows the user to send a file from anywhere while
reminding him that this might be risky.

- Fixes #211