### PR TITLE
Avoid prepending `#call`, require subclasses to implement `#handle`

### DIFF
--- a/spec/integration/hanami/controller/cache_spec.rb
+++ b/spec/integration/hanami/controller/cache_spec.rb
@@ -7,7 +7,7 @@ module CacheControl
 
     cache_control :public, max_age: 600
 
-    def call(*)
+    def handle(*)
     end
   end
 
@@ -16,7 +16,7 @@ module CacheControl
 
     cache_control :public, max_age: 600
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private
     end
   end
@@ -24,7 +24,7 @@ module CacheControl
   class Symbol < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private
     end
   end
@@ -32,7 +32,7 @@ module CacheControl
   class Symbols < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private, :no_cache, :no_store
     end
   end
@@ -40,7 +40,7 @@ module CacheControl
   class Hash < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :public, :no_store, max_age: 900, s_maxage: 86_400, min_fresh: 500, max_stale: 700
     end
   end
@@ -48,7 +48,7 @@ module CacheControl
   class PrivatePublic < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.cache_control :private, :public
     end
   end
@@ -71,7 +71,7 @@ module CacheControl
       end.to_app
     end
 
-    def call(env)
+    def handle(env)
       @app.call(env)
     end
   end
@@ -81,7 +81,7 @@ module Web
   module Controllers
     module Home
       class Index < Hanami::Action
-        def call(*)
+        def handle(*)
         end
       end
     end
@@ -92,7 +92,7 @@ module Admin
   module Controllers
     module Home
       class Index < Hanami::Action
-        def call(*)
+        def handle(*)
         end
       end
     end
@@ -105,7 +105,7 @@ module Expires
 
     expires 900, :public, :no_cache
 
-    def call(*)
+    def handle(*)
     end
   end
 
@@ -114,7 +114,7 @@ module Expires
 
     expires 900, :public, :no_cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 600, :private
     end
   end
@@ -122,7 +122,7 @@ module Expires
   class Symbol < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 900, :private
     end
   end
@@ -130,7 +130,7 @@ module Expires
   class Symbols < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 900, :private, :no_cache, :no_store
     end
   end
@@ -138,7 +138,7 @@ module Expires
   class Hash < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.expires 900, :public, :no_store, s_maxage: 86_400, min_fresh: 500, max_stale: 700
     end
   end
@@ -160,7 +160,7 @@ module Expires
       end.to_app
     end
 
-    def call(env)
+    def handle(env)
       @app.call(env)
     end
   end
@@ -170,7 +170,7 @@ module ConditionalGet
   class Etag < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh etag: 'updated'
     end
   end
@@ -178,7 +178,7 @@ module ConditionalGet
   class LastModified < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh last_modified: Time.now
     end
   end
@@ -186,7 +186,7 @@ module ConditionalGet
   class EtagLastModified < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh etag: 'updated', last_modified: Time.now
     end
   end
@@ -212,7 +212,7 @@ module ConditionalGet
       end
     end
 
-    def call(env)
+    def handle(env)
       @app.call(env)
     end
   end
@@ -220,7 +220,7 @@ module ConditionalGet
   class LastModifiedNilValue < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh last_modified: nil
     end
   end
@@ -228,7 +228,7 @@ module ConditionalGet
   class EtagNilValue < Hanami::Action
     include Hanami::Action::Cache
 
-    def call(_, res)
+    def handle(_, res)
       res.fresh etag: nil
     end
   end

--- a/spec/integration/hanami/controller/inheritance_spec.rb
+++ b/spec/integration/hanami/controller/inheritance_spec.rb
@@ -13,5 +13,11 @@ RSpec.describe Hanami::Action do
 
       expect(last_response.body).to eq("[:base_action, :authenticated, :book, :found]")
     end
+
+    it "supports conventional use of 'super' inside #handle" do
+      delete "/books/23"
+
+      expect(last_response.body).to eq("[:base_action, :authenticated, :book, :found, :destroyed]")
+    end
   end
 end

--- a/spec/integration/hanami/controller/rack_errors_spec.rb
+++ b/spec/integration/hanami/controller/rack_errors_spec.rb
@@ -28,19 +28,19 @@ ConfigurationHandledExceptionSubclass = Class.new(ConfigurationHandledException)
 module Errors
   # Unhandled
   class WithoutMessage < Hanami::Action
