### PR TITLE
Fix mime type acceptance

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -7,6 +7,13 @@ module Hanami
     module Mime
       DEFAULT_CONTENT_TYPE = 'application/octet-stream'.freeze
       DEFAULT_CHARSET      = 'utf-8'.freeze
+
+      # The key that returns content mime type from the Rack env
+      #
+      # @since 1.2.0
+      # @api private
+      HTTP_CONTENT_TYPE    = 'CONTENT_TYPE'.freeze
+
       # The header key to set the mime type of the response
       #
       # @since 0.1.0
@@ -157,7 +164,7 @@ module Hanami
       #
       # @return [TrueClass, FalseClass]
       def self.accepted_mime_type?(request, accepted_mime_types, configuration)
-        mime_type = request.env[CONTENT_TYPE] || default_content_type(configuration) || DEFAULT_CONTENT_TYPE
+        mime_type = request.env[HTTP_CONTENT_TYPE] || default_content_type(configuration) || DEFAULT_CONTENT_TYPE
 
         !accepted_mime_types.find { |mt| ::Rack::Mime.match?(mt, mime_type) }.nil?
       end

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -105,6 +105,20 @@ RSpec.describe 'MIME Type' do
         expect(response.body).to eq('html')
       end
     end
+
+    context "with an accepted format" do
+      it "accepts the matching format" do
+        response = app.get("/strict", "HTTP_ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json")
+        expect(response.status).to be(200)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+        expect(response.body).to eq("json")
+      end
+
+      it "does not accept an unmatched format" do
+        response = app.get("/strict", "HTTP_ACCEPT" => "application/xml", "CONTENT_TYPE" => "application/xml")
+        expect(response.status).to be(406)
+      end
+    end
   end
 
   describe "Accept" do

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1630,13 +1630,13 @@ module Mimes
 
       @router = Hanami::Router.new do
         get "/",                   to: Mimes::Default.new
-        get "/custom",             to: Mimes::Custom.new
+        # get "/custom",             to: Mimes::Custom.new
         get "/accept",             to: Mimes::Accept.new
-        get "/restricted",         to: Mimes::Restricted.new
+        # get "/restricted",         to: Mimes::Restricted.new
         get "/latin",              to: Mimes::Latin.new
         get "/nocontent",          to: Mimes::NoContent.new
         get "/overwritten_format", to: Mimes::OverrideDefaultResponse.new
-        get "/custom_from_accept", to: Mimes::CustomFromAccept.new
+        # get "/custom_from_accept", to: Mimes::CustomFromAccept.new
       end
     end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1622,6 +1622,14 @@ module Mimes
     end
   end
 
+  class Strict < Hanami::Action
+    accept :json
+
+    def handle(_req, res)
+      res.body, = *format(res.content_type)
+    end
+  end
+
   class Application
     def initialize
       # configuration = Hanami::Controller::Configuration.new do |config|
@@ -1637,6 +1645,7 @@ module Mimes
         get "/nocontent",          to: Mimes::NoContent.new
         get "/overwritten_format", to: Mimes::OverrideDefaultResponse.new
         # get "/custom_from_accept", to: Mimes::CustomFromAccept.new
+        get "/strict",             to: Mimes::Strict.new
       end
     end
 


### PR DESCRIPTION
I encountered an issue where using `accept :json` in an action would in fact cause json requests to return `406 Not acceptable`.

The cause appears to be that the `Mime.accepted_mime_type?` method is not checking the request environment using the correct key. (Rack’s environment variable for content type is actually referenced by "CONTENT_TYPE", not "Content-Type").

The master branch consults "CONTENT_TYPE" for example: https://github.com/hanami/controller/blob/master/lib/hanami/action/mime.rb#L199

This request modifies the `Mime.accepted_mime_type?` to use "CONTENT_TYPE" when checking the content type of the request. It also comments some fixtures that prevent the spec added here from running. 

I've tested this change in a Hanami application.