### PR TITLE
Fix multi-threading error on Rails app

### DIFF
--- a/lib/hanami/action/callable.rb
+++ b/lib/hanami/action/callable.rb
@@ -71,17 +71,17 @@ module Hanami
           @params ||= {}
           @params[Thread.current.object_id] = self.class.params_class.new(@_env)
           super params
-          @params.delete(Thread.current.object_id)
         end
 
         finish
       end
 
-      private
-
       def params
+        @params ||= {}
         @params[Thread.current.object_id]
       end
+
+      private
 
       # Prepare the Rack response before the control is returned to the
       # webserver.

--- a/lib/hanami/action/callable.rb
+++ b/lib/hanami/action/callable.rb
@@ -67,14 +67,21 @@ module Hanami
         _rescue do
           @_env    = env
           @headers = ::Rack::Utils::HeaderHash.new(configuration.default_headers)
-          @params  = self.class.params_class.new(@_env)
-          super @params
+
+          @params ||= {}
+          @params[Thread.current.object_id] = self.class.params_class.new(@_env)
+          super params
+          @params.delete(Thread.current.object_id)
         end
 
         finish
       end
 
       private
+
+      def params
+        @params[Thread.current.object_id]
+      end
 
       # Prepare the Rack response before the control is returned to the
       # webserver.


### PR DESCRIPTION
Using Hanami Controller withing a Rails app cause a memoize of Action.

This memoized action can be used on multiples thread that break params
integrity.