### PR TITLE
remove flash and session from action

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -679,28 +679,6 @@ module Hanami
       end
     end
 
-    # Raise error when `Hanami::Action::Session` isn't included.
-    #
-    # To use `session`, include `Hanami::Action::Session`.
-    #
-    # @raise [Hanami::Controller::MissingSessionError]
-    #
-    # @since 1.2.0
-    def session
-      raise Hanami::Controller::MissingSessionError.new(:session)
-    end
-
-    # Raise error when `Hanami::Action::Session` isn't included.
-    #
-    # To use `flash`, include `Hanami::Action::Session`.
-    #
-    # @raise [Hanami::Controller::MissingSessionError]
-    #
-    # @since 1.2.0
-    def flash
-      raise Hanami::Controller::MissingSessionError.new(:flash)
-    end
-
     # Finalize the response
     #
     # This method is abstract and COULD be implemented by included modules in

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -75,20 +75,6 @@ RSpec.describe Hanami::Action do
         expect(response.body).to   eq([])
       end
     end
-
-    context "when invoking the session method with sessions disabled" do
-      it "raises an informative exception" do
-        expected = Hanami::Controller::MissingSessionError
-        expect { MissingSessionAction.new(configuration: configuration).call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
-      end
-    end
-
-    context "when invoking the flash method with sessions disabled" do
-      it "raises an informative exception" do
-        expected = Hanami::Controller::MissingSessionError
-        expect { MissingFlashAction.new(configuration: configuration).call({}) }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
-      end
-    end
   end
 
   describe "#request" do


### PR DESCRIPTION
Looks like from some merge conflicts or something similar we have some leftover code in `action.rb`.

Both methods are present in `response.rb`

@jodosha I wasn't sure to delete `MissingSessionError` class from the code, maybe we want to use it in the future to implement the missing functionality of raising it if the `Session` module is missing for both `response` and `request`