### PR TITLE
Remove module prepending from `Action.inherited` hook

### DIFF
--- a/spec/integration/hanami/controller/cache_spec.rb
+++ b/spec/integration/hanami/controller/cache_spec.rb
@@ -7,7 +7,7 @@ module CacheControl
 
     cache_control :public, max_age: 600
 
-    def call(*)
+    def handle(*)
     end
   end
 
@@ -16,7 +16,7 @@ module CacheControl
 
     cache_control :public, max_age: 600
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private
     end
   end
@@ -24,7 +24,7 @@ module CacheControl
   class Symbol < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private
     end
   end
@@ -32,7 +32,7 @@ module CacheControl
   class Symbols < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private, :no_cache, :no_store
     end
   end
@@ -40,7 +40,7 @@ module CacheControl
   class Hash < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :public, :no_store, max_age: 900, s_maxage: 86_400, min_fresh: 500, max_stale: 700
     end
   end
@@ -48,7 +48,7 @@ module CacheControl
   class PrivatePublic < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private, :public
     end
   end
@@ -71,7 +71,7 @@ module CacheControl
       end.to_app
     end
 
-    def call(env)
+    def handle(env)
       @app.call(env)
     end
   end
@@ -81,7 +81,7 @@ module Web
   module Controllers
     module Home
       class Index < Hanami::Action
-        def call(*)
+        def handle(*)
         end
       end
     end
@@ -92,7 +92,7 @@ module Admin
   module Controllers
     module Home
       class Index < Hanami::Action
-        def call(*)
+        def handle(*)
         end
       end
     end
@@ -105,7 +105,7 @@ module Expires
 
     expires 900, :public, :no_cache
 
-    def call(*)
+    def handle(*)
     end
   end
 
@@ -114,7 +114,7 @@ module Expires
 
     expires 900, :public, :no_cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 600, :private
     end
   end
@@ -122,7 +122,7 @@ module Expires
   class Symbol < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 900, :private
     end
   end
@@ -130,7 +130,7 @@ module Expires
   class Symbols < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 900, :private, :no_cache, :no_store
     end
   end
@@ -138,7 +138,7 @@ module Expires
   class Hash < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 900, :public, :no_store, s_maxage: 86_400, min_fresh: 500, max_stale: 700
     end
   end
@@ -160,7 +160,7 @@ module Expires
       end.to_app
     end
 
-    def call(env)
+    def handle(env)
       @app.call(env)
     end
   end
@@ -170,7 +170,7 @@ module ConditionalGet
   class Etag < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh etag: 'updated'
     end
   end
@@ -178,7 +178,7 @@ module ConditionalGet
   class LastModified < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh last_modified: Time.now
     end
   end
@@ -186,7 +186,7 @@ module ConditionalGet
   class EtagLastModified < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh etag: 'updated', last_modified: Time.now
     end
   end
@@ -212,7 +212,7 @@ module ConditionalGet
       end
     end
 
-    def call(env)
+    def handle(env)
       @app.call(env)
     end
   end
@@ -220,7 +220,7 @@ module ConditionalGet
   class LastModifiedNilValue < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh last_modified: nil
     end
   end
@@ -228,7 +228,7 @@ module ConditionalGet
   class EtagNilValue < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh etag: nil
     end
   end

--- a/spec/integration/hanami/controller/rack_errors_spec.rb
+++ b/spec/integration/hanami/controller/rack_errors_spec.rb
@@ -28,19 +28,19 @@ ConfigurationHandledExceptionSubclass = Class.new(ConfigurationHandledException)
 module Errors
   # Unhandled
   class WithoutMessage < Hanami::Action
-    def call(*)
+    def handle(*)
       raise UnhandledException
     end
   end
 
   class WithMessage < Hanami::Action
-    def call(*)
+    def handle(*)
       raise UnhandledExceptionWithMessage, "boom"
     end
   end
 
   class WithCustomMessage < Hanami::Action
-    def call(*)
+    def handle(*)
       raise UnhandledExceptionWithCustomMessage, "nope"
     end
   end
@@ -49,7 +49,7 @@ module Errors
   class ActionHandled < Hanami::Action
     handle_exception HandledException => 400
 
-    def call(*)
+    def handle(*)
       raise HandledException
     end
   end
@@ -57,19 +57,19 @@ module Errors
   class ActionHandledSubclass < Hanami::Action
     handle_exception HandledException => 400
 
-    def call(*)
+    def handle(*)
       raise HandledExceptionSubclass
     end
   end
 
   class ConfigurationHandled < Hanami::Action
