### PR TITLE
deprecate parsed_request_body

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :validations do
   gem 'hanami-validations', '~> 1.3.beta', require: false, git: 'https://github.com/hanami/validations.git', branch: 'develop'
 end
 
+gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'
 gem 'coveralls', require: false

--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -247,7 +247,7 @@ module Hanami
 
       # Return parsed request body
       def parsed_request_body
-        Hanami::Utils::Deprecation.new('parsed_request_body will be deprecated in the future release please use `params`')
+        Hanami::Utils::Deprecation.new('parsed_request_body is deprecated and it will be removed in future versions')
         @_env.fetch(ROUTER_PARSED_BODY, nil)
       end
 

--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -246,8 +246,10 @@ module Hanami
       end
 
       # Return parsed request body
+      #
+      # @deprecated
       def parsed_request_body
-        Hanami::Utils::Deprecation.new('parsed_request_body is deprecated and it will be removed in future versions')
+        Hanami::Utils::Deprecation.new('#parsed_request_body is deprecated and it will be removed in future versions')
         @_env.fetch(ROUTER_PARSED_BODY, nil)
       end
 

--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -3,6 +3,7 @@ require 'hanami/action/request'
 require 'hanami/action/base_params'
 require 'hanami/action/rack/callable'
 require 'hanami/action/rack/file'
+require 'hanami/utils/deprecation'
 
 module Hanami
   module Action
@@ -246,6 +247,7 @@ module Hanami
 
       # Return parsed request body
       def parsed_request_body
+        Hanami::Utils::Deprecation.new('parsed_request_body will be deprecated in the future release please use `params`')
         @_env.fetch(ROUTER_PARSED_BODY, nil)
       end
 

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -1,3 +1,5 @@
+require "hanami/devtools/unit"
+
 RSpec.describe Hanami::Action do
   describe ".configuration" do
     after do
@@ -136,17 +138,7 @@ RSpec.describe Hanami::Action do
   end
 
   describe "#parsed_request_body" do
-    before do
-      @original_stderr = $stderr
-      $stderr = File.open(File::NULL, "w")
-    end
-
-    after do
-      $stderr = @original_stderr
-      @original_stderr = nil
-    end
-
-    it "exposes the body of the request parsed by router body parsers" do
+    it "exposes the body of the request parsed by router body parsers", silence_deprecations: true do
       action_class = Class.new do
         include Hanami::Action
 
@@ -180,7 +172,7 @@ RSpec.describe Hanami::Action do
       env = Rack::MockRequest.env_for('http://example.com/foo',
                                       'router.parsed_body' => { 'a' => 'foo' })
 
-      expect { action.call(env) }.to output(/parsed_request_body is deprecated and it will be removed in future versions/).to_stderr
+      expect { action.call(env) }.to output(/#parsed_request_body is deprecated and it will be removed in future versions/).to_stderr
     end
   end
 

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -136,6 +136,16 @@ RSpec.describe Hanami::Action do
   end
 
   describe "#parsed_request_body" do
+    before do
+      @original_stderr = $stderr
+      $stderr = File.open(File::NULL, "w")
+    end
+
+    after do
+      $stderr = @original_stderr
+      @original_stderr = nil
+    end
+
     it "exposes the body of the request parsed by router body parsers" do
       action_class = Class.new do
         include Hanami::Action
@@ -153,6 +163,24 @@ RSpec.describe Hanami::Action do
       action.call(env)
       parsed_request_body = action.request_body
       expect(parsed_request_body).to eq('a' => 'foo')
+    end
+
+    it "shows deprecation message" do
+      action_class = Class.new do
+        include Hanami::Action
+
+        expose :request_body
+
+        def call(_)
+          @request_body = parsed_request_body
+        end
+      end
+
+      action = action_class.new
+      env = Rack::MockRequest.env_for('http://example.com/foo',
+                                      'router.parsed_body' => { 'a' => 'foo' })
+
+      expect { action.call(env) }.to output(/parsed_request_body is deprecated and it will be removed in future versions/).to_stderr
     end
   end
 


### PR DESCRIPTION
Fixes #254 

@jodosha one question usually when deprecating a method we show a deprecation message and call the new method but since the new method actually is an argument of the method `call`from the action I wasn't sure how to proceed, we could call `params` that will return the whole Rack env or even constructor the params for the user our self, but I do not know if it will have some penalties. WDYT?