-    def call(*)
+    def handle(*)
       raise UnhandledException
     end
   end
 
   class WithMessage < Hanami::Action
-    def call(*)
+    def handle(*)
       raise UnhandledExceptionWithMessage, "boom"
     end
   end
 
   class WithCustomMessage < Hanami::Action
-    def call(*)
+    def handle(*)
       raise UnhandledExceptionWithCustomMessage, "nope"
     end
   end
@@ -49,7 +49,7 @@ module Errors
   class ActionHandled < Hanami::Action
     handle_exception HandledException => 400
 
-    def call(*)
+    def handle(*)
       raise HandledException
     end
   end
@@ -57,19 +57,19 @@ module Errors
   class ActionHandledSubclass < Hanami::Action
     handle_exception HandledException => 400
 
-    def call(*)
+    def handle(*)
       raise HandledExceptionSubclass
     end
   end
 
   class ConfigurationHandled < Hanami::Action
-    def call(*)
+    def handle(*)
       raise ConfigurationHandledException
     end
   end
 
   class ConfigurationHandledSubclass < Hanami::Action
-    def call(*)
+    def handle(*)
       raise ConfigurationHandledExceptionSubclass
     end
   end

--- a/spec/isolation/without_hanami_validations_spec.rb
+++ b/spec/isolation/without_hanami_validations_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Without validations' do
 
   it "has params that don't respond to .valid?" do
     action = Class.new(Hanami::Action) do
-      def call(req, res)
+      def handle(req, res)
         res.body = [req.params.respond_to?(:valid?), req.params.valid?]
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe 'Without validations' do
 
   it "has params that don't respond to .errors" do
     action = Class.new(Hanami::Action) do
-      def call(req, res)
+      def handle(req, res)
         res.body = req.params.respond_to?(:errors)
       end
     end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -86,14 +86,14 @@ end
 
 module Test
   class Index < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res[:xyz] = req.params[:name]
     end
   end
 end
 
 class CallAction < Hanami::Action
-  def call(_req, res)
+  def handle(_req, res)
     res.status = 201
     res.body   = "Hi from TestAction!"
     res.headers.merge!("X-Custom" => "OK")
@@ -101,7 +101,7 @@ class CallAction < Hanami::Action
 end
 
 class UncheckedErrorCallAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     raise
   end
 end
@@ -109,7 +109,7 @@ end
 class ErrorCallAction < Hanami::Action
   handle_exception RuntimeError => 500
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise
   end
 end
@@ -118,7 +118,7 @@ class MyCustomError < StandardError; end
 class ErrorCallFromInheritedErrorClass < Hanami::Action
   handle_exception StandardError => :handler
 
-  def call(*)
+  def handle(*)
     raise MyCustomError
   end
 
@@ -134,7 +134,7 @@ class ErrorCallFromInheritedErrorClassStack < Hanami::Action
   handle_exception StandardError => :standard_handler
   handle_exception MyCustomError => :handler
 
-  def call(*)
+  def handle(*)
     raise MyCustomError
   end
 
@@ -154,7 +154,7 @@ end
 class ErrorCallWithSymbolMethodNameAsHandlerAction < Hanami::Action
   handle_exception StandardError => :handler
 
-  def call(*)
+  def handle(*)
     raise StandardError
   end
 
@@ -169,7 +169,7 @@ end
 class ErrorCallWithStringMethodNameAsHandlerAction < Hanami::Action
   handle_exception StandardError => "standard_error_handler"
 
-  def call(*)
+  def handle(*)
     raise StandardError
   end
 
@@ -184,7 +184,7 @@ end
 class ErrorCallWithUnsetStatusResponse < Hanami::Action
   handle_exception ArgumentError => "arg_error_handler"
 
-  def call(*)
+  def handle(*)
     raise ArgumentError
   end
 
@@ -197,7 +197,7 @@ end
 class ErrorCallWithSpecifiedStatusCodeAction < Hanami::Action
   handle_exception StandardError => 422
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise StandardError
   end
 end