-    def call(*)
+    def handle(*)
       raise ConfigurationHandledException
     end
   end
 
   class ConfigurationHandledSubclass < Hanami::Action
-    def call(*)
+    def handle(*)
       raise ConfigurationHandledExceptionSubclass
     end
   end

--- a/spec/isolation/without_hanami_validations_spec.rb
+++ b/spec/isolation/without_hanami_validations_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Without validations' do
 
   it "has params that don't respond to .valid?" do
     action = Class.new(Hanami::Action) do
-      def call(req, res)
+      def handle(req, res)
         res.body = [req.params.respond_to?(:valid?), req.params.valid?]
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe 'Without validations' do
 
   it "has params that don't respond to .errors" do
     action = Class.new(Hanami::Action) do
-      def call(req, res)
+      def handle(req, res)
         res.body = req.params.respond_to?(:errors)
       end
     end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -87,14 +87,14 @@ end
 
 module Test
   class Index < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res[:xyz] = req.params[:name]
     end
   end
 end
 
 class CallAction < Hanami::Action
-  def call(_req, res)
+  def handle(_req, res)
     res.status = 201
     res.body   = "Hi from TestAction!"
     res.headers.merge!("X-Custom" => "OK")
@@ -102,7 +102,7 @@ class CallAction < Hanami::Action
 end
 
 class UncheckedErrorCallAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     raise
   end
 end
@@ -110,7 +110,7 @@ end
 class ErrorCallAction < Hanami::Action
   handle_exception RuntimeError => 500
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise
   end
 end
@@ -119,7 +119,7 @@ class MyCustomError < StandardError; end
 class ErrorCallFromInheritedErrorClass < Hanami::Action
   handle_exception StandardError => :handler
 
-  def call(*)
+  def handle(*)
     raise MyCustomError
   end
 
@@ -135,7 +135,7 @@ class ErrorCallFromInheritedErrorClassStack < Hanami::Action
   handle_exception StandardError => :standard_handler
   handle_exception MyCustomError => :handler
 
-  def call(*)
+  def handle(*)
     raise MyCustomError
   end
 
@@ -155,7 +155,7 @@ end
 class ErrorCallWithSymbolMethodNameAsHandlerAction < Hanami::Action
   handle_exception StandardError => :handler
 
-  def call(*)
+  def handle(*)
     raise StandardError
   end
 
@@ -170,7 +170,7 @@ end
 class ErrorCallWithStringMethodNameAsHandlerAction < Hanami::Action
   handle_exception StandardError => "standard_error_handler"
 
-  def call(*)
+  def handle(*)
     raise StandardError
   end
 
@@ -185,7 +185,7 @@ end
 class ErrorCallWithUnsetStatusResponse < Hanami::Action
   handle_exception ArgumentError => "arg_error_handler"
 
-  def call(*)
+  def handle(*)
     raise ArgumentError
   end
 
@@ -198,7 +198,7 @@ end
 class ErrorCallWithSpecifiedStatusCodeAction < Hanami::Action
   handle_exception StandardError => 422
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise StandardError
   end
 end
@@ -208,7 +208,7 @@ class BeforeMethodAction < Hanami::Action
   append_before :add_first_name_to_logger, :add_last_name_to_logger
   prepend_before :add_title_to_logger
 
-  def call(req, res)
+  def handle(req, res)
   end
 
   private
@@ -286,7 +286,7 @@ class BeforeBlockAction < Hanami::Action
   before { |_, res|   res[:article].reverse! }
   before { |req, res| res[:arguments] = [req.class.name, res.class.name] }
 
-  def call(req, res)
+  def handle(req, res)
   end
 end
 
@@ -299,7 +299,7 @@ class AfterMethodAction < Hanami::Action
   append_after :add_first_name_to_logger, :add_last_name_to_logger
   prepend_after :add_title_to_logger
 
-  def call(*)
+  def handle(*)
   end
 
   private
@@ -337,25 +337,25 @@ class AfterBlockAction < Hanami::Action
   after { |_, res| res[:egg].reverse! }
   after { |req, res| res[:arguments] = [req.class.name, res.class.name] }
 
-  def call(*)
+  def handle(*)
   end
 end
 
 class YieldAfterBlockAction < AfterBlockAction
   after { |req, res| res[:meaning_of_life_params] = req.params }
 
-  def call(*)
+  def handle(*)
   end
 end
 
 class MissingSessionAction < Hanami::Action
