### PR TITLE
Failing spec for after callback after send_file

### DIFF
--- a/spec/integration/hanami/controller/send_file_spec.rb
+++ b/spec/integration/hanami/controller/send_file_spec.rb
@@ -205,4 +205,20 @@ RSpec.describe "Full stack application" do
     get "/files/flow", {}
     expect(response.status).to be(200)
   end
+
+  context 'with after callback' do
+    it 'calls the after callback after the action call' do
+      action = SendFileTest::Files::WithAfterCallback.new
+      expect(action).to receive(:after_callback)
+      action.call({})
+    end
+  end
+
+  context 'with before callback' do
+    it 'calls the before callback before the action call' do
+      action = SendFileTest::Files::WithBeforeCallback.new
+      expect(action).to receive(:before_callback)
+      action.call({})
+    end
+  end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1230,6 +1230,32 @@ module SendFileTest
         halt 202
       end
     end
+
+    class WithAfterCallback
+      include SendFileTest::Action
+
+      after :after_callback
+
+      def call(params)
+        send_file Pathname.new('test.txt')
+      end
+
+      def after_callback(params)
+      end
+    end
+
+    class WithBeforeCallback
+      include SendFileTest::Action
+
+      before :before_callback
+
+      def call(params)
+        send_file Pathname.new('test.txt')
+      end
+
+      def before_callback(params)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Specs to reproduce #240:

* with after callback fails
* with before callback passes