### PR TITLE
Use Content-Type header to restrict access

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -518,7 +518,7 @@ module Hanami
     end
 
     def enforce_accepted_mime_types(req, *)
-      Mime.accepted_mime_type?(req, accepted_mime_types) or halt 406
+      Mime.accepted_mime_type?(req, accepted_mime_types, configuration) or halt 406
     end
 
     attr_reader :handled_exceptions

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -127,8 +127,10 @@ module Hanami
         accepted_mime_types
       end
 
-      def self.accepted_mime_type?(request, accepted_mime_types)
-        !accepted_mime_types.find { |mt| request.accept?(mt) }.nil?
+      def self.accepted_mime_type?(request, accepted_mime_types, configuration)
+        mime_type = request.env[CONTENT_TYPE] || default_content_type(configuration) || DEFAULT_CONTENT_TYPE
+
+        !accepted_mime_types.find { |mt| ::Rack::Mime.match?(mt, mime_type) }.nil?
       end
 
       def self.calculate_content_type_with_charset(configuration, request, accepted_mime_types)

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -32,41 +32,77 @@ RSpec.describe 'MIME Type' do
       expect(response.body).to        eq("")
     end
 
-    context "when Accept is sent" do
+    context 'when ACCEPT header is set and no accept macro is use' do
       it 'sets "Content-Type" header according to wildcard value' do
         response = app.get("/", "HTTP_ACCEPT" => "*/*")
         expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
         expect(response.body).to                    eq("all")
       end
+    end
 
+    context "when no ACCEPT or Content-Type are sent but there is a restriction using the accept macro" do
+      it 'sets the status to 406' do
+        response = app.get("/custom_from_accept")
+        expect(response.status).to eq 406
+      end
+    end
+
+    context "when Content-Type are sent and there is a restriction using the accept macro" do
+      it 'sets "Content-Type" to fallback' do
+        response = app.get("/custom_from_accept", "Content-Type" => "application/custom")
+        expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
+        expect(response.body).to                    eq("all")
+      end
+
+      it 'sets status to 406 if Content-Type do not match' do
+        response = app.get("/custom_from_accept", "Content-Type" => "application/xml")
+        expect(response.status).to eq(406)
+      end
+    end
+
+    context "when ACCEPT and Content-Type are sent and we use the accept macro" do
       it 'sets "Content-Type" header according to exact value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom")
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom", "Content-Type" => "application/custom")
         expect(response.headers["Content-Type"]).to eq("application/custom; charset=utf-8")
         expect(response.body).to                    eq("custom")
       end
 
       it 'sets "Content-Type" header according to weighted value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.9,application/json;q=0.5")
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.9,application/json;q=0.5", "Content-Type" => "application/custom")
         expect(response.headers["Content-Type"]).to eq("application/custom; charset=utf-8")
         expect(response.body).to                    eq("custom")
       end
 
       it 'sets "Content-Type" header according to weighted, unordered value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.1, application/json;q=0.5")
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.1, application/json;q=0.5", "Content-Type" => "application/json")
         expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
         expect(response.body).to                    eq("json")
       end
+    end
 
+    context "when ACCEPT and Content-Type are send and there are no restriction using accept macro" do
       it 'sets "Content-Type" header according to exact and weighted value' do
-        response = app.get("/", "HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        response = app.get("/", "HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "Content-Type" => "application/xml")
         expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
         expect(response.body).to                    eq("html")
       end
 
       it 'sets "Content-Type" header according to quality scale value' do
-        response = app.get("/", "HTTP_ACCEPT" => "application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8")
+        response = app.get("/", "HTTP_ACCEPT" => "application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8", "Content-Type" => "application/xml")
         expect(response.headers["Content-Type"]).to eq("application/xml; charset=utf-8")
         expect(response.body).to                    eq("xml")
+      end
+    end
+
+    # See https://github.com/hanami/controller/issues/225
+    context "with an accepted format and default response format" do
+      let(:app) { Rack::MockRequest.new(MimesWithDefault::Application.new) }
+      let(:content_type) { "application/json" }
+      let(:response) { app.get("/default_and_accept", "Content-Type" => content_type) }
+
+      it "defaults to the accepted format" do
+        expect(response.status).to be(200)
+        expect(response.body).to eq('html')
       end
     end
   end