-  def call(*)
+  def handle(*)
     session
   end
 end
 
 class MissingFlashAction < Hanami::Action
-  def call(*)
+  def handle(*)
     flash
   end
 end
@@ -363,32 +363,32 @@ end
 class SessionAction < Hanami::Action
   include Hanami::Action::Session
 
-  def call(req, res)
+  def handle(req, res)
   end
 end
 
 class FlashAction < Hanami::Action
   include Hanami::Action::Session
 
-  def call(*, res)
+  def handle(*, res)
     res.flash[:error] = "ouch"
   end
 end
 
 class RedirectAction < Hanami::Action
-  def call(*, res)
+  def handle(*, res)
     res.redirect_to "/destination"
   end
 end
 
 class StatusRedirectAction < Hanami::Action
-  def call(*, res)
+  def handle(*, res)
     res.redirect_to "/destination", status: 301
   end
 end
 
 class SafeStringRedirectAction < Hanami::Action
-  def call(*, res)
+  def handle(*, res)
     location = Hanami::Utils::Escape::SafeString.new("/destination")
     res.redirect_to location
   end
@@ -397,7 +397,7 @@ end
 class GetCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body = res.cookies[:foo]
   end
 end
@@ -405,7 +405,7 @@ end
 class ChangeCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body = res.cookies[:foo]
     res.cookies[:foo] = "baz"
   end
@@ -414,7 +414,7 @@ end
 class GetDefaultCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body          = ""
     res.cookies[:bar] = "foo"
   end
@@ -423,7 +423,7 @@ end
 class GetOverwrittenCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body          = ""
     res.cookies[:bar] = { value: "foo", domain: "hanamirb.com", path: "/action", secure: false, httponly: false }
   end
@@ -432,7 +432,7 @@ end
 class GetAutomaticallyExpiresCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.cookies[:bar] = { value: "foo", max_age: 120 }
   end
 end
@@ -440,7 +440,7 @@ end
 class SetCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body          = "yo"
     res.cookies[:foo] = "yum!"
   end
@@ -453,7 +453,7 @@ class SetCookiesWithOptionsAction < Hanami::Action
     @expires = expires
   end
 
-  def call(*, res)
+  def handle(*, res)
     res.cookies[:kukki] = { value: "yum!", domain: "hanamirb.org", path: "/controller", expires: @expires, secure: true, httponly: true }
   end
 end
@@ -461,7 +461,7 @@ end
 class RemoveCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.cookies[:rm] = nil
   end
 end
@@ -469,7 +469,7 @@ end
 class IterateCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     result = []
     res.cookies.each do |key, value|
       result << "'#{key}' has value '#{value}'"
@@ -480,13 +480,13 @@ class IterateCookiesAction < Hanami::Action
 end
 
 class ThrowCodeAction < Hanami::Action
-  def call(req, *)
+  def handle(req, *)
     halt req.params[:status].to_i, req.params[:message]
   end
 end
 
 class CatchAndThrowSymbolAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     catch :done do
       throw :done, 1
       raise "This code shouldn't be reachable"
@@ -498,7 +498,7 @@ class ThrowBeforeMethodAction < Hanami::Action
   before :authorize!
   before :set_body
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 
@@ -517,7 +517,7 @@ class ThrowBeforeBlockAction < Hanami::Action
   before { halt 401 }
   before { res.body = "Hi!" }
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 end
@@ -526,7 +526,7 @@ class ThrowAfterMethodAction < Hanami::Action
   after :raise_timeout!
   after :set_body
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 
@@ -545,7 +545,7 @@ class ThrowAfterBlockAction < Hanami::Action
   after { halt 408 }
   after { res.body = "Later!" }
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 end
@@ -553,7 +553,7 @@ end
 class HandledExceptionAction < Hanami::Action
   handle_exception RecordNotFound => 404
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise RecordNotFound.new
   end
 end
@@ -562,19 +562,19 @@ class DomainLogicException < StandardError
 end
 
 class GlobalHandledExceptionAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     raise DomainLogicException.new
   end
 end
 
 class UnhandledExceptionAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     raise RecordNotFound.new
   end
 end
 
 class ParamsAction < Hanami::Action
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -591,7 +591,7 @@ class WhitelistedParamsAction < Hanami::Action
 
   params Params
 
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -601,7 +601,7 @@ class WhitelistedDslAction < Hanami::Action
     required(:username).filled
   end
 
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -612,7 +612,7 @@ class WhitelistedUploadDslAction < Hanami::Action
     required(:upload).filled
   end
 
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -622,7 +622,7 @@ class ParamsValidationAction < Hanami::Action
     required(:email).filled(:str?)
   end
 
