### PR TITLE
Fix conditions to add Last-Modified / Etag headers

### DIFF
--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -41,7 +41,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def header
-          { ETAG => @value }
+          { ETAG => @value } if @value
         end
 
         private
@@ -73,7 +73,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def header
-          { LAST_MODIFIED => @value.httpdate } if @value.respond_to?(:httpdate)
+          { LAST_MODIFIED => @value.httpdate } if @value && @value.respond_to?(:httpdate)
         end
 
         private

--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -41,7 +41,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def header
-          { ETAG => @value } if none_match
+          { ETAG => @value }
         end
 
         private
@@ -73,7 +73,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def header
-          { LAST_MODIFIED => @value.httpdate } if modified_since
+          { LAST_MODIFIED => @value.httpdate } if @value.respond_to?(:httpdate)
         end
 
         private

--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -67,7 +67,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def fresh?
-          !Hanami::Utils::Blank.blank?(modified_since) && Time.httpdate(modified_since).to_i >= @value.to_i
+          !Hanami::Utils::Blank.blank?(modified_since) && Time.httpdate(modified_since).to_i >= @value.to_time.to_i
         end
 
         # @since 0.3.0


### PR DESCRIPTION
http://hanamirb.org/guides/actions/http-caching/#etag

The document says if `If-None-Match` or `If-Modified-Since` headers are missing, `Etag` or `Last-Modified` headers will be in response headers.
And it is correct as common HTTP server specification, I think.

So, I fixed that.