### PR TITLE
Configuration setters

### DIFF
--- a/lib/hanami/controller/configuration.rb
+++ b/lib/hanami/controller/configuration.rb
@@ -238,6 +238,8 @@ module Hanami
         end
       end
 
+      attr_reader :cookies
+
       # Set default cookies options for all responses
       #
       # By default this value is an empty hash.
@@ -252,22 +254,18 @@ module Hanami
       # @example Setting the value
       #   require 'hanami/controller'
       #
-      #   Hanami::Controller.configure do
-      #     cookies({
+      #   Hanami::Controller::Configuration.new do |config|
+      #     config.cookies = {
       #       domain: 'hanamirb.org',
       #       path: '/controller',
       #       secure: true,
       #       httponly: true
-      #     })
+      #     }
       #   end
-      def cookies(options = nil)
-        if options
-          @cookies.merge!(
-            options.reject { |_, v| v.nil? }
-          )
-        else
-          @cookies
-        end
+      def cookies=(options)
+        @cookies.merge!(
+          options.reject { |_, v| v.nil? }
+        )
       end
 
       # Returns a format for the given mime type

--- a/lib/hanami/controller/configuration.rb
+++ b/lib/hanami/controller/configuration.rb
@@ -209,6 +209,8 @@ module Hanami
       # FIXME: new API docs
       attr_accessor :default_charset
 
+      attr_reader :default_headers
+
       # Set default headers for all responses
       #
       # By default this value is an empty hash.
@@ -223,19 +225,15 @@ module Hanami
       # @example Setting the value
       #   require 'hanami/controller'
       #
-      #   Hanami::Controller.configure do
-      #     default_headers({
+      #   Hanami::Controller::Configuration.new do |config|
+      #     config.default_headers = {
       #       'X-Frame-Options' => 'DENY'
-      #     })
+      #     }
       #   end
-      def default_headers(headers = nil)
-        if headers
-          @default_headers.merge!(
-            headers.reject {|_,v| v.nil? }
-          )
-        else
-          @default_headers
-        end
+      def default_headers=(headers)
+        @default_headers.merge!(
+          headers.reject { |_, v| v.nil? }
+        )
       end
 
       attr_reader :cookies

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1188,9 +1188,9 @@ module HeadTest
   class Application
     def initialize
       configuration = Hanami::Controller::Configuration.new do |config|
-        config.default_headers(
+        config.default_headers = {
           "X-Frame-Options" => "DENY"
-        )
+        }
       end
 
       router = Hanami::Router.new(namespace: HeadTest, configuration: configuration) do

--- a/spec/unit/hanami/action/cookies_spec.rb
+++ b/spec/unit/hanami/action/cookies_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Hanami::Action do
     describe "with default cookies" do
       let(:configuration) do
         Hanami::Controller::Configuration.new do |config|
-          config.cookies(domain: "hanamirb.org", path: "/controller", secure: true, httponly: true)
+          config.cookies = { domain: "hanamirb.org", path: "/controller", secure: true, httponly: true }
         end
       end
 

--- a/spec/unit/hanami/controller/configuration_spec.rb
+++ b/spec/unit/hanami/controller/configuration_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Hanami::Controller::Configuration do
       let(:configuration) do
         h = headers
         described_class.new do |config|
-          config.default_headers(h)
+          config.default_headers = h
         end
       end
 
@@ -214,7 +214,7 @@ RSpec.describe Hanami::Controller::Configuration do
         let(:configuration) do
           h = headers
           described_class.new do |config|
-            config.default_headers(h.merge('X-NIL' => nil))
+            config.default_headers = h.merge('X-NIL' => nil)
           end
         end
 


### PR DESCRIPTION
## Enhancement

Let cookies and default headers to be assigned by a _setter_ method:

```ruby
configuration = Hanami::Controller::Configuration.new do |config|
  config.cookies = { domain: "example.com" }
  config.default_headers = {
    "X-Frame-Options" => "DENY"
  }
end
```

There are two reasons to do so:

  1. Consistency with other settings of `Hanami::Controller::Configuration` that are already assigned with a _setter_ since 2.0.
  1. Consistency with new `Hanami::Configuration` (from `hanami` gem) that now uses _setters_ to set values such as cookies.

## Breaking change

This is a breaking change, in the past the same settings above needed to be configured like this:

```ruby
cookies(domain: "example.com")
default_headers(
  "X-Frame-Options" => "DENY"
)
```