### PR TITLE
Remove handle exceptions setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Complete, fast and testable actions for Rack
 - [Luca Guidi] `Hanami::Controller::Configuration#initialize` returns a frozen configuration instance
 - [Luca Guidi] Removed `Hanami::Controller::Configuration#prepare`
 - [Luca Guidi] Removed `Hanami::Action.configuration`
-- [Luca Guidi] Removed `Hanami::Action.configuration.handle_exceptions` in favor of `#handle_exceptions?`
+- [Luca Guidi] Removed `Hanami::Action.configuration.handle_exceptions`
 - [Luca Guidi] Removed `Hanami::Action.configuration.default_request_format` in favor of `#default_request_format`
 - [Luca Guidi] Removed `Hanami::Action.configuration.default_charset` in favor of `#default_charset`
 - [Luca Guidi] Removed `Hanami::Action.configuration.format` to register a MIME Type for a single action. Please use the configuration.
@@ -42,6 +42,7 @@ Complete, fast and testable actions for Rack
 - [Luca Guidi] Removed `Hanami::Action#send_file` and `#unsafe_send_file` in favor of `Hanami::Action::Response#send_file` and `#unsafe_send_file`, respectively
 - [Luca Guidi] Removed `Hanami::Action#errors`
 - [Luca Guidi] `Hanami::Action` callback hooks now accept `Hanami::Action::Request` and `Hanami::Action::Response` arguments
+- [Luca Guidi] When an exception is raised, it won't be caught, unless it's handled
 - [Luca Guidi] `Hanami::Action` exception handlers now accept `Hanami::Action::Request`, `Hanami::Action::Response`, and exception arguments
 
 ## v1.1.1 - 2017-11-22

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -558,8 +558,6 @@ module Hanami
         raise exception
       end
 
