### PR TITLE
Fix broken 404 links to guides.hanamirb.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Complete, fast and testable actions for Rack and [Hanami](http://hanamirb.org)
 ## Contact
 
 * Home page: http://hanamirb.org
+* Community: http://hanamirb.org/community
+* Guides: https://guides.hanamirb.org
 * Mailing List: http://hanamirb.org/mailing-list
 * API Doc: http://rdoc.info/gems/hanami-controller
 * Bugs/Issues: https://github.com/hanami/controller/issues
 * Chat: http://chat.hanamirb.org
-* Chat: https://gitter.im/hanami/chat
 
 ## Rubies
 

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -126,7 +126,7 @@ module Hanami
       #
       # @since 0.7.0
       #
-      # @see http://hanamirb.org/guides/validations/overview/
+      # @see https://guides.hanamirb.org/validations/overview
       #
       # @example
       #   class Signup

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -50,7 +50,7 @@ module Hanami
         # @since 0.3.0
         #
         # @see Hanami::Action::Params
-        # @see http://hanamirb.org/guides/validations/overview/
+        # @see https://guides.hanamirb.org//validations/overview
         #
         # @example Anonymous Block
         #   require 'hanami/controller'


### PR DESCRIPTION
Add guides subdomain to all broken links to fix https://github.com/hanami/hanami/issues/980