### PR TITLE
Fix the parsing and evaluation of the Accepts Header

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -265,13 +265,8 @@ module Hanami
       #   end
       def content_type
         return @content_type unless @content_type.nil?
-
-        if accept_header?
-          type = content_type_from_accept_header
-          return type if type
-        end
-
-        default_response_type || default_content_type || DEFAULT_CONTENT_TYPE
+        @content_type = content_type_from_accept_header if accept_header?
+        @content_type || default_response_type || default_content_type || DEFAULT_CONTENT_TYPE
       end
 
       # Action charset setter, receives new charset value

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -569,15 +569,40 @@ module Hanami
         end.compact.max&.format
       end
 
+      # @since 1.0.1
+      # @api private
       class RequestMimeWeight
         include Comparable
 
-        attr_reader :quality, :index, :mime, :format, :priority
+        # @since 1.0.1
+        # @api private
+        attr_reader :quality
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :index
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :mime
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :format
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :priority
+
+        # @since 1.0.1
+        # @api private
         def initialize(mime, quality, index, format = mime)
           @quality, @index, @format = quality, index, format
           calculate_priority(mime)
         end
 
+        # @since 1.0.1
+        # @api private
         def <=>(other)
           return priority <=> other.priority unless priority == other.priority
           other.index <=> index
@@ -585,6 +610,8 @@ module Hanami
 
         private
 
+        # @since 1.0.1
+        # @api private
         def calculate_priority(mime)
           @priority ||= (mime.split('/'.freeze, 2).count('*'.freeze) * -10) + quality
         end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -581,9 +581,6 @@ module Hanami
         def <=>(other)
           return priority <=> other.priority unless priority == other.priority
           other.index <=> index
-          # return other.quality <=> quality unless quality == other.quality
-          # return other.priority <=> priority unless priority == other.priority
-          # other.index <=> index
         end
 
         private

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -583,9 +583,11 @@ module Hanami
         end
 
         def <=>(other)
-          return quality <=> other.quality unless quality == other.quality
           return priority <=> other.priority unless priority == other.priority
           other.index <=> index
+          # return other.quality <=> quality unless quality == other.quality
+          # return other.priority <=> priority unless priority == other.priority
+          # other.index <=> index
         end
 
         private

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -569,14 +569,17 @@ module Hanami
           values << Specification.new(req_mime, quality, index, match)
         end
 
-        value = values.sort.last
+        value = values.max
         value.format if value
       end
 
       class Specification
-        attr_reader :quality, :index, :mime, :format
-        def initialize(mime, quality, index, format)
-          @mime, @quality, @index, @format = mime, quality, index, format
+        include Comparable
+
+        attr_reader :quality, :index, :mime, :format, :priority
+        def initialize(mime, quality, index, format = mime)
+          @quality, @index, @format = quality, index, format
+          calculate_priority(mime)
         end
 
         def <=>(other)
@@ -585,7 +588,9 @@ module Hanami
           other.index <=> index
         end
 
-        def priority
+        private
+
+        def calculate_priority(mime)
           @priority ||= (mime.split('/'.freeze, 2).count('*'.freeze) * -10) + quality
         end
       end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -568,13 +568,9 @@ module Hanami
           next unless match
           values << Specification.new(req_mime, quality, index, match)
         end
-        p values
-        value = values.sort.last
 
-        if value
-          # return default_content_type if value.mime == DEFAULT_ACCEPT
-          value.format
-        end
+        value = values.sort.last
+        value.format if value
       end
 
       class Specification

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -562,18 +562,14 @@ module Hanami
       # @see https://github.com/hanami/controller/issues/104
       # @see https://github.com/hanami/controller/issues/275
       def best_q_match(q_value_header, available_mimes)
-        values = []
-        ::Rack::Utils.q_values(q_value_header).each_with_index do |(req_mime, quality), index|
+        ::Rack::Utils.q_values(q_value_header).each_with_index.map do |(req_mime, quality), index|
           match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
           next unless match
-          values << Specification.new(req_mime, quality, index, match)
-        end
-
-        value = values.max
-        value.format if value
+          RequestMimeWeight.new(req_mime, quality, index, match)
+        end.compact.max&.format
       end
 
-      class Specification
+      class RequestMimeWeight
         include Comparable
 
         attr_reader :quality, :index, :mime, :format, :priority

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -568,11 +568,11 @@ module Hanami
           next unless match
           values << Specification.new(req_mime, quality, index, match)
         end
-
+        p values
         value = values.sort.last
 
         if value
-          return default_content_type if value.mime == DEFAULT_ACCEPT
+          # return default_content_type if value.mime == DEFAULT_ACCEPT
           value.format
         end
       end

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -346,10 +346,14 @@ RSpec.describe 'MIME Type' do
             expect(response.status).to be(200)
             expect(response.body).to   eq("html")
           end
+        end
 