@@ -207,7 +207,7 @@ class BeforeMethodAction < Hanami::Action
   append_before :add_first_name_to_logger, :add_last_name_to_logger
   prepend_before :add_title_to_logger
 
-  def call(req, res)
+  def handle(req, res)
   end
 
   private
@@ -285,7 +285,7 @@ class BeforeBlockAction < Hanami::Action
   before { |_, res|   res[:article].reverse! }
   before { |req, res| res[:arguments] = [req.class.name, res.class.name] }
 
-  def call(req, res)
+  def handle(req, res)
   end
 end
 
@@ -298,7 +298,7 @@ class AfterMethodAction < Hanami::Action
   append_after :add_first_name_to_logger, :add_last_name_to_logger
   prepend_after :add_title_to_logger
 
-  def call(*)
+  def handle(*)
   end
 
   private
@@ -336,25 +336,25 @@ class AfterBlockAction < Hanami::Action
   after { |_, res| res[:egg].reverse! }
   after { |req, res| res[:arguments] = [req.class.name, res.class.name] }
 
-  def call(*)
+  def handle(*)
   end
 end
 
 class YieldAfterBlockAction < AfterBlockAction
   after { |req, res| res[:meaning_of_life_params] = req.params }
 
-  def call(*)
+  def handle(*)
   end
 end
 
 class MissingSessionAction < Hanami::Action
-  def call(*)
+  def handle(*)
     session
   end
 end
 
 class MissingFlashAction < Hanami::Action
-  def call(*)
+  def handle(*)
     flash
   end
 end
@@ -362,32 +362,32 @@ end
 class SessionAction < Hanami::Action
   include Hanami::Action::Session
 
-  def call(req, res)
+  def handle(req, res)
   end
 end
 
 class FlashAction < Hanami::Action
   include Hanami::Action::Session
 
-  def call(*, res)
+  def handle(*, res)
     res.flash[:error] = "ouch"
   end
 end
 
 class RedirectAction < Hanami::Action
-  def call(*, res)
+  def handle(*, res)
     res.redirect_to "/destination"
   end
 end
 
 class StatusRedirectAction < Hanami::Action
-  def call(*, res)
+  def handle(*, res)
     res.redirect_to "/destination", status: 301
   end
 end
 
 class SafeStringRedirectAction < Hanami::Action
-  def call(*, res)
+  def handle(*, res)
     location = Hanami::Utils::Escape::SafeString.new("/destination")
     res.redirect_to location
   end
@@ -396,7 +396,7 @@ end
 class GetCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body = res.cookies[:foo]
   end
 end
@@ -404,7 +404,7 @@ end
 class ChangeCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body = res.cookies[:foo]
     res.cookies[:foo] = "baz"
   end
@@ -413,7 +413,7 @@ end
 class GetDefaultCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body          = ""
     res.cookies[:bar] = "foo"
   end
@@ -422,7 +422,7 @@ end
 class GetOverwrittenCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body          = ""
     res.cookies[:bar] = { value: "foo", domain: "hanamirb.com", path: "/action", secure: false, httponly: false }
   end
@@ -431,7 +431,7 @@ end
 class GetAutomaticallyExpiresCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.cookies[:bar] = { value: "foo", max_age: 120 }
   end
 end
@@ -439,7 +439,7 @@ end
 class SetCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.body          = "yo"
     res.cookies[:foo] = "yum!"
   end
@@ -452,7 +452,7 @@ class SetCookiesWithOptionsAction < Hanami::Action
     @expires = expires
   end
 
-  def call(*, res)
+  def handle(*, res)
     res.cookies[:kukki] = { value: "yum!", domain: "hanamirb.org", path: "/controller", expires: @expires, secure: true, httponly: true }
   end
 end
@@ -460,7 +460,7 @@ end
 class RemoveCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     res.cookies[:rm] = nil
   end
 end
@@ -468,7 +468,7 @@ end
 class IterateCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def call(*, res)
+  def handle(*, res)
     result = []
     res.cookies.each do |key, value|
       result << "'#{key}' has value '#{value}'"