-  def call(req, *)
+  def handle(req, *)
     halt 400 unless req.params.valid?
   end
 end
@@ -661,7 +661,7 @@ class NestedParams < Hanami::Action::Params
 end
 
 class Root < Hanami::Action
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
     res.headers.merge!("X-Test" => "test")
   end
@@ -669,14 +669,14 @@ end
 
 module About
   class Team < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
       res.headers.merge!("X-Test" => "test")
     end
   end
 
   class Contacts < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -684,37 +684,37 @@ end
 
 module Identity
   class Show < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class New < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Create < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Edit < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Update < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Destroy < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -722,43 +722,43 @@ end
 
 module Flowers
   class Index < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Show < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class New < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Create < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Edit < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Update < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Destroy < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -780,7 +780,7 @@ module Painters
       end
     end
 
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -791,7 +791,7 @@ module Dashboard
     include Hanami::Action::Session
     before :authenticate!
 
-    def call(*, res)
+    def handle(*, res)
       res.body = "User ID from session: #{res.session[:user_id]}"
     end
 
@@ -811,7 +811,7 @@ module Sessions
   class Create < Hanami::Action
     include Hanami::Action::Session
 
-    def call(*, res)
+    def handle(*, res)
       res.session[:user_id] = 23
       res.redirect_to "/"
     end
@@ -820,7 +820,7 @@ module Sessions
   class Destroy < Hanami::Action
     include Hanami::Action::Session
 
-    def call(*, res)
+    def handle(*, res)
       res.session[:user_id] = nil
     end
   end
@@ -829,7 +829,7 @@ end
 class StandaloneSession < Hanami::Action
   include Hanami::Action::Session
 
-  def call(*, res)
+  def handle(*, res)
     res.session[:age] = Time.now.year - 1982
   end
 end
@@ -838,7 +838,7 @@ module Glued
   class SendFile < Hanami::Action
     include Hanami::Action::Glue
 
-    def call(_req, _res)
+    def handle(_req, _res)
       send_file "test.txt"
     end
   end
@@ -854,7 +854,7 @@ module App
   class StandaloneAction < Hanami::Action
     handle_exception App::CustomError => 400
 
-    def call(_req, _res)
+    def handle(_req, _res)
       raise App::CustomError
     end
   end
@@ -868,7 +868,7 @@ module App2
     class Index < Hanami::Action
       handle_exception App2::CustomError => 400
 
-      def call(_req, _res)
+      def handle(_req, _res)
         raise App2::CustomError
       end
     end
@@ -899,7 +899,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def call(_req, res)
+        def handle(_req, res)
           res.body = "Muzic!"
           res.headers["X-Frame-Options"] = "ALLOW FROM https://example.org"
         end
@@ -910,7 +910,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def call(_req, _res)
+        def handle(_req, _res)
           raise ArgumentError
         end
       end
@@ -922,7 +922,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def call(_req, res)
+        def handle(_req, res)
           res.body = current_user
         end
       end
@@ -934,7 +934,7 @@ module MusicPlayer
 
         handle_exception ArtistNotFound => 404
 
-        def call(_req, _res)
+        def handle(_req, _res)
           raise ArtistNotFound
         end
       end
@@ -946,7 +946,7 @@ module MusicPlayer
     include Hanami::Action::Session
     include MusicPlayer::Controllers::Authentication
 
-    def call(_req, _res)
+    def handle(_req, _res)
       raise ArgumentError
     end
   end
@@ -967,7 +967,7 @@ class VisibilityAction < Hanami::Action
   include Hanami::Action::Cookies
   include Hanami::Action::Session
 
-  def call(*, res)
+  def handle(*, res)
     res.body   = "x"
     res.status = 201
     res.format = :json
@@ -980,7 +980,7 @@ end
 module SendFileTest
   module Files
     class Show < Hanami::Action
-      def call(req, res)
+      def handle(req, res)
         id = req.params[:id]
 
         # This if statement is only for testing purpose
@@ -1027,44 +1027,44 @@ module SendFileTest
     end
 
     class UnsafeLocal < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file "Gemfile"
       end
     end
 
     class UnsafePublic < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file "spec/support/fixtures/test.txt"
       end
     end
 
     class UnsafeAbsolute < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file Pathname.new("Gemfile").realpath
       end
     end
 
     class UnsafeMissingLocal < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file "missing"
       end
     end
 
     class UnsafeMissingAbsolute < Hanami::Action
