### PR TITLE
Hanami application support

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -4,6 +4,7 @@ begin
 rescue LoadError
 end
 
+require 'hanami/controller/configuration'
 require 'hanami/action/request'
 require 'hanami/action/response'
 require 'hanami/action/base_params'
@@ -425,7 +426,7 @@ module Hanami
     #
     # @since 0.1.0
     # @api private
-    def self.new(configuration:, **args)
+    def self.new(configuration: Hanami::Controller::Configuration.new, **args)
       allocate.tap do |obj|
         obj.instance_variable_set(:@name, Name[name])
         obj.instance_variable_set(:@configuration, configuration)

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -422,10 +422,18 @@ module Hanami
       end
     end
 
-    # Callbacks API instance methods
+    # Returns a new action
     #
-    # @since 0.1.0
-    # @api private
+    # @overload new(**args)
+    #   @param args [Hash] action dependencies
+    #
+    # @overload new(configuration:, **args)
+    #   @param configuration [Hanami::Controller::Configuration] action configuration
+    #   @param args [Hash] action dependencies
+    #
+    # @return [Hanami::Action] Action object
+    #
+    # @since 2.0.0
     def self.new(configuration: Hanami::Controller::Configuration.new, **args)
       allocate.tap do |obj|
         obj.instance_variable_set(:@name, Name[name])
@@ -471,7 +479,20 @@ module Hanami
       finish(request, response, halted)
     end
 
-    def initialize(**)
+    def initialize(**deps)
+      @_deps = deps
+    end
+
+    # Returns a new copy of the action with new arguments merged with those
+    # previously passed to `.new`
+    #
+    # @param new_args [Hash] new arguments
+    #
+    # @return [Hanami::Action] New action object
+    #
+    # @since 2.0.0
+    def with(**new_args)
+      self.class.new(@_deps.merge(new_args))
     end
 
     protected

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -10,6 +10,29 @@ RSpec.describe Hanami::Action do
     end
   end
 
+  describe "#with" do
+    let(:action_class) {
+      Class.new(Hanami::Action) do
+        attr_reader :dep_one, :dep_two
+
+        def initialize(dep_one:, dep_two:, **deps)
+          @dep_one = dep_one
+          @dep_two = dep_two
+          super
+        end
+      end
+    }
+
+    it "returns a copy of the action with updated options" do
+      action = action_class.new(dep_one: "one", dep_two: "two")
+
+      new_action = action.with(dep_two: "due")
+      expect(new_action).to be_an(action.class)
+      expect(new_action.dep_one).to eq "one"
+      expect(new_action.dep_two).to eq "due"
+    end
+  end
+
   describe "#call" do
     it "calls an action" do
       response = CallAction.new(configuration: configuration).call({})


### PR DESCRIPTION
Changes required for https://github.com/hanami/hanami/pull/1019, i.e.

- Auto-registering direct `Hanami::Action` subclasses by dry-system (where no configuration is otherwise provided)
- Re-instantiating action objects with new configuration provided within various routing scopes