### PR TITLE
Don't mutate Rack env when sending files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Complete, fast and testable actions for Rack
 - [Anton Davydov] Ensure HTTP Cache to not crash when `HTTP_IF_MODIFIED_SINCE` and `HTTP_IF_NONE_MATCH` have blank values
 - [Luca Guidi] Keep flash values after a redirect
 - [Craig M. Wellington & Luca Guidi] Ensure to return 404 when `Action#send_file` cannot find a file with a globbed route
+- [Luca Guidi] Don't mutate Rack env when sending files
 
 ## v1.0.0.beta1 - 2017-02-14
 ### Added

--- a/lib/hanami/action/rack/file.rb
+++ b/lib/hanami/action/rack/file.rb
@@ -10,7 +10,6 @@ module Hanami
       #
       # @see Hanami::Action::Rack#send_file
       class File
-
         # The key that returns path info from the Rack env
         #
         # @since 1.0.0.beta1
@@ -29,7 +28,9 @@ module Hanami
         # @since 0.4.3
         # @api private
         def call(env)
+          env = env.dup
           env[PATH_INFO] = @path
+
           @file.get(env)
         rescue Errno::ENOENT
           [404, {}, nil]

--- a/test/action/rack/file_test.rb
+++ b/test/action/rack/file_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+describe Hanami::Action::Rack::File do
+  describe "#call" do
+    it "doesn't mutate given env" do
+      env      = Rack::MockRequest.env_for("/download", method: "GET")
+      expected = env.dup
+
+      file = Hanami::Action::Rack::File.new("/report.pdf", __dir__)
+      file.call(env)
+
+      env.must_equal expected
+    end
+  end
+end


### PR DESCRIPTION
This PR avoids mutations of the Rack env when sending files.

Imagine the following scenario:

```ruby
class Download
  include Hanami::Action

  def call(env)
    puts env['PATH_INFO'] # => "/download"
    send_file "report.pdf"
    puts env['PATH_INFO'] # => "report.pdf" WRONG
  end
end
```

With this fix the requested `PATH_INFO` is preserved, as long as the whole Rack env.