-      def call(_req, res)
+      def handle(_req, res)
         res.unsafe_send_file Pathname.new(".").join("missing")
       end
     end
 
     class Flow < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.send_file Pathname.new("test.txt")
         res.redirect_to "/"
       end
     end
 
     class Glob < Hanami::Action
-      def call(*)
+      def handle(*)
         halt 202
       end
     end
@@ -1072,7 +1072,7 @@ module SendFileTest
     class BeforeCallback < Hanami::Action
       before :before_callback
 
-      def call(*, res)
+      def handle(*, res)
         res.send_file Pathname.new("test.txt")
       end
 
@@ -1086,7 +1086,7 @@ module SendFileTest
     class AfterCallback < Hanami::Action
       after :after_callback
 
-      def call(*, res)
+      def handle(*, res)
         res.send_file Pathname.new("test.txt")
       end
 
@@ -1135,7 +1135,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def call(_req, res)
+      def handle(_req, res)
         res.body = "index"
       end
     end
@@ -1145,7 +1145,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def call(req, res)
+      def handle(req, res)
         content = "code"
 
         res.headers.merge!(
@@ -1168,7 +1168,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def call(_req, res)
+      def handle(_req, res)
         res.headers.merge!(
           "Last-Modified" => "Fri, 27 Nov 2015 13:32:36 GMT",
           "X-Rate-Limit"  => "4000",
@@ -1220,7 +1220,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res[:greeting] = "Hello"
         end
       end
@@ -1230,7 +1230,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res.body = "foo"
         end
       end
@@ -1242,7 +1242,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*)
+        def handle(*)
         end
       end
 
@@ -1255,7 +1255,7 @@ module FullStack
           required(:title).filled(:str?)
         end
 
-        def call(req, res)
+        def handle(req, res)
           req.params.valid?
 
           res.redirect_to "/books"
@@ -1278,7 +1278,7 @@ module FullStack
           end
         end
 
-        def call(req, res)
+        def handle(req, res)
           valid = req.params.valid?
 
           res.status = 201
@@ -1297,7 +1297,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*)
+        def handle(*)
         end
       end
 
@@ -1306,7 +1306,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res.flash[:message] = "Saved!"
           res.redirect_to "/settings"
         end
@@ -1319,7 +1319,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res.redirect_to "/poll/1"
         end
       end
@@ -1329,7 +1329,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(req, res)
+        def handle(req, res)
           if req.env["REQUEST_METHOD"] == "GET"
             res.flash[:notice] = "Start the poll"
           else
@@ -1344,7 +1344,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(req, res)
+        def handle(req, res)
           if req.env["REQUEST_METHOD"] == "POST"
             res.flash[:notice] = "Poll completed"
             res.redirect_to "/"
@@ -1362,7 +1362,7 @@ module FullStack
         before :redirect_to_root
         after :set_body
 
-        def call(*, res)
+        def handle(*, res)
           res.body = "call method shouldn't be called"
         end
 
@@ -1419,7 +1419,7 @@ module FullStack
 end
 
 class MethodInspectionAction < Hanami::Action
-  def call(req, res)
+  def handle(req, res)
     res.body = req.request_method
   end
 end
@@ -1428,7 +1428,7 @@ class RackExceptionAction < Hanami::Action
   class TestException < ::StandardError
   end
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise TestException.new
   end
 end
@@ -1439,7 +1439,7 @@ class HandledRackExceptionAction < Hanami::Action
 
   handle_exception TestException => 500
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise TestException.new
   end
 end
@@ -1453,7 +1453,7 @@ class HandledRackExceptionSubclassAction < Hanami::Action
 
   handle_exception TestException => 500
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise TestSubclassException.new
   end
 end
@@ -1466,7 +1466,7 @@ module SessionWithCookies
         include Hanami::Action::Session
         include Hanami::Action::Cookies
 
-        def call(req, res)
+        def handle(req, res)
         end
       end
     end
@@ -1503,7 +1503,7 @@ module SessionsWithoutCookies
         include Hanami::Action::Session
         include Inspector
 
-        def call(*)
+        def handle(*)
         end
       end
     end
@@ -1532,20 +1532,20 @@ end
 
 module Mimes
   class Default < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.body, = *format(res.content_type)
     end
   end
 
   class Custom < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.format = format(:xml)
       res.body   = res.format
     end
   end
 
   class Latin < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.charset = "latin1"
       res.format  = format(:html)
       res.body    = res.format