@@ -479,13 +479,13 @@ class IterateCookiesAction < Hanami::Action
 end
 
 class ThrowCodeAction < Hanami::Action
-  def call(req, *)
+  def handle(req, *)
     halt req.params[:status].to_i, req.params[:message]
   end
 end
 
 class CatchAndThrowSymbolAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     catch :done do
       throw :done, 1
       raise "This code shouldn't be reachable"
@@ -497,7 +497,7 @@ class ThrowBeforeMethodAction < Hanami::Action
   before :authorize!
   before :set_body
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 
@@ -516,7 +516,7 @@ class ThrowBeforeBlockAction < Hanami::Action
   before { halt 401 }
   before { res.body = "Hi!" }
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 end
@@ -525,7 +525,7 @@ class ThrowAfterMethodAction < Hanami::Action
   after :raise_timeout!
   after :set_body
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 
@@ -544,7 +544,7 @@ class ThrowAfterBlockAction < Hanami::Action
   after { halt 408 }
   after { res.body = "Later!" }
 
-  def call(_req, res)
+  def handle(_req, res)
     res.body = "Hello!"
   end
 end
@@ -552,7 +552,7 @@ end
 class HandledExceptionAction < Hanami::Action
   handle_exception RecordNotFound => 404
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise RecordNotFound.new
   end
 end
@@ -561,19 +561,19 @@ class DomainLogicException < StandardError
 end
 
 class GlobalHandledExceptionAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     raise DomainLogicException.new
   end
 end
 
 class UnhandledExceptionAction < Hanami::Action
-  def call(_req, _res)
+  def handle(_req, _res)
     raise RecordNotFound.new
   end
 end
 
 class ParamsAction < Hanami::Action
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -590,7 +590,7 @@ class WhitelistedParamsAction < Hanami::Action
 
   params Params
 
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -600,7 +600,7 @@ class WhitelistedDslAction < Hanami::Action
     required(:username).filled
   end
 
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -611,7 +611,7 @@ class WhitelistedUploadDslAction < Hanami::Action
     required(:upload).filled
   end
 
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -621,7 +621,7 @@ class ParamsValidationAction < Hanami::Action
     required(:email).filled(:str?)
   end
 
-  def call(req, *)
+  def handle(req, *)
     halt 400 unless req.params.valid?
   end
 end
@@ -660,7 +660,7 @@ class NestedParams < Hanami::Action::Params
 end
 
 class Root < Hanami::Action
-  def call(req, res)
+  def handle(req, res)
     res.body = req.params.to_h.inspect
     res.headers.merge!("X-Test" => "test")
   end
@@ -668,14 +668,14 @@ end
 
 module About
   class Team < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
       res.headers.merge!("X-Test" => "test")
     end
   end
 
   class Contacts < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -683,37 +683,37 @@ end
 
 module Identity
   class Show < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class New < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Create < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Edit < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Update < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Destroy < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -721,43 +721,43 @@ end
 
 module Flowers
   class Index < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Show < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class New < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Create < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Edit < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Update < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Destroy < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -779,7 +779,7 @@ module Painters
       end
     end
 
