### PR TITLE
Rack 2.1

### DIFF
--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -83,6 +83,12 @@ module Hanami
       # The key that returns router parsed body from the Rack env
       ROUTER_PARSED_BODY = 'router.parsed_body'.freeze
 
+      # This is the root directory for `#unsafe_send_file`
+      #
+      # @since x.x.x
+      # @api private
+      FILE_SYSTEM_ROOT = Pathname.new("/").freeze
+
       # Override Ruby's hook for modules.
       # It includes basic Hanami::Action modules to the given class.
       #
@@ -353,7 +359,11 @@ module Hanami
       #     end
       #   end
       def unsafe_send_file(path)
-        directory = self.class.configuration.root_directory if Pathname.new(path).relative?
+        directory = if Pathname.new(path).relative?
+                      self.class.configuration.root_directory
+                    else
+                      FILE_SYSTEM_ROOT
+                    end
 
         _send_file(
           File.new(path, directory).call(@_env)

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -21,7 +21,7 @@ module Mimes
     include Hanami::Action
 
     def call(_params)
-      self.body = format
+      self.body = format.to_s
     end
   end
 
@@ -32,7 +32,7 @@ module Mimes
     configuration.default_charset 'ISO-8859-1'
 
     def call(_params)
-      self.body = format
+      self.body = format.to_s
     end
   end
 
@@ -41,7 +41,7 @@ module Mimes
 
     def call(_params)
       self.format = :xml
-      self.body   = format
+      self.body   = format.to_s
     end
   end
 
@@ -51,7 +51,7 @@ module Mimes
     def call(_params)
       self.charset = 'latin1'
       self.format  = :html
-      self.body    = format
+      self.body    = format.to_s
     end
   end
 
@@ -64,7 +64,7 @@ module Mimes
       headers['X-AcceptXml']     = accept?('application/xml').to_s
       headers['X-AcceptJson']    = accept?('text/json').to_s
 
-      self.body = format
+      self.body = format.to_s
     end
   end
 
@@ -75,7 +75,7 @@ module Mimes
     accept :json, :custom
 
     def call(_params)
-      self.body = format
+      self.body = format.to_s
     end
   end
 
@@ -105,7 +105,7 @@ module Mimes
     configuration.default_response_format :json
 
     def call(_params)
-      self.body = configuration.default_request_format
+      self.body = configuration.default_request_format.to_s
     end
   end
 
@@ -135,7 +135,7 @@ module Mimes
 
     def call(_params)
       self.format = :json
-      self.body   = format
+      self.body   = format.to_s
     end
   end
 
@@ -146,7 +146,7 @@ module Mimes
 
     def call(_params)
       self.format = :json
-      self.body   = format
+      self.body   = format.to_s
     end
   end
 end

--- a/spec/unit/hanami/action/cookies_spec.rb
+++ b/spec/unit/hanami/action/cookies_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe Hanami::Action do
       action   = SetCookiesWithOptionsAction.new(expires: tomorrow)
       _, headers, = action.call({})
 
-      expect(headers).to eq("Content-Type" => "application/octet-stream; charset=utf-8", "Set-Cookie" => "kukki=yum%21; domain=hanamirb.org; path=/controller; expires=#{tomorrow.gmtime.rfc2822}; secure; HttpOnly")
+      expect(headers).to eq("Content-Type" => "application/octet-stream; charset=utf-8", "Set-Cookie" => "kukki=yum%21; domain=hanamirb.org; path=/controller; expires=#{tomorrow.httpdate}; secure; HttpOnly")
     end
 
     it "removes cookies" do
       action = RemoveCookiesAction.new
       _, headers, = action.call("HTTP_COOKIE" => "foo=bar;rm=me")
 
-      expect(headers).to eq("Content-Type" => "application/octet-stream; charset=utf-8", "Set-Cookie" => "rm=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000")
+      expect(headers).to eq("Content-Type" => "application/octet-stream; charset=utf-8", "Set-Cookie" => "rm=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT")
     end
 
     it "iterates cookies" do
@@ -75,7 +75,7 @@ RSpec.describe Hanami::Action do
         _, headers, = action.call({})
         max_age = 120
         expect(headers["Set-Cookie"]).to include("max-age=#{max_age}")
-        expect(headers["Set-Cookie"]).to include("expires=#{(Time.now + max_age).gmtime.rfc2822}")
+        expect(headers["Set-Cookie"]).to include("expires=#{(Time.now + max_age).httpdate}")
       end
     end
   end


### PR DESCRIPTION
## Technical details

  * For `Hanami::Action#unsafe_file_send` the root was set to blank string to `Hanami::Action::Rack::File`, because we want to allow any file in the file system to be reachable. Starting from 2.1, `Rack::File` now tries to expand the given root. `::File.expand_path("")` returns the current directory, usually the root of a project. But because we want to reach files outside of the project, we must set an explicit highest file system node in the hierarchy, so we pick UNIX root. Please note that this doesn't loose the security of this method, which is already unsafe, hence the name.

  * Rack body chunks, are expected to be `String` and not anymore objects that can be serialized to string. I had to change the specs where there was a `Symbol` passed to the body (e.g. `self.body = format`, where `format` is a symbol).

  * Cookies expiration is now set with `Time#httpdate`.