### PR TITLE
Allow Hanami::Action to be inherited multiple times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['CI']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils',  '~> 2.0.alpha', require: false, git: 'https://github.com/hanami/utils.git',  branch: 'feature/callbacks-chain-dup'
+gem 'hanami-utils',  '~> 2.0.alpha', require: false, git: 'https://github.com/hanami/utils.git',  branch: 'unstable'
 gem 'hanami-router', '~> 2.0.alpha', require: false, git: 'https://github.com/hanami/router.git', branch: 'unstable'
 
 group :validations do

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['CI']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils',  '~> 2.0.alpha', require: false, git: 'https://github.com/hanami/utils.git',  branch: 'unstable'
+gem 'hanami-utils',  '~> 2.0.alpha', require: false, git: 'https://github.com/hanami/utils.git',  branch: 'feature/callbacks-chain-dup'
 gem 'hanami-router', '~> 2.0.alpha', require: false, git: 'https://github.com/hanami/router.git', branch: 'unstable'
 
 group :validations do

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -171,16 +171,25 @@ module Hanami
     # @since 0.1.0
     # @api private
     def self.inherited(base)
-      base.class_eval do
-        include Utils::ClassAttribute
-        class_attribute :before_callbacks
-        self.before_callbacks = Utils::Callbacks::Chain.new
+      if base.superclass == Hanami::Action
+        base.class_eval do
+          include Utils::ClassAttribute
 
-        class_attribute :after_callbacks
-        self.after_callbacks = Utils::Callbacks::Chain.new
+          class_attribute :before_callbacks
+          self.before_callbacks = Utils::Callbacks::Chain.new
 
-        prepend InstanceMethods
-        include Validatable if defined?(Validatable)
+          class_attribute :after_callbacks
+          self.after_callbacks = Utils::Callbacks::Chain.new
+
+          prepend InstanceMethods
+          include Validatable if defined?(Validatable)
+        end
+      else
+        base.class_eval do
+          self.before_callbacks = superclass.before_callbacks.dup
+          self.after_callbacks  = superclass.after_callbacks.dup
+          prepend InstanceMethods
+        end
       end
     end
 
@@ -410,21 +419,25 @@ module Hanami
     #
     # @since 0.1.0
     # @api private
-    module InstanceMethods
-      def initialize(configuration:, **args)
-        super(**args)
-        @configuration       = configuration
-        @accepted_mime_types = Mime.restrict_mime_types(configuration, self.class.accepted_formats)
-
-        # Exceptions
-        @handled_exceptions = @configuration.handled_exceptions.merge(self.class.handled_exceptions)
-        @handled_exceptions = Hash[
-          @handled_exceptions.sort{|(ex1,_),(ex2,_)| ex1.ancestors.include?(ex2) ? -1 : 1 }
-        ]
-
-        freeze
+    def self.new(configuration:, **args)
+      allocate.tap do |obj|
+        obj.instance_variable_set(:@configuration, configuration)
+        obj.instance_variable_set(:@accepted_mime_types, Mime.restrict_mime_types(configuration, accepted_formats))
+        obj.instance_variable_set(
+          :@handled_exceptions,
+          Hash[
+            configuration
+            .handled_exceptions
+            .merge(handled_exceptions)
+            .sort{ |(ex1,_),(ex2,_)| ex1.ancestors.include?(ex2) ? -1 : 1 }
+          ]
+        )
+        obj.send(:initialize, **args)
+        obj.freeze
       end
+    end
 
+    module InstanceMethods
       # Implements the Rack/Hanami::Action protocol
       #
       # @since 0.1.0

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -186,8 +186,6 @@ module Hanami
         end
       else
         base.class_eval do
-          self.before_callbacks = superclass.before_callbacks.dup
-          self.after_callbacks  = superclass.after_callbacks.dup
           prepend InstanceMethods
         end
       end

--- a/spec/integration/hanami/controller/inheritance_spec.rb
+++ b/spec/integration/hanami/controller/inheritance_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+RSpec.describe Hanami::Action do
+  describe "inheritance" do
+    include Rack::Test::Methods
+
+    let(:app) { Inheritance::Application.new }
+
+    it "calls the exact chain of events" do
+      get "/books/23"
+
+      expect(last_response.body).to eq("[:base_action, :authenticated, :book, :found]")
+    end
+  end
+end


### PR DESCRIPTION
Ensure actions to be able to:

  * Properly inherit callbacks chain from ancestors
  * Add callbacks without interfering with siblings and ancestors

This fix is partially based on @timriley work on `Action.new`.