@@ -1553,7 +1553,7 @@ module Mimes
   end
 
   class Accept < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.headers["X-AcceptDefault"] = req.accept?("application/octet-stream").to_s
       res.headers["X-AcceptHtml"]    = req.accept?("text/html").to_s
       res.headers["X-AcceptXml"]     = req.accept?("application/xml").to_s
@@ -1566,7 +1566,7 @@ module Mimes
   class CustomFromAccept < Hanami::Action
     accept :json, :custom
 
-    def call(*, res)
+    def handle(*, res)
       res.body, = *format(res.content_type)
     end
   end
@@ -1574,19 +1574,19 @@ module Mimes
   class Restricted < Hanami::Action
     accept :html, :json, :custom
 
-    def call(_req, res)
+    def handle(_req, res)
       res.body, = *format(res.content_type)
     end
   end
 
   class NoContent < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.status = 204
     end
   end
 
   class OverrideDefaultResponse < Hanami::Action
-    def call(*, res)
+    def handle(*, res)
       res.format = format(:xml)
     end
 
@@ -1625,7 +1625,7 @@ module MimesWithDefault
   class Default < Hanami::Action
     accept :json
 
-    def call(*, res)
+    def handle(*, res)
       res.body, = *format(res.content_type)
     end
   end
@@ -1724,7 +1724,7 @@ module Flash
       class Index < Hanami::Action
         include Hanami::Action::Session
 
-        def call(req, res)
+        def handle(req, res)
           res.flash[:hello] = "world"
 
           if req.env["REQUEST_METHOD"] == "GET"
@@ -1738,7 +1738,7 @@ module Flash
       class Books < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.body = "flash_empty: #{res.flash.empty?} flash: #{res.flash.inspect}"
         end
       end
@@ -1746,7 +1746,7 @@ module Flash
       class Print < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.body = res.flash[:hello]
         end
       end
@@ -1754,7 +1754,7 @@ module Flash
       class EachRedirect < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.flash[:hello] = "world"
           res.redirect_to "/each"
         end
@@ -1763,7 +1763,7 @@ module Flash
       class Each < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           each_result = []
           res.flash.each { |type, message| each_result << [type, message] }
           res.body = "flash_each: #{each_result}"
@@ -1773,7 +1773,7 @@ module Flash
       class MapRedirect < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.flash[:hello] = "world"
           res.redirect_to "/map"
         end
@@ -1782,7 +1782,7 @@ module Flash
       class Map < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.body = "flash_map: #{res.flash.map { |type, message| [type, message] }}"
         end
       end

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Hanami::Action do
   class FormatController
     class Lookup < Hanami::Action
-      def call(*)
+      def handle(*)
       end
     end
 
     class Custom < Hanami::Action
-      def call(req, res)
+      def handle(req, res)
         input = req.params[:format]
         input = input.to_sym unless input.nil?
 
@@ -15,7 +15,7 @@ RSpec.describe Hanami::Action do
     end
 
     class Configuration < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.body = res.format
       end
     end

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Hanami::Action::Params do
 
           it "doesn't filter _csrf_token" do
             response = Rack::MockRequest.new(action).request('PATCH', "?id=1", params: { _csrf_token: 'def', x: { foo: 'bar' } })
-            expect(response.body).to match(%(:id=>"1", :_csrf_token=>"def"))
+            expect(response.body).to match(%(:_csrf_token=>"def", :id=>"1"))
           end
         end
 

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Hanami::Action do
   describe "#request" do
     it "gets a Rack-like request object" do
       action_class = Class.new(Hanami::Action) do
-        def call(req, res)
+        def handle(req, res)
           res[:request] = req
         end
       end


### PR DESCRIPTION
Opening this PR for discussion, since it achieves a few important things:

1. It makes it possible to create `Hanami::Action` subclasses that use dry-auto_inject to inject their own dependencies (the prepended `#initialize` was breaking this before)
2. It makes it possible to have deeper class hierarchies, such as `class ApplicationAction < Hanami::Action`, and then e.g. `class Users::Show < ApplicationAction`) (since we're no longer prepending `#initialize`, which in the previous implementation was broken when prepended more than once)
3. It improves understandability of the library - when a subclass implements `#handle`, but the main interface remains `#call`, then application developers will implicitly understand that some extra code is being run in between the two.

👋 @jodosha, I'll let you suggest who else to bring in for review here :)