-      res.halted = true
-
       instance_exec(
         req,
         res,

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -558,6 +558,8 @@ module Hanami
         raise exception
       end
 
+      res.halted = true
+
       instance_exec(
         req,
         res,

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -73,7 +73,7 @@ module Hanami
 
       def self.content_type(configuration, request, accepted_mime_types)
         if request.accept_header?
-          type = best_q_match(request.accept, accepted_mime_types, default_content_type(configuration))
+          type = best_q_match(request.accept, accepted_mime_types)
           return type if type
         end
 
@@ -102,7 +102,11 @@ module Hanami
       def self.detect_format(content_type, configuration)
         return if content_type.nil?
         ct = content_type.split(";").first
-        configuration.format_for(ct) || TYPES.key(ct)
+        configuration.format_for(ct) || format_for(ct)
+      end
+
+      def self.format_for(content_type)
+        TYPES.key(content_type)
       end
 
       def self.restrict_mime_types(configuration, accepted_formats)
@@ -140,7 +144,7 @@ module Hanami
       # @see https://github.com/hanami/controller/issues/59
       # @see https://github.com/hanami/controller/issues/104
       # @see https://github.com/hanami/controller/issues/275
-      def self.best_q_match(q_value_header, available_mimes, default_content_type = nil)
+      def self.best_q_match(q_value_header, available_mimes = TYPES.values)
         ::Rack::Utils.q_values(q_value_header).each_with_index.map do |(req_mime, quality), index|
           match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
           next unless match

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -29,7 +29,7 @@ module Hanami
       EMPTY_BODY = [].freeze
 
       attr_reader :action, :exposures, :format, :env
-      attr_accessor :charset
+      attr_accessor :charset, :halted
 
       def initialize(action:, configuration:, content_type: nil, env: {}, header: {})
         super([], 200, header.dup)
@@ -40,6 +40,8 @@ module Hanami
         @charset   = ::Rack::MediaType.params(content_type).fetch('charset', nil)
         @exposures = {}
         @env       = env
+
+        @halted       = false
         @sending_file = false
       end
 
@@ -135,7 +137,7 @@ module Hanami
       end
 
       def renderable?
-        !@sending_file && body.empty? && !head?
+        !@sending_file && (body.empty? || halted) && !head?
       end
 
       def head?

--- a/lib/hanami/controller/configuration.rb
+++ b/lib/hanami/controller/configuration.rb
@@ -51,7 +51,6 @@ module Hanami
       #
       # @since 0.2.0
       def initialize(&blk)
-        @handle_exceptions       = true
         @handled_exceptions      = {}
         @formats                 = DEFAULT_FORMATS.dup
         @mime_types              = nil
@@ -66,29 +65,6 @@ module Hanami
         freeze
       end
 
-      # Handle exceptions with an HTTP status or let them uncaught
-      #
-      # If this value is set to `true`, the configured exceptions will return
-      # the specified HTTP status, the rest of them with `500`.
-      #
-      # If this value is set to `false`, the exceptions won't be caught.
-      #
-      # @attr_writer handle_exceptions [TrueClass,FalseClass] Handle exceptions
-      #   with an HTTP status or leave them uncaught
-      #
-      # @attr_reader handle_exceptions [TrueClass,FalseClass] The result of the
-      #   check
-      #
-      # @since 0.2.0
-      #
-      # @see Hanami::Controller::Configuration#handle_exception
-      # @see Hanami::Controller#configure
-      # @see Hanami::Action::Throwable
-      # @see http://httpstatus.es/500
-      #
-      # FIXME: new API docs
-      attr_accessor :handle_exceptions
-
       # Specify how to handle an exception with an HTTP status
       #
       # Raised exceptions will return the configured HTTP status, only if
@@ -99,7 +75,6 @@ module Hanami
       #
       # @since 0.2.0
       #
-      # @see Hanami::Controller::Configuration#handle_exceptions
       # @see Hanami::Controller#configure
       # @see Hanami::Action::Throwable
       #

--- a/spec/integration/hanami/controller/rack_exception_spec.rb
+++ b/spec/integration/hanami/controller/rack_exception_spec.rb
@@ -2,8 +2,7 @@ RSpec.describe "Exception notifiers integration" do
   let(:env) { Hash[] }
 
   it 'reference error in rack.exception' do
-    action = RackExceptionAction.new(configuration: configuration)
-    action.call(env)
+    expect { RackExceptionAction.new(configuration: configuration).call(env) }.to raise_error(RackExceptionAction::TestException)
 
     expect(env['rack.exception']).to be_kind_of(RackExceptionAction::TestException)
   end

--- a/spec/support/controller.rb
+++ b/spec/support/controller.rb
@@ -1,7 +1,6 @@
 Hanami::Controller::Configuration.class_eval do
   def ==(other)
     other.kind_of?(self.class) &&
-      other.handle_exceptions  == handle_exceptions &&
       other.handled_exceptions == handled_exceptions
   end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -100,7 +100,15 @@ class CallAction < Hanami::Action
   end
 end
 
+class UncheckedErrorCallAction < Hanami::Action
+  def call(req, res)
+    raise
+  end
+end
+
 class ErrorCallAction < Hanami::Action
+  handle_exception RuntimeError => 500
+
   def call(req, res)
     raise
   end
@@ -266,10 +274,6 @@ class HandledErrorBeforeMethodAction < BeforeMethodAction
   private
   def set_article
     raise RecordNotFound.new
-  end
-
-  def handle_exceptions?
-    true
   end
 end
 
@@ -946,12 +950,6 @@ class VisibilityAction < Hanami::Action
     res.headers.merge!('X-Custom' => 'OK', 'Y-Custom' => 'YO')
     res.session[:foo] = 'bar'
   end
-
-  private
-
-  def handle_exceptions?
-    false
-  end
 end
 
 module SendFileTest
@@ -1078,8 +1076,7 @@ module SendFileTest
   class Application
     def initialize
       configuration = Hanami::Controller::Configuration.new do|config|
-        config.handle_exceptions = false
-        config.public_directory  = "spec/support/fixtures"
+        config.public_directory = "spec/support/fixtures"
       end
 
       router = Hanami::Router.new(configuration: configuration, namespace: SendFileTest) do
@@ -1167,7 +1164,6 @@ module HeadTest
   class Application
     def initialize
       configuration = Hanami::Controller::Configuration.new do |config|
-        config.handle_exceptions = false
         config.default_headers(
           "X-Frame-Options" => "DENY"
         )
@@ -1360,9 +1356,7 @@ module FullStack
 
   class Application
     def initialize
-      configuration = Hanami::Controller::Configuration.new do |config|
-        config.handle_exceptions = false
-      end
+      configuration = Hanami::Controller::Configuration.new
 
       routes   = Hanami::Router.new(namespace: FullStack::Controllers, configuration: configuration) do
         get '/',     to: 'home#index'
@@ -1455,9 +1449,7 @@ module SessionWithCookies
 
   class Application
     def initialize
-      configuration = Hanami::Controller::Configuration.new do |config|
-        config.handle_exceptions = false
-      end
+      configuration = Hanami::Controller::Configuration.new
 
       resolver = EndpointResolver.new(configuration: configuration, namespace: SessionWithCookies::Controllers)
       routes   = Hanami::Router.new(resolver: resolver) do
@@ -1494,9 +1486,7 @@ module SessionsWithoutCookies
 
   class Application
     def initialize
-      configuration = Hanami::Controller::Configuration.new do |config|
-        config.handle_exceptions = false
-      end
+      configuration = Hanami::Controller::Configuration.new
 
       routes   = Hanami::Router.new(configuration: configuration, namespace: SessionsWithoutCookies::Controllers) do
         get '/', to: 'home#index'

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe Hanami::Action do
 
         res.format = format(input)
       end
-
-      private
-
-      def handle_exceptions?
-        false
-      end
     end
 
     class Configuration < Hanami::Action

--- a/spec/unit/hanami/action/throw_spec.rb
+++ b/spec/unit/hanami/action/throw_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe Hanami::Action do
       expect(response.status).to be(404)
     end
 
-    it "returns a 500 if an action isn't handled" do
-      response = UnhandledExceptionAction.new(configuration: configuration).call({})
-
-      expect(response.status).to be(500)
+    it "raises the exception, if not handled" do
+      expect { UnhandledExceptionAction.new(configuration: configuration).call({}) }.to raise_error(RecordNotFound)
     end
 
     describe "with global handled exceptions" do
@@ -44,11 +42,8 @@ RSpec.describe Hanami::Action do
       expect(response.body).to eq(["Secret Sauce"])
     end
 
-    it "throws the code as it is, when not recognized" do
-      response = ThrowCodeAction.new(configuration: configuration).call(status: 2_131_231)
-
-      expect(response.status).to be(500)
-      expect(response.body).to eq(["Internal Server Error"])
+    it "raises an exception when the code isn't valid" do
+      expect { ThrowCodeAction.new(configuration: configuration).call(status: 2_131_231) }.to raise_error(StandardError)
     end
 
     it "stops execution of before filters (method)" do

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe Hanami::Action do
       expect(response.body).to    eq(["Hi from TestAction!"])
     end
 
-    context "when exception handling code is enabled" do
+    context "when an exception isn't handled" do
+      it "should raise an actual exception" do
+        expect { UncheckedErrorCallAction.new(configuration: configuration).call({}) }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when an exception is handled" do
       it "returns an HTTP 500 status code when an exception is raised" do
         response = ErrorCallAction.new(configuration: configuration).call({})
 
@@ -63,18 +69,6 @@ RSpec.describe Hanami::Action do
 
         expect(response.status).to eq(200)
         expect(response.body).to   eq([])
-      end
-    end
-
-    context "when exception handling code is disabled" do
-      let(:configuration) do
-        Hanami::Controller::Configuration.new do |config|
-          config.handle_exceptions = false
-        end
-      end
-
-      it "should raise an actual exception" do
-        expect { ErrorCallAction.new(configuration: configuration).call({}) }.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/unit/hanami/controller/configuration_spec.rb
+++ b/spec/unit/hanami/controller/configuration_spec.rb
@@ -7,20 +7,6 @@ RSpec.describe Hanami::Controller::Configuration do
     end
   end
 
-  describe 'handle exceptions' do
-    it 'returns true by default' do
-      expect(configuration.handle_exceptions).to be(true)
-    end
-
-    it 'allows to set the value with a writer' do
-      configuration = described_class.new do |config|
-        config.handle_exceptions = false
-      end
-
-      expect(configuration.handle_exceptions).to be(false)
-    end
-  end
-
   describe 'handled exceptions' do
     it 'returns an empty hash by default' do
       expect(configuration.handled_exceptions).to eq({})


### PR DESCRIPTION
**TL;DR:** Remove `Hanami::Controller::Configuration#handle_exceptions`.

## How exception handling used to work

We had the possibility of catching exceptions and transform them into a HTTP status or handle them manually.

But.. if the `configuration.handle_exceptions` was turned off (development/test env) the exception was shown as a stack trace in the browser. If that setting was turned on (production) the exception was automatically transformed into a `500 Server Side Error`.

---

This combination of elements settings used to create a matrix of four possibilities: checked/unchecked exception, combined with `handle_exceptions` on/off.

I've seen this matrix to generate confusion in developers and also to make difficult testing of checked exceptions.

---

For instance, let's say we're transforming an `ActiveRecord::RecordNotFound` into a `404 Not Found` HTTP status. During the tests we have `handle_exceptions` off (`false`), because we want to see any exception occurred and be able to fix the code problem.

Well, because of this old exception handling, we won't have easy times to test a simple record not found => 404 scenario. In other words, our application behavior during the tests is **diverging a lot from production**.

---

**Bottom line:** `handle_exceptions` was set according to the current dev/test/production environment. This used to create confusion, and different app behaviors across environments.

## How exception handling will work

By removing `handle_exceptions` we eliminate the confusion and the environment differences.

**The new policy is simple:** Is the exception handled? Handle it. If not, let it to bubble up.

Here's a few examples with `activerecord` gem (from a real world app):

### Unhandled exceptions

```ruby
module Web
  module Controllers
    module Authors
      class Show < Hanami::Action
        def call(req, res)
          res[:author] = Author.find(req.params[:id])
        end
      end
    end
  end
end
```

If `Author` can find the author: `200 OK`, if not the action will **raise an exception** that will be eventually handled by other layers.


### Handled exceptions

```ruby
module Web
  module Controllers
    module Authors
      class Show < Hanami::Action
        handle_exception ActiveRecord::RecordNotFound => 404

        def call(req, res)
          res[:author] = Author.find(req.params[:id])
        end
      end
    end
  end
end
```

If `Author` can find the author: `200 OK`, if not `404 Not Found`.

### Configuration Handled exceptions

To make easy to handle common class of exceptions we can still configure those:

```ruby
module Web
  module Controllers
    module Authors
      class Show < Hanami::Action
        def call(req, res)
          res[:author] = Author.find(req.params[:id])
        end
      end
    end
  end
end

Hanami::Controller::Configuration.new do |config|
  config.handle_exception ActiveRecord::RecordNotFound => 404
end
```

If `Author` can find the author: `200 OK`, if not `404 Not Found`.

---

From the last example, there are **NOT** differences between environments: if an `ActiveRecord::RecordNotFound` is raised, it will always turned into a `404`. If any other exception is raised (eg. `NoMethodError`) that will be let to bubble up.