### PR TITLE
Do not error when If-Modified-Since is set but no validation exists for it

### DIFF
--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -67,7 +67,10 @@ module Hanami
         # @since 0.3.0
         # @api private
         def fresh?
-          !Hanami::Utils::Blank.blank?(modified_since) && Time.httpdate(modified_since).to_i >= @value.to_time.to_i
+          return false if Hanami::Utils::Blank.blank?(modified_since)
+          return false if Hanami::Utils::Blank.blank?(@value)
+
+          Time.httpdate(modified_since).to_i >= @value.to_time.to_i
         end
 
         # @since 0.3.0

--- a/spec/integration/hanami/controller/cache_spec.rb
+++ b/spec/integration/hanami/controller/cache_spec.rb
@@ -310,6 +310,18 @@ RSpec.describe "HTTP Cache" do
         end
       end
 
+      context "when If-Modified-Since is set" do
+        it "completes request" do
+          response = app.get("/etag", "HTTP_IF_MODIFIED_SINCE" => Time.now.httpdate)
+          expect(response.status).to be(200)
+        end
+
+        it "returns etag header" do
+          response = app.get("/etag", "HTTP_IF_MODIFIED_SINCE" => Time.now.httpdate)
+          expect(response.headers.fetch("ETag")).to eq("updated")
+        end
+      end
+
       context "when etag has nil value" do
         it "completes request" do
           response = app.get("/etag-nil-value", "HTTP_IF_NONE_MATCH" => "outdated")


### PR DESCRIPTION
We encountered a bug where an upstream proxy was setting the `Last-Modified` header automatically, which caused hanami controller to error with a 500.

It went something like this:

1. We want to cache on an etag, so we had the directive `fresh etag: 'some-value'`
2. Upstream proxy automatically adds the `Last-Modified` header
3. Browser sends `If-Modified-Since`
4. Since there is no validation value for `last_modified` validation was specified in the `fresh` call, `@value` is nil and causes hanami controller to error out

This PR fixes that issue by ensuring that `@value` is not blank.