-          it 'defaults to the accepted format' do
-            accept = 'text/*,application/json,text/html,*/*'
-            response = Rack::MockRequest.new(MimeRoutes).get('/default_and_accept', 'HTTP_ACCEPT' => accept)
+        # See https://github.com/hanami/controller/issues/225
+        context "with an accepted format and default request format" do
+          let(:accept) { "text/*,application/json,text/html,*/*" }
+          let(:response) { app.get("/restricted", "HTTP_ACCEPT" => accept) }
+
+          it "defaults to the accepted format" do
             expect(response.status).to be(200)
             expect(response.body).to eq('json')
           end

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -11,6 +11,7 @@ MimeRoutes = Hanami::Router.new do
   get '/response',           to: 'mimes#default_response'
   get '/overwritten_format', to: 'mimes#override_default_response'
   get '/custom_from_accept', to: 'mimes#custom_from_accept'
+  get '/default_and_accept', to: 'mimes#default_and_accept'
 end
 
 module Mimes
@@ -113,6 +114,16 @@ module Mimes
 
     def call(_params)
       self.format = :xml
+    end
+  end
+
+  class DefaultAndAccept
+    include Hanami::Action
+    configuration.default_request_format :html
+    accept :json
+
+    def call(params)
+      self.body = format.to_s
     end
   end
 end
@@ -254,6 +265,18 @@ RSpec.describe 'MIME Type' do
           expect(response.body).to                       eq("html")
         end
       end
+
+      context 'applies the weighting mechanism for media ranges' do
+        let(:accept) { "text/*,application/json,text/html,*/*" }
+
+        it "accepts selected mime types" do
+          expect(response.headers["X-AcceptDefault"]).to eq("true")
+          expect(response.headers["X-AcceptHtml"]).to    eq("true")
+          expect(response.headers["X-AcceptXml"]).to     eq("true")
+          expect(response.headers["X-AcceptJson"]).to    eq("true")
+          expect(response.body).to                       eq("json")
+        end
+      end
     end
   end
 
@@ -322,6 +345,13 @@ RSpec.describe 'MIME Type' do
           it "accepts selected mime types" do
             expect(response.status).to be(200)
             expect(response.body).to   eq("html")
+          end
+
+          it 'defaults to the accepted format' do
+            accept = 'text/*,application/json,text/html,*/*'
+            response = Rack::MockRequest.new(MimeRoutes).get('/default_and_accept', 'HTTP_ACCEPT' => accept)
+            expect(response.status).to be(200)
+            expect(response.body).to eq('json')
           end
         end
       end

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe Hanami::Action do
       end
     end
 
+    class JsonLookup
+      include Hanami::Action
+      configuration.handle_exceptions = false
+      configuration.default_request_format :html
+      accept :json
+
+      def call(params)
+      end
+    end
+
+
     class Custom
       include Hanami::Action
       configuration.handle_exceptions = false
@@ -113,6 +124,14 @@ RSpec.describe Hanami::Action do
         expect(exception).to         be_kind_of(Hanami::Controller::UnknownFormatError)
         expect(exception.message).to eq("Cannot find a corresponding Mime type for 'unknown'. Please configure it with Hanami::Controller::Configuration#format.")
       end
+    end
+
+    it "accepts 'application/json, text/plain, */*' and returns :json" do
+      action = FormatController::JsonLookup.new
+      status, headers, _ = action.call('HTTP_ACCEPT' => 'application/json,text/plain,*/*')
+      expect(action.format).to eq(:json)
+      expect(headers['Content-Type']).to eq('application/json; charset=utf-8')
+      expect(status).to eq(200)
     end
 
     Hanami::Action::Mime::MIME_TYPES.each do |format, mime_type|

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe Hanami::Action do
       end
     end
 
+    # See https://github.com/hanami/controller/issues/225
     it "accepts 'application/json, text/plain, */*' and returns :json" do
       action = FormatController::JsonLookup.new
       status, headers, _ = action.call('HTTP_ACCEPT' => 'application/json,text/plain,*/*')

--- a/spec/unit/hanami/action/request_mime_weight_spec.rb
+++ b/spec/unit/hanami/action/request_mime_weight_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Hanami::Action::Mime::Specification do
+RSpec.describe Hanami::Action::Mime::RequestMimeWeight do
   let(:plain_text) { described_class.new('text/plain', 0.7, 2) }
   let(:any_text) { described_class.new('text/*', 1, 0) }
   let(:anything) { described_class.new('*/*', 1, 3) }

--- a/spec/unit/hanami/action/specification_spec.rb
+++ b/spec/unit/hanami/action/specification_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe Hanami::Action::Mime::Specification do
+  let(:plain_text) { described_class.new('text/plain', 0.7, 2) }
+  let(:any_text) { described_class.new('text/*', 1, 0) }
+  let(:anything) { described_class.new('*/*', 1, 3) }
+
+  it "calculates priority"
+  it 'compares against another Specification' do
+  end
+
+  context '#priority' do
+    it 'lower priority for media ranges' do
+      expect(plain_text.priority).to eq(0.7)
+      expect(any_text.priority).to eq(-9)
+      expect(anything.priority).to eq(-19)
+    end
+  end
+
+  context '#<=>' do
+    let(:html) { described_class.new('text/html', 1, 4) }
+    let(:json) { described_class.new('application/json', 1, 1) }
+
+
+    it 'checks priority first' do
+      expect(anything <=> json).to eq(-1)
+      expect(anything <=> any_text).to eq(-1)
+    end
+
+    it 'against same priority and quality, a lower index takes precedence' do
+      expect(html <=> json).to eq(-1)
+    end
+  end
+end