-    def call(req, res)
+    def handle(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -790,7 +790,7 @@ module Dashboard
     include Hanami::Action::Session
     before :authenticate!
 
-    def call(*, res)
+    def handle(*, res)
       res.body = "User ID from session: #{res.session[:user_id]}"
     end
 
@@ -810,7 +810,7 @@ module Sessions
   class Create < Hanami::Action
     include Hanami::Action::Session
 
-    def call(*, res)
+    def handle(*, res)
       res.session[:user_id] = 23
       res.redirect_to "/"
     end
@@ -819,7 +819,7 @@ module Sessions
   class Destroy < Hanami::Action
     include Hanami::Action::Session
 
-    def call(*, res)
+    def handle(*, res)
       res.session[:user_id] = nil
     end
   end
@@ -828,7 +828,7 @@ end
 class StandaloneSession < Hanami::Action
   include Hanami::Action::Session
 
-  def call(*, res)
+  def handle(*, res)
     res.session[:age] = Time.now.year - 1982
   end
 end
@@ -837,7 +837,7 @@ module Glued
   class SendFile < Hanami::Action
     include Hanami::Action::Glue
 
-    def call(_req, _res)
+    def handle(_req, _res)
       send_file "test.txt"
     end
   end
@@ -853,7 +853,7 @@ module App
   class StandaloneAction < Hanami::Action
     handle_exception App::CustomError => 400
 
-    def call(_req, _res)
+    def handle(_req, _res)
       raise App::CustomError
     end
   end
@@ -867,7 +867,7 @@ module App2
     class Index < Hanami::Action
       handle_exception App2::CustomError => 400
 
-      def call(_req, _res)
+      def handle(_req, _res)
         raise App2::CustomError
       end
     end
@@ -898,7 +898,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def call(_req, res)
+        def handle(_req, res)
           res.body = "Muzic!"
           res.headers["X-Frame-Options"] = "ALLOW FROM https://example.org"
         end
@@ -909,7 +909,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def call(_req, _res)
+        def handle(_req, _res)
           raise ArgumentError
         end
       end
@@ -921,7 +921,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def call(_req, res)
+        def handle(_req, res)
           res.body = current_user
         end
       end
@@ -933,7 +933,7 @@ module MusicPlayer
 
         handle_exception ArtistNotFound => 404
 
-        def call(_req, _res)
+        def handle(_req, _res)
           raise ArtistNotFound
         end
       end
@@ -945,7 +945,7 @@ module MusicPlayer
     include Hanami::Action::Session
     include MusicPlayer::Controllers::Authentication
 
-    def call(_req, _res)
+    def handle(_req, _res)
       raise ArgumentError
     end
   end
@@ -966,7 +966,7 @@ class VisibilityAction < Hanami::Action
   include Hanami::Action::Cookies
   include Hanami::Action::Session
 
-  def call(*, res)
+  def handle(*, res)
     res.body   = "x"
     res.status = 201
     res.format = :json
@@ -979,7 +979,7 @@ end
 module SendFileTest
   module Files
     class Show < Hanami::Action
-      def call(req, res)
+      def handle(req, res)
         id = req.params[:id]
 
         # This if statement is only for testing purpose
@@ -1026,44 +1026,44 @@ module SendFileTest
     end
 
     class UnsafeLocal < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file "Gemfile"
       end
     end
 
     class UnsafePublic < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file "spec/support/fixtures/test.txt"
       end
     end
 
     class UnsafeAbsolute < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file Pathname.new("Gemfile").realpath
       end
     end
 
     class UnsafeMissingLocal < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.unsafe_send_file "missing"
       end
     end
 
     class UnsafeMissingAbsolute < Hanami::Action
-      def call(_req, res)
+      def handle(_req, res)
         res.unsafe_send_file Pathname.new(".").join("missing")
       end
     end
 
     class Flow < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.send_file Pathname.new("test.txt")
         res.redirect_to "/"
       end
     end
 
     class Glob < Hanami::Action
-      def call(*)
+      def handle(*)
         halt 202
       end
     end
@@ -1071,7 +1071,7 @@ module SendFileTest
     class BeforeCallback < Hanami::Action
       before :before_callback
 
-      def call(*, res)
+      def handle(*, res)
         res.send_file Pathname.new("test.txt")
       end
 
@@ -1085,7 +1085,7 @@ module SendFileTest
     class AfterCallback < Hanami::Action
       after :after_callback
 
-      def call(*, res)
+      def handle(*, res)
         res.send_file Pathname.new("test.txt")
       end
 
@@ -1134,7 +1134,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def call(_req, res)
+      def handle(_req, res)
         res.body = "index"
       end
     end
@@ -1144,7 +1144,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def call(req, res)
+      def handle(req, res)
         content = "code"
 
         res.headers.merge!(
@@ -1167,7 +1167,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def call(_req, res)
+      def handle(_req, res)
         res.headers.merge!(
           "Last-Modified" => "Fri, 27 Nov 2015 13:32:36 GMT",
           "X-Rate-Limit"  => "4000",
@@ -1219,7 +1219,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res[:greeting] = "Hello"
         end
       end
@@ -1229,7 +1229,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res.body = "foo"
         end
       end
@@ -1241,7 +1241,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*)
+        def handle(*)
         end
       end
 
@@ -1254,7 +1254,7 @@ module FullStack
           required(:title).filled(:str?)
         end
 
-        def call(req, res)
+        def handle(req, res)
           req.params.valid?
 
           res.redirect_to "/books"
@@ -1277,7 +1277,7 @@ module FullStack
           end
         end
 
-        def call(req, res)
+        def handle(req, res)
           valid = req.params.valid?
 
           res.status = 201
@@ -1296,7 +1296,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*)
+        def handle(*)
         end
       end
 
@@ -1305,7 +1305,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res.flash[:message] = "Saved!"
           res.redirect_to "/settings"
         end
@@ -1318,7 +1318,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(*, res)
+        def handle(*, res)
           res.redirect_to "/poll/1"
         end
       end
@@ -1328,7 +1328,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(req, res)
+        def handle(req, res)
           if req.env["REQUEST_METHOD"] == "GET"
             res.flash[:notice] = "Start the poll"
           else
@@ -1343,7 +1343,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def call(req, res)
+        def handle(req, res)
           if req.env["REQUEST_METHOD"] == "POST"
             res.flash[:notice] = "Poll completed"
             res.redirect_to "/"
@@ -1361,7 +1361,7 @@ module FullStack
         before :redirect_to_root
         after :set_body
 
-        def call(*, res)
+        def handle(*, res)
           res.body = "call method shouldn't be called"
         end
 
@@ -1418,7 +1418,7 @@ module FullStack
 end
 
 class MethodInspectionAction < Hanami::Action
-  def call(req, res)
+  def handle(req, res)
     res.body = req.request_method
   end
 end
@@ -1427,7 +1427,7 @@ class RackExceptionAction < Hanami::Action
   class TestException < ::StandardError
   end
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise TestException.new
   end
 end
@@ -1438,7 +1438,7 @@ class HandledRackExceptionAction < Hanami::Action
 
   handle_exception TestException => 500
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise TestException.new
   end
 end
@@ -1452,7 +1452,7 @@ class HandledRackExceptionSubclassAction < Hanami::Action
 
   handle_exception TestException => 500
 
-  def call(_req, _res)
+  def handle(_req, _res)
     raise TestSubclassException.new
   end
 end
@@ -1465,7 +1465,7 @@ module SessionWithCookies
         include Hanami::Action::Session
         include Hanami::Action::Cookies
 
-        def call(req, res)
+        def handle(req, res)
         end
       end
     end
@@ -1502,7 +1502,7 @@ module SessionsWithoutCookies
         include Hanami::Action::Session
         include Inspector
 
-        def call(*)
+        def handle(*)
         end
       end
     end
@@ -1531,20 +1531,20 @@ end
 
 module Mimes
   class Default < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.body, = *format(res.content_type)
     end
   end
 
   class Custom < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.format = format(:xml)
       res.body   = res.format
     end
   end
 
   class Latin < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.charset = "latin1"
       res.format  = format(:html)
       res.body    = res.format
@@ -1552,7 +1552,7 @@ module Mimes
   end
 
   class Accept < Hanami::Action
-    def call(req, res)
+    def handle(req, res)
       res.headers["X-AcceptDefault"] = req.accept?("application/octet-stream").to_s
       res.headers["X-AcceptHtml"]    = req.accept?("text/html").to_s
       res.headers["X-AcceptXml"]     = req.accept?("application/xml").to_s
@@ -1565,7 +1565,7 @@ module Mimes
   class CustomFromAccept < Hanami::Action
     accept :json, :custom
 
-    def call(*, res)
+    def handle(*, res)
       res.body, = *format(res.content_type)
     end
   end
@@ -1573,19 +1573,19 @@ module Mimes
   class Restricted < Hanami::Action
     accept :html, :json, :custom
 
-    def call(_req, res)
+    def handle(_req, res)
       res.body, = *format(res.content_type)
     end
   end
 
   class NoContent < Hanami::Action
-    def call(_req, res)
+    def handle(_req, res)
       res.status = 204
     end
   end
 
   class OverrideDefaultResponse < Hanami::Action
-    def call(*, res)
+    def handle(*, res)
       res.format = format(:xml)
     end
 
@@ -1624,7 +1624,7 @@ module MimesWithDefault
   class Default < Hanami::Action
     accept :json
 
-    def call(*, res)
+    def handle(*, res)
       res.body, = *format(res.content_type)
     end
   end
@@ -1725,7 +1725,7 @@ module Flash
       class Index < Hanami::Action
         include Hanami::Action::Session
 
-        def call(req, res)
+        def handle(req, res)
           res.flash[:hello] = "world"
 
           if req.env["REQUEST_METHOD"] == "GET"
@@ -1739,7 +1739,7 @@ module Flash
       class Books < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.body = "flash_empty: #{res.flash.empty?} flash: #{res.flash.inspect}"
         end
       end
@@ -1747,7 +1747,7 @@ module Flash
       class Print < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.body = res.flash[:hello]
         end
       end
@@ -1755,7 +1755,7 @@ module Flash
       class EachRedirect < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.flash[:hello] = "world"
           res.redirect_to "/each"
         end
@@ -1764,7 +1764,7 @@ module Flash
       class Each < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           each_result = []
           res.flash.each { |type, message| each_result << [type, message] }
           res.body = "flash_each: #{each_result}"
@@ -1774,7 +1774,7 @@ module Flash
       class MapRedirect < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.flash[:hello] = "world"
           res.redirect_to "/map"
         end
@@ -1783,7 +1783,7 @@ module Flash
       class Map < Hanami::Action
         include Hanami::Action::Session
 
-        def call(_, res)
+        def handle(_, res)
           res.body = "flash_map: #{res.flash.map { |type, message| [type, message] }}"
         end
       end
@@ -1855,13 +1855,14 @@ module Inheritance
       end
 
       class Show < RestfulAction
-        def call(*, res)
+        def handle(*, res)
           res[:found] = true
         end
       end
 
       class Destroy < Show
-        def call(*, res)
+        def handle(*, res)
+          super
           res[:destroyed] = true
         end
       end

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Hanami::Action do
   class FormatController
     class Lookup < Hanami::Action
-      def call(*)
+      def handle(*)
       end
     end
 
     class Custom < Hanami::Action
-      def call(req, res)
+      def handle(req, res)
         input = req.params[:format]
         input = input.to_sym unless input.nil?
 
@@ -15,7 +15,7 @@ RSpec.describe Hanami::Action do
     end
 
     class Configuration < Hanami::Action
-      def call(*, res)
+      def handle(*, res)
         res.body = res.format
       end
     end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Hanami::Action do
   describe "#request" do
     it "gets a Rack-like request object" do
       action_class = Class.new(Hanami::Action) do
-        def call(req, res)
+        def handle(req, res)
           res[:request] = req
         end
       end


### PR DESCRIPTION
Following up from #274, and after much discussion with @jodosha (who is kind, gracious, and patient), this PR is a tidier, up-to-date removal of the `#call` method prepending. 

Prepending behaviour over `#call` proved to be problematic in a couple of key ways:

1. Since the prepended behavior had to be added in a class `.inherited` hook, any sort of deep class heirarchy would result in the behavior being prepended multiple times.
2. It added a different params signature to the method (`#call(env)` instead of `#call(req, res)`), which made it impossible to call `super` from within a `Hanami::Action` subclass' own `#call` method.
3. It rendered the return value of the action subclass' own `#call` method meaningless.

Together, these violated the principle of least surprise around the class inheritance and method dispatch behavior that Rubyists are accustomed to.

This change makes `#call` a regular instance method defined directly on `Hanami::Action`. To invoke custom behavior within subclasses, it follows the Template Method pattern, calling `#handle(req, res)` from within `#call`. Action subclasses should now implement this `#handle` method instead of `#call`.

Apart from fixing all the issues around inheritance standard Ruby object behaviour, this hopefully also improves the understandability of the library – since the key public interface is `#call(env)`, but with app developers implementing `#handle(req, res)`, it should be clearer that `#call` manages a broader lifecycle of events, of which `#handle` is just one step.

After these changes, Hanami::Action objects are still very much functional, callable objects, just with the _framework_ providing the `#call` method instead of the application developers.