### PR TITLE
Replace Fixnum with in Integer in methods docs

### DIFF
--- a/lib/hanami/action/rack.rb
+++ b/lib/hanami/action/rack.rb
@@ -265,7 +265,7 @@ module Hanami
 
       # Sets the HTTP status code for the response
       #
-      # @param status [Fixnum] an HTTP status code
+      # @param status [Integer] an HTTP status code
       # @return [void]
       #
       # @since 0.1.0

--- a/lib/hanami/action/redirect.rb
+++ b/lib/hanami/action/redirect.rb
@@ -15,7 +15,7 @@ module Hanami
       # Redirect to the given URL and halt the request
       #
       # @param url [String] the destination URL
-      # @param status [Fixnum] the http code
+      # @param status [Integer] the http code
       #
       # @since 0.1.0
       #

--- a/lib/hanami/action/throwable.rb
+++ b/lib/hanami/action/throwable.rb
@@ -71,7 +71,7 @@ module Hanami
       # Otherwise, it sets the response body with the default message associated
       # to the code (eg 404 will set `"Not Found"`).
       #
-      # @param code [Fixnum] a valid HTTP status code
+      # @param code [Integer] a valid HTTP status code
       # @param message [String] the response body
       #
       # @since 0.2.0
@@ -110,7 +110,7 @@ module Hanami
 
       # Sets the given code and message for the response
       #
-      # @param code [Fixnum] a valid HTTP status code
+      # @param code [Integer] a valid HTTP status code
       # @param message [String] the response body
       #
       # @since 0.1.0

--- a/lib/hanami/http/status.rb
+++ b/lib/hanami/http/status.rb
@@ -31,7 +31,7 @@ module Hanami
 
       # Return a status for the given code
       #
-      # @param code [Fixnum] a valid HTTP code
+      # @param code [Integer] a valid HTTP code
       #
       # @return [Array] a pair of code and message for an HTTP status
       #
@@ -48,7 +48,7 @@ module Hanami
 
       # Return a message for the given status code
       #
-      # @param code [Fixnum] a valid HTTP code
+      # @param code [Integer] a valid HTTP code
       #
       # @return [String] a message for the given status code
       #


### PR DESCRIPTION
Because Fixnum and Bignum where unified into Integer since Ruby 2.4 and
now are deprecated, even [Ruby 2.4 is now EOL](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/).