### PR TITLE
Include `Hanami::Action::Response#exposures` in view rendering context

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -102,7 +102,7 @@ module Hanami
         end
 
         def finish(req, res, halted)
-          res.render(view, **req.params, **res.exposures) if render?(res)
+          res.render(view, **req.params) if render?(res)
           super
         end
 

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -76,7 +76,7 @@ module Hanami
       end
 
       def render(view, **options)
-        self.body = view.(**view_options.(request, self), **options.merge(exposures)).to_str
+        self.body = view.(**view_options.(request, self), **exposures.merge(options)).to_str
       end
 
       def format=(args)

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -76,7 +76,7 @@ module Hanami
       end
 
       def render(view, **options)
-        self.body = view.(**view_options.(request, self), **options).to_str
+        self.body = view.(**view_options.(request, self), **options.merge(exposures)).to_str
       end
 
       def format=(args)

--- a/spec/integration/hanami/controller/application_action/view_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe "View rendering in application actions", :application_integration
 
               def handle(req, res)
                 res[:job] = "Singer"
-                res.render view, name: req.params[:name]
+                res[:age] = 0
+                res.render view, name: req.params[:name], age: 51
               end
             end
           end
@@ -70,7 +71,7 @@ RSpec.describe "View rendering in application actions", :application_integration
         module Main
           module Views
             class TestView < Main::View
-              expose :name, :job
+              expose :name, :job, :age
             end
           end
         end
@@ -87,6 +88,7 @@ RSpec.describe "View rendering in application actions", :application_integration
         - request.params.to_h.values.sort.each do |value|
           p = value
         p = job
+        p = age
       SLIM
 
       require "hanami/init"
@@ -95,7 +97,7 @@ RSpec.describe "View rendering in application actions", :application_integration
       response = action.(name: "Jennifer", last_name: "Lopez")
       rendered = response.body[0]
 
-      expect(rendered).to eq "<html><body><h1>Hello, Jennifer</h1><p>Jennifer</p><p>Lopez</p><p>Singer</p></body></html>"
+      expect(rendered).to eq "<html><body><h1>Hello, Jennifer</h1><p>Jennifer</p><p>Lopez</p><p>Singer</p><p>51</p></body></html>"
     end
   end
 end

--- a/spec/integration/hanami/controller/application_action/view_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "View rendering in application actions", :application_integration
               include Deps[view: "views.test_view"]
 
               def handle(req, res)
+                res[:job] = "Singer"
                 res.render view, name: req.params[:name]
               end
             end
@@ -69,7 +70,7 @@ RSpec.describe "View rendering in application actions", :application_integration
         module Main
           module Views
             class TestView < Main::View
-              expose :name
+              expose :name, :job
             end
           end
         end
@@ -85,6 +86,7 @@ RSpec.describe "View rendering in application actions", :application_integration
         h1 Hello, #{name}
         - request.params.to_h.values.sort.each do |value|
           p = value
+        p = job
       SLIM
 
       require "hanami/init"
@@ -93,7 +95,7 @@ RSpec.describe "View rendering in application actions", :application_integration
       response = action.(name: "Jennifer", last_name: "Lopez")
       rendered = response.body[0]
 
-      expect(rendered).to eq "<html><body><h1>Hello, Jennifer</h1><p>Jennifer</p><p>Lopez</p></body></html>"
+      expect(rendered).to eq "<html><body><h1>Hello, Jennifer</h1><p>Jennifer</p><p>Lopez</p><p>Singer</p></body></html>"
     end
   end
 end


### PR DESCRIPTION
## Syntax preview

```
class MyAction < Hanami::Action
  def handle(*, res)
    res[:users] = repo.all
    res[:foo] = "X"
    res.render(view, foo: "Y")
  end
end
```

The `:users` exposure is added to the view args for rendering.

In case of overlapping names between _inline options_ passed to `Hanami::Action::Response#render` and `Hanami::Action::Response#exposures`, _inline options_ will take the precedence.

In the example above the view will receive `"Y"` as value for `:foo`.