### PR TITLE
Implement content_type guard

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -198,7 +198,7 @@ module Hanami
           before do
             mime_type = @_env[HTTP_CONTENT_TYPE] || default_content_type || DEFAULT_CONTENT_TYPE
 
-            unless mime_types.find {|mt| ::Rack::Mime.match?(mime_type, mt) }
+            if mime_types.none? {|mt| ::Rack::Mime.match?(mime_type, mt) }
               halt 415
             end
           end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -18,7 +18,7 @@ module Hanami
 
       # The key that returns content mime type from the Rack env
       #
-      # @since 1.1.1
+      # @since x.x.x
       # @api private
       HTTP_CONTENT_TYPE    = 'CONTENT_TYPE'.freeze
 
@@ -176,7 +176,7 @@ module Hanami
         #
         # @param formats[Array<Symbol>] one or more symbols representing mime type(s)
         #
-        # @since 1.1.1
+        # @since x.x.x
         #
         # @example
         #   require 'hanami/controller'

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -16,6 +16,12 @@ module Hanami
       # @api private
       HTTP_ACCEPT          = 'HTTP_ACCEPT'.freeze
 
+      # The key that returns content mime type from the Rack env
+      #
+      # @since 1.1.1
+      # @api private
+      HTTP_CONTENT_TYPE    = 'CONTENT_TYPE'.freeze
+
       # The header key to set the mime type of the response
       #
       # @since 0.1.0
@@ -162,6 +168,38 @@ module Hanami
           before do
             unless mime_types.find {|mt| accept?(mt) }
               halt 406
+            end
+          end
+        end
+
+        # Restrict the payload type to the specified mime type symbols.
+        #
+        # @param formats[Array<Symbol>] one or more symbols representing mime type(s)
+        #
+        # @since 1.1.1
+        #
+        # @example
+        #   require 'hanami/controller'
+        #
+        #   class Upload
+        #     include Hanami::Action
+        #     content_type :json
+        #
+        #     def call(params)
+        #       # ...
+        #     end
+        #   end
+        #
+        #   # When called with "text/html"        => 415
+        #   # When called with "application/json" => 200
+        def content_type(*formats)
+          mime_types = formats.map { |format| format_to_mime_type(format) }
+
+          before do
+            mime_type = @_env[HTTP_CONTENT_TYPE] || default_content_type || DEFAULT_CONTENT_TYPE
+
+            unless mime_types.find {|mt| ::Rack::Mime.match?(mime_type, mt) }
+              halt 415
             end
           end
         end

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -418,8 +418,16 @@ RSpec.describe 'MIME Type' do
     let(:app) { Rack::MockRequest.new(MimeRoutes) }
     let(:response) { app.post("/default_and_content_type", "CONTENT_TYPE" => content_type) }
 
-    context "when media type is supported" do
+    context "when media type is a first from the supported" do
       let(:content_type) { "application/json" }
+
+      it "accepts payload" do
+        expect(response.status).to be(200)
+      end
+    end
+
+    context "when media type is a second from the supported" do
+      let(:content_type) { "text/plain" }
 
       it "accepts payload" do
         expect(response.status).to be(200)

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -1,17 +1,19 @@
 require 'hanami/router'
 
 MimeRoutes = Hanami::Router.new do
-  get '/',                   to: 'mimes#default'
-  get '/custom',             to: 'mimes#custom'
-  get '/configuration',      to: 'mimes#configuration'
-  get '/accept',             to: 'mimes#accept'
-  get '/restricted',         to: 'mimes#restricted'
-  get '/latin',              to: 'mimes#latin'
-  get '/nocontent',          to: 'mimes#no_content'
-  get '/response',           to: 'mimes#default_response'
-  get '/overwritten_format', to: 'mimes#override_default_response'
-  get '/custom_from_accept', to: 'mimes#custom_from_accept'
-  get '/default_and_accept', to: 'mimes#default_and_accept'
+  get '/',                          to: 'mimes#default'
+  get '/custom',                    to: 'mimes#custom'
+  get '/configuration',             to: 'mimes#configuration'
+  get '/accept',                    to: 'mimes#accept'
+  get '/restricted',                to: 'mimes#restricted'
+  get '/latin',                     to: 'mimes#latin'
+  get '/nocontent',                 to: 'mimes#no_content'
+  get '/response',                  to: 'mimes#default_response'
+  get '/overwritten_format',        to: 'mimes#override_default_response'
+  get '/custom_from_accept',        to: 'mimes#custom_from_accept'
+  get '/default_and_accept',        to: 'mimes#default_and_accept'
+  post '/content_type',             to: 'mimes#content_type'
+  post '/default_and_content_type', to: 'mimes#default_and_content_type'
 end
 
 module Mimes
@@ -124,6 +126,27 @@ module Mimes
 
     def call(params)
       self.body = format.to_s
+    end
+  end
+
+  class ContentType
+    include Hanami::Action
+    content_type :json
+
+    def call(_params)
+      self.format = :json
+      self.body   = format
+    end
+  end
+
+  class DefaultAndContentType
+    include Hanami::Action
+    configuration.default_request_format :txt
+    content_type :json, :txt
+
+    def call(_params)
+      self.format = :json
+      self.body   = format
     end
   end
 end
@@ -358,6 +381,64 @@ RSpec.describe 'MIME Type' do
             expect(response.body).to eq('json')
           end
         end
+      end
+    end
+  end
+
+  describe "Content-Type" do
+    let(:app) { Rack::MockRequest.new(MimeRoutes) }
+    let(:response) { app.post("/content_type", "CONTENT_TYPE" => content_type) }
+
+    context "when media type is supported" do
+      let(:content_type) { "application/json" }
+
+      it "accepts payload" do
+        expect(response.status).to be(200)
+      end
+    end
+
+    context "when media type is unsupported" do
+      let(:content_type) { "text/html" }
+
+      it "rejects payload" do
+        expect(response.status).to be(415)
+      end
+    end
+
+    context "when media type is missing" do
+      let(:response) { app.post("/content_type") }
+
+      it "fallbacks to the default hardcoded application/octet-stream content type and rejects payload" do
+        expect(response.status).to be(415)
+      end
+    end
+  end
+
+  describe "Content-Type with defaults" do
+    let(:app) { Rack::MockRequest.new(MimeRoutes) }
+    let(:response) { app.post("/default_and_content_type", "CONTENT_TYPE" => content_type) }
+
+    context "when media type is supported" do
+      let(:content_type) { "application/json" }
+
+      it "accepts payload" do
+        expect(response.status).to be(200)
+      end
+    end
+
+    context "when media type is unsupported" do
+      let(:content_type) { "text/html" }
+
+      it "rejects payload" do
+        expect(response.status).to be(415)
+      end
+    end
+
+    context "when media type is missing" do
+      let(:response) { app.post("/default_and_content_type") }
+
+      it "fallbacks to the configured text/plain content type and accepts payload" do
+        expect(response.status).to be(200)
       end
     end
   end


### PR DESCRIPTION
Closes #236 

Allows to restrict the `Content-Type` of the payload and halt with `415 Unsupported Media Type`

Example

```ruby
class Upload
  include Hanami::Action
  content_type :json

  def call(params)
    # ...
  end
end
```

Related latest RFC

1. https://tools.ietf.org/html/rfc7231#section-3.3
2. https://tools.ietf.org/html/rfc7231#section-4.3.1
3. https://tools.ietf.org/html/rfc7231#section-6.5.13