### PR TITLE
Pass router.params with other request params to action's test

### DIFF
--- a/spec/integration/hanami/controller/routing_spec.rb
+++ b/spec/integration/hanami/controller/routing_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'Hanami::Router integration' do
       response = app.request("PATCH", "/flowers/23", params: { flower: { name: "Sakura!" } })
 
       expect(response.status).to be(200)
-      expect(response.body).to   eq(%({:flower=>{:name=>"Sakura!"}, :id=>"23"}))
+      expect(response.body).to   eq(%({:id=>"23", :flower=>{:name=>"Sakura!"}}))
     end
 
     it "calls DELETE destroy" do

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe Hanami::Action::Params do
       context "with Hanami::Router" do
         it "returns all the params as they are" do
           # Hanami::Router params are always symbolized
-          _, _, body = action.call('router.params' => { id: '23' })
-          expect(body).to eq([%({:id=>"23"})])
+          _, _, body = action.call('router.params' => { id: '23' }, a: '1')
+          expect(body).to eq([%({:id=>"23", :a=>"1"})])
         end
       end
     end


### PR DESCRIPTION
Hello.

This PR fix this issue https://github.com/hanami/validations/issues/138

Before this fix only `router.params` or other request params appears in `params` variable but not simultaneously