### PR TITLE
Better missing session error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 cache: bundler
 script: 'script/ci'
 rvm:
-  - 2.3.5
+  - 2.3.6
   - 2.4.2
+  - 2.5.0
   - ruby-head
   - jruby-9.1.13.0
   - jruby-head

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -64,6 +64,18 @@ module Hanami
       end
     end
 
+    # Override method_missing.
+    #
+    # Provide more detailed information when Hanami::Action::Session has not
+    # been included in a given class.
+    def method_missing(meth_id, *args)
+      if meth_id == :session || meth_id == :flash
+        raise Hanami::Controller::MissingSessionError.new(meth_id)
+      else
+        super
+      end
+    end
+
     private
 
     # Finalize the response

--- a/lib/hanami/controller.rb
+++ b/lib/hanami/controller.rb
@@ -47,6 +47,18 @@ module Hanami
       end
     end
 
+    # Missing session error
+    #
+    # This error is raised when an action sends either session or flash to
+    # itself and it does not include Hanami::Action::Session.
+    #
+    # @see Hanami::Action::Session
+    class MissingSessionError < Hanami::Controller::Error
+      def initialize(session_method)
+        super("To use `#{ session_method }`, add `include Hanami::Action::Session`. For more information see [DOCS LINK]")
+      end
+    end
+
     include Utils::ClassAttribute
 
     # Framework configuration

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -478,6 +478,22 @@ class YieldAfterBlockAction < AfterBlockAction
   before {|params| @meaning_of_life_params = params }
 end
 
+class MissingSessionAction
+  include Hanami::Action
+
+  def call(params)
+    session
+  end
+end
+
+class MissingFlashAction
+  include Hanami::Action
+
+  def call(params)
+    flash
+  end
+end
+
 class SessionAction
   include Hanami::Action
   include Hanami::Action::Session

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -92,6 +92,26 @@ RSpec.describe Hanami::Action do
         expect { ErrorCallAction.new.call({}) }.to raise_error(RuntimeError)
       end
     end
+
+    context "when invoking the session method with sessions disabled" do
+      before { MissingSessionAction.configuration.handle_exceptions = false }
+      after { MissingSessionAction.configuration.reset! }
+
+      it "raises an informative exception" do
+        expected = Hanami::Controller::MissingSessionError
+        expect { MissingSessionAction.new.call({}) }.to raise_error(expected)
+      end
+    end
+
+    context "when invoking the flash method with sessions disabled" do
+      before { MissingFlashAction.configuration.handle_exceptions = false }
+      after { MissingFlashAction.configuration.reset! }
+
+      it "raises an informative exception" do
+        expected = Hanami::Controller::MissingSessionError
+        expect { MissingFlashAction.new.call({}) }.to raise_error(expected)
+      end
+    end
   end
 
   describe "#request" do


### PR DESCRIPTION
This PR handles hanami/hanami#859.

When either `#session` or `#flash` are invoked by an action that does not include `Hanami::Action::Session`, raise `Hanami::Controller::MissingSessionError` to provide better insight into why those methods are undefined.

The docs can be updated (as mentioned in the above issue) to point out the need to include the session module, and the appropriate url can be placed in the new exception's message. 