--- a/spec/unit/hanami/action/specification_spec.rb
+++ b/spec/unit/hanami/action/specification_spec.rb
@@ -5,15 +5,29 @@ RSpec.describe Hanami::Action::Mime::Specification do
   let(:any_text) { described_class.new('text/*', 1, 0) }
   let(:anything) { described_class.new('*/*', 1, 3) }
 
-  it "calculates priority"
   it 'compares against another Specification' do
+    expect(described_class.new('text/plain', 1, 2)).to be > plain_text
+    expect(plain_text).to be > any_text
+    expect(anything).to be < plain_text
+    expect(described_class.new('text/*', 0.8, 0)).to be < any_text
+
+    list = [plain_text, anything, any_text]
+    expect(list.sort).to eq([anything, any_text, plain_text])
   end
 
   context '#priority' do
-    it 'lower priority for media ranges' do
+    it 'returns a lower priority for media ranges' do
       expect(plain_text.priority).to eq(0.7)
       expect(any_text.priority).to eq(-9)
       expect(anything.priority).to eq(-19)
+    end
+
+    it 'applies the quality of the mime type' do
+      low_quality = described_class.new('text/plain', 0.2, 0)
+      expect(low_quality.priority).to eq(0.2)
+
+      high_quality_media_range = described_class.new('text/*', 0.8, 0)
+      expect(high_quality_media_range.priority).to eq(-9.2)
     end
   end
 
@@ -24,7 +38,7 @@ RSpec.describe Hanami::Action::Mime::Specification do
 
     it 'checks priority first' do
       expect(anything <=> json).to eq(-1)
-      expect(anything <=> any_text).to eq(-1)
+      expect(any_text <=> anything).to eq(1)
     end
 
     it 'against same priority and quality, a lower index takes precedence' do


### PR DESCRIPTION
# Accept Header Parsing

First of all the [Accept Header specification](https://tools.ietf.org/html/rfc7231#section-5.3.2) mentions that any media range has lower priority than the more specific ones, so `text/html` has higher precedence than `text/*` and `*/*` even at the same `q` (quality) value.

The order of the media types seem to be irrelevant and in case of ties the server could return any of the requested media ranges.

## Our Troubles

As evidenced by [hanami/controller#225](https://github.com/hanami/controller/issues/225) something seems broken. At first I thought that this line of code was the problem: 

```ruby
if req_mime == DEFAULT_ACCEPT
  # See https://github.com/hanami/controller/issues/167
  match = default_content_type
else
```

What this does is: if the mime type being checked is `*/*`  we should return the configured default content type (`text/html` in hanami's case, `application/octet-stream` on controller' s).

That led me to this part of the code:

```ruby
values = ::Rack::Utils.q_values(q_value_header)
values = values.map do |req_mime, quality|
  if req_mime == DEFAULT_ACCEPT
    # See https://github.com/hanami/controller/issues/167
    match = default_content_type
  else
    match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
  end
  next unless match
  [match, quality]
end.compact
```

Here's the bigger picture and what pointed me to even bigger problems. `Rack::Mime.match?` tries to *expand* the media ranges, so it will try to match `text/*` to `text/plain` for example.

The method from where this was taken has the following signature: `best_q_match(req_mimes, available_mimes)`. If we call it with a `req_mimes` of `application/json,text/html,*/*,text/*` what this snippet will output is: `[['application/json', 1.0], ['text/html', 1.0], ['text/html', 1.0], ['text/plain', 1.0]]`.

Then we proceed to sort this matrix using a custom sorting algorithm (same code is found on `rack 2.0`):

```ruby
 value = values.sort_by do |match, quality|
   (match.split('/'.freeze, 2).count('*'.freeze) * -10) + quality
 end.last
```

By then, no media ranges reach this part of the code, so the priority rule never gets applied. So we end up with `text/plain` when we should have returned either `text/html` or `application/json`.

### Differences when the Action has an `accept :json`

With the same `req_mime` as before and an `available_mimes` of `application/json` (the side effect of sending `Action.accept`) the result would be `text/html`. Why? Because the check for the `DEFAULT_ACCEPT` ignores the `available_mimes`, it ends up in the result, gets sorted and picked in the end. 

## Solution

I borrowed a lot of ideas on how to solve it by looking at [negotiator](https://github.com/jshttp/negotiator) and seeing how the python, nodejs communities (among others) solved this.

I created an object (name `Specification` which is a crappy name, so I'm open to suggestions) that encapsulates the mime specification, its quality, index on the accepts header and the format solved by `Rack::Mime.match`.

Said object then calculates the priority and in case of ties opts for the type nearest to the start of the header.

Fixes #225