@@ -133,88 +169,6 @@ RSpec.describe 'MIME Type' do
           expect(response.headers["X-AcceptXml"]).to     eq("true")
           expect(response.headers["X-AcceptJson"]).to    eq("true")
           expect(response.body).to                       eq("json")
-        end
-      end
-    end
-  end
-
-  describe "Restricted Accept" do
-    let(:app)      { Rack::MockRequest.new(Mimes::Application.new) }
-    let(:response) { app.get("/restricted", "HTTP_ACCEPT" => accept) }
-
-    context "when Accept is missing" do
-      let(:accept) { nil }
-
-      it "returns the mime type according to the application defined policy" do
-        expect(response.status).to be(200)
-        expect(response.body).to   eq("all")
-      end
-    end
-
-    context "when Accept is sent" do
-      context 'when "*/*"' do
-        let(:accept) { "*/*" }
-
-        it "returns the mime type according to the application defined policy" do
-          expect(response.status).to be(200)
-          expect(response.body).to   eq("all")
-        end
-      end
-
-      context "when accepted" do
-        let(:accept) { "text/html" }
-
-        it "accepts selected MIME Types" do
-          expect(response.status).to be(200)
-          expect(response.body).to   eq("html")
-        end
-      end
-
-      context "when custom MIME Type" do
-        let(:accept) { "application/custom" }
-
-        it "accepts selected mime types" do
-          expect(response.status).to be(200)
-          expect(response.body).to   eq("custom")
-        end
-      end
-
-      context "when not accepted" do
-        let(:accept) { "application/xml" }
-
-        it "accepts selected MIME Types" do
-          expect(response.status).to be(406)
-        end
-      end
-
-      context "when weighted" do
-        context "with an accepted format as first choice" do
-          let(:accept) { "text/html,application/xhtml+xml,application/xml;q=0.9" }
-
-          it "accepts selected mime types" do
-            expect(response.status).to be(200)
-            expect(response.body).to   eq("html")
-          end
-        end
-
-        context "with an accepted format as last choice" do
-          let(:accept) { "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,*/*;q=0.5" }
-
-          it "accepts selected mime types" do
-            expect(response.status).to be(200)
-            expect(response.body).to   eq("html")
-          end
-        end
-
-        # See https://github.com/hanami/controller/issues/225
-        context "with an accepted format and default request format" do
-          let(:accept) { "text/*,application/json,text/html,*/*" }
-          let(:response) { app.get("/default_and_accept", "HTTP_ACCEPT" => accept) }
-
-          it "defaults to the accepted format" do
-            expect(response.status).to be(200)
-            expect(response.body).to eq('json')
-          end
         end
       end
     end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1591,20 +1591,6 @@ module Mimes
     end
   end
 
-  class DefaultAndAccept < Hanami::Action
-    accept :json
-
-    def call(*, res)
-      res.body, = *format(res.content_type)
-    end
-
-    private
-
-    def default_response_format
-      :html
-    end
-  end
-
   class Application
     def initialize
       configuration = Hanami::Controller::Configuration.new do |config|
@@ -1620,7 +1606,32 @@ module Mimes
         get '/nocontent',          to: 'mimes#no_content'
         get '/overwritten_format', to: 'mimes#override_default_response'
         get '/custom_from_accept', to: 'mimes#custom_from_accept'
-        get '/default_and_accept', to: 'mimes#default_and_accept'
+      end
+    end
+
+    def call(env)
+      @router.call(env)
+    end
+  end
+end
+
+module MimesWithDefault
+  class Default < Hanami::Action
+    accept :json
+
+    def call(*, res)
+      res.body, = *format(res.content_type)
+    end
+  end
+
+  class Application
+    def initialize
+      configuration = Hanami::Controller::Configuration.new do |config|
+        config.default_response_format= :html
+      end
+
+      @router = Hanami::Router.new(configuration: configuration) do
+        get '/default_and_accept', to: 'mimes_with_default#default'
       end
     end
 


### PR DESCRIPTION
Check `Content-Type` header when using the `accept` DSL for restrict access

Update specs to work with the new behavior

@jodosha I probably left out some edge cases so feel free to comment as much as possible I will happily modify as much as needed  

---

Ref #257