### PR TITLE
Automatically apply application-level configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :validations do
 end
 
 group :test do
-  gem 'hanami', github: 'hanami/hanami', branch: 'unstable'
+  gem 'hanami', github: 'hanami/hanami', branch: 'enhancement/unstable/action-settings'
   gem 'hanami-view', github: 'hanami/view', branch: 'master'
   gem 'slim'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :validations do
 end
 
 group :test do
-  gem 'hanami', github: 'hanami/hanami', branch: 'enhancement/unstable/action-settings'
+  gem 'hanami', github: 'hanami/hanami', branch: 'unstable'
   gem 'hanami-view', github: 'hanami/view', branch: 'master'
   gem 'slim'
 end

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -15,6 +15,7 @@ module Hanami
 
       def included(action_class)
         action_class.include InstanceMethods
+        configure_action action_class
       end
 
       def inspect
@@ -41,6 +42,15 @@ module Hanami
         elsif application.key?(identifier)
           application[identifier]
         end
+      end
+
+      def configure_action(action_class)
+        if application.config.cookies.enabled?
+          action_class.config.cookies = application.config.cookies.options
+        end
+
+        action_class.config.default_request_format = application.config.default_request_format
+        action_class.config.default_response_format = application.config.default_response_format
       end
 
       module InstanceMethods

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -45,12 +45,9 @@ module Hanami
       end
 
       def configure_action(action_class)
-        if application.config.cookies.enabled?
-          action_class.config.cookies = application.config.cookies.options
+        application.config.actions.values.each do |(key, value)|
+          action_class.config.public_send :"#{key}=", value
         end
-
-        action_class.config.default_request_format = application.config.default_request_format
-        action_class.config.default_response_format = application.config.default_response_format
       end
 
       module InstanceMethods

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -44,7 +44,7 @@ module Hanami
       end
 
       module InstanceMethods
-        define_method :view_context do
+        def view_context
           @view_context
         end
 

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -45,8 +45,9 @@ module Hanami
       end
 
       def configure_action(action_class)
-        application.config.actions.values.each do |(key, value)|
-          action_class.config.public_send :"#{key}=", value
+        action_class.config.settings.each do |setting|
+          application_value = application.config.actions.public_send(:"#{setting}")
+          action_class.config.public_send :"#{setting}=", application_value
         end
       end
 

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -13,8 +13,8 @@ module Hanami
         define_initialize
       end
 
-      def included(klass)
-        klass.include InstanceMethods
+      def included(action_class)
+        action_class.include InstanceMethods
       end
 
       def inspect

--- a/lib/hanami/action/configuration.rb
+++ b/lib/hanami/action/configuration.rb
@@ -23,6 +23,16 @@ module Hanami
         yield self if block_given?
       end
 
+      # Returns the list of available settings
+      #
+      # @return [Set]
+      #
+      # @since 2.0.0
+      # @api private
+      def settings
+        self.class.settings
+      end
+
       # @!method handled_exceptions=(exceptions)
       #
       #   Specifies how to handle exceptions with an HTTP status

--- a/spec/integration/hanami/controller/application_action/configuration_spec.rb
+++ b/spec/integration/hanami/controller/application_action/configuration_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/action"
+
+RSpec.describe "Application actions / Configuration", :application_integration do
+  describe "Inside Hanami app" do
+    before do
+      module TestApp
+        class Application < Hanami::Application
+          config.actions.default_response_format = :json
+        end
+      end
+
+      module Main
+      end
+
+      Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+      Hanami.init
+    end
+
+    let(:action_class) {
+      module Main
+        class Action < Hanami::Action
+        end
+      end
+
+      Main::Action
+    }
+
+    subject(:configuration) { action_class.config }
+
+    it "applies 'config.actions' configuration from the application" do
+      expect(configuration.default_response_format).to eq :json
+    end
+  end
+end

--- a/spec/integration/hanami/controller/application_action/view_integration_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_integration_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/action"
+
+RSpec.describe "Application actions / view integration", :application_integration do
+  describe "Outside Hanami app" do
+    subject(:action) { Class.new(Hanami::Action).new }
+
+    before do
+      allow(Hanami).to receive(:respond_to?).with(:application?) { nil }
+    end
+
+    it "does not provide view integration methods" do
+      expect(action).not_to respond_to(:view_context)
+    end
+  end
+
+  describe "Inside Hanami app" do
+    before do
+      module TestApp
+        class Application < Hanami::Application
+        end
+      end
+
+      module Main
+      end
+
+      Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+      Hanami.init
+    end
+
+    let(:action_module) { Main }
+
+    let(:action_class) {
+      eval <<~RUBY
+        module #{action_module}
+          class Action < Hanami::Action
+          end
+        end
+
+        #{action_module}::Action
+      RUBY
+    }
+
+    subject(:action) { action_class.new(**action_args) }
+    let(:action_args) { {} }
+
+    describe "#view_context" do
+      subject(:view_context) { action.view_context }
+
+      shared_examples "injected view context" do
+        context "view context provided to initializer" do
+          let(:view_context) { double(:view_context) }
+          let(:action_args) { {view_context: view_context} }
+
+          it "is the provided context object" do
+            is_expected.to eql view_context
+          end
+        end
+      end
+
+      context "Action inside slice" do
+        let(:action_module) { Main }
+
+        context "no view context registered" do
+          it "is nil" do
+            is_expected.to be_nil
+          end
+
+          it_behaves_like "injected view context"
+        end
+
+        context "view context registered in slice" do
+          let(:slice_view_context) { double(:slice_view_context) }
+
+          before do
+            Main::Slice.register "view.context", slice_view_context
+          end
+
+          it "is the slice's view context" do
+            is_expected.to eql slice_view_context
+          end
+
+          it_behaves_like "injected view context"
+        end
+
+        context "view context registered in application" do
+          let(:application_view_context) { double(:application_view_context) }
+
+          before do
+            Hanami.application.register "view.context", application_view_context
+          end
+
+          it "is the applications's view context" do
+            is_expected.to eql application_view_context
+          end
+
+          it_behaves_like "injected view context"
+        end
+      end
+
+      context "Action inside application" do
+        let(:action_module) { TestApp }
+
+        context "no view context registered" do
+          it "is nil" do
+            is_expected.to be_nil
+          end
+
+          it_behaves_like "injected view context"
+        end
+
+        context "view context registered in application" do
+          let(:application_view_context) { double(:application_view_context) }
+
+          before do
+            Hanami.application.register "view.context", application_view_context
+          end
+
+          it "is the applications's view context" do
+            is_expected.to eql application_view_context
+          end
+
+          it_behaves_like "injected view context"
+        end
+      end
+    end
+
+    describe "#view_options" do
+      subject(:view_options) { action.send(:view_options, req, res) }
+      let(:req) { double(:req) }
+      let(:res) { double(:res) }
+
+      context "without view context" do
+        it "is an empty hash" do
+          is_expected.to eq({})
+        end
+      end
+
+      context "with view context" do
+        let(:initial_view_context) { double(:initial_view_context) }
+        let(:action_args) { {view_context: initial_view_context} }
+
+        context "default #view_context_options" do
+          let(:request_view_context) { double(:request_view_context) }
+
+          before do
+            allow(initial_view_context).to receive(:with).with(
+              request: req,
+              response: res,
+            ) { request_view_context }
+          end
+
+          it "is the view context with the request and response provided" do
+            is_expected.to eq(context: request_view_context)
+          end
+        end
+
+        context "custom #view_context_options" do
+          let(:custom_view_context) { double(:custom_view_context)}
+
+          before do
+            action_class.class_eval do
+              def view_context_options(req, res)
+                {custom_option: "custom option"}
+              end
+            end
+
+            allow(initial_view_context).to receive(:with).with(
+              custom_option: "custom option"
+            ) { custom_view_context }
+          end
+
+          it "is the view context with the custom options provided" do
+            is_expected.to eq(context: custom_view_context)
+          end
+        end
+
+        context "specialized method (calling super) defined in action class" do
+          let(:request_view_context) { double(:request_view_context) }
+
+          before do
+            allow(initial_view_context).to receive(:with).with(
+              request: req,
+              response: res,
+            ) { request_view_context }
+
+            action_class.class_eval do
+              def view_options(req, res)
+                super.merge(extra_option: "extra option")
+              end
+            end
+          end
+
+          it "includes the options provided by the specialized method" do
+            is_expected.to eq(context: request_view_context, extra_option: "extra option")
+          end
+        end
+      end
+    end
+  end
+end
+
+

--- a/spec/integration/hanami/controller/application_action_spec.rb
+++ b/spec/integration/hanami/controller/application_action_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe "Application actions", :application_integration do
     it "is not an application action" do
       expect(action.class.ancestors).not_to include(a_kind_of(Hanami::Action::ApplicationAction))
     end
-
-    it "does not provide view integration methods" do
-      expect(action).not_to respond_to(:view_context)
-    end
   end
 
   describe "Inside Hanami app" do
@@ -34,246 +30,19 @@ RSpec.describe "Application actions", :application_integration do
       Hanami.init
     end
 
-    let(:action_module) { Main }
-
     let(:action_class) {
-      eval <<~RUBY
-        module #{action_module}
-          class Action < Hanami::Action
-          end
+      module Main
+        class Action < Hanami::Action
         end
+      end
 
-        #{action_module}::Action
-      RUBY
+      Main::Action
     }
 
-    subject(:action) { action_class.new(**action_args) }
-    let(:action_args) { {} }
+    subject(:action) { action_class.new }
 
     it "is an application action" do
       expect(action.class.ancestors).to include(a_kind_of(Hanami::Action::ApplicationAction))
-    end
-
-    describe "#view_context" do
-      subject(:view_context) { action.view_context }
-
-      shared_examples "injectable view context" do
-        context "view context provided to initializer" do
-          let(:view_context) { double(:view_context) }
-          let(:action_args) { {view_context: view_context} }
-
-          it "is the provided context object" do
-            is_expected.to eql view_context
-          end
-        end
-      end
-
-      context "Action inside slice" do
-        let(:action_module) { Main }
-
-        context "no view context registered" do
-          it "is nil" do
-            is_expected.to be_nil
-          end
-
-          it_behaves_like "injectable view context"
-        end
-
-        context "view context registered in slice" do
-          let(:slice_view_context) { double(:slice_view_context) }
-
-          before do
-            Main::Slice.register "view.context", slice_view_context
-          end
-
-          it "is the slice's view context" do
-            is_expected.to eql slice_view_context
-          end
-
-          it_behaves_like "injectable view context"
-        end
-
-        context "view context registered in application" do
-          let(:application_view_context) { double(:application_view_context) }
-
-          before do
-            Hanami.application.register "view.context", application_view_context
-          end
-
-          it "is the applications's view context" do
-            is_expected.to eql application_view_context
-          end
-
-          it_behaves_like "injectable view context"
-        end
-      end
-
-      context "Action inside application" do
-        let(:action_module) { TestApp }
-
-        context "no view context registered" do
-          it "is nil" do
-            is_expected.to be_nil
-          end
-
-          it_behaves_like "injectable view context"
-        end
-
-        context "view context registered in application" do
-          let(:application_view_context) { double(:application_view_context) }
-
-          before do
-            Hanami.application.register "view.context", application_view_context
-          end
-
-          it "is the applications's view context" do
-            is_expected.to eql application_view_context
-          end
-
-          it_behaves_like "injectable view context"
-        end
-      end
-
-      context "Action inside slice, inheriting from Action inside application" do
-        let(:action_class) {
-          module TestApp
-            class Action < Hanami::Action
-            end
-          end
-
-          module Main
-            class Action < TestApp::Action
-            end
-          end
-
-          Main::Action
-        }
-
-        context "no view context registered" do
-          it "is nil" do
-            is_expected.to be_nil
-          end
-
-          it_behaves_like "injectable view context"
-        end
-
-        context "view context registered in application" do
-          let(:application_view_context) { double(:application_view_context) }
-
-          before do
-            Hanami.application.register "view.context", application_view_context
-          end
-
-          it "is the applications's view context" do
-            is_expected.to eql application_view_context
-          end
-
-          it_behaves_like "injectable view context"
-        end
-
-        context "view context registered in slice" do
-          let(:slice_view_context) { double(:slice_view_context) }
-
-          before do
-            Main::Slice.register "view.context", slice_view_context
-          end
-
-          it "is the slices's view context" do
-            is_expected.to eql slice_view_context
-          end
-
-          it_behaves_like "injectable view context"
-        end
-
-        context "view context registered in both application and slice" do
-          let(:application_view_context) { double(:application_view_context) }
-          let(:slice_view_context) { double(:slice_view_context) }
-
-          before do
-            Hanami.application.register "view.context", application_view_context
-            Main::Slice.register "view.context", slice_view_context
-          end
-
-          it "is the slices's view context" do
-            is_expected.to eql slice_view_context
-          end
-
-          it_behaves_like "injectable view context"
-        end
-      end
-    end
-
-    describe "#view_options" do
-      subject(:view_options) { action.send(:view_options, req, res) }
-      let(:req) { double(:req) }
-      let(:res) { double(:res) }
-
-      context "without view context" do
-        it "is an empty hash" do
-          is_expected.to eq({})
-        end
-      end
-
-      context "with view context" do
-        let(:initial_view_context) { double(:initial_view_context) }
-        let(:action_args) { {view_context: initial_view_context} }
-
-        context "default #view_context_options" do
-          let(:request_view_context) { double(:request_view_context) }
-
-          before do
-            allow(initial_view_context).to receive(:with).with(
-              request: req,
-              response: res,
-            ) { request_view_context }
-          end
-
-          it "is the view context with the request and response provided" do
-            is_expected.to eq(context: request_view_context)
-          end
-        end
-
-        context "custom #view_context_options" do
-          let(:custom_view_context) { double(:custom_view_context)}
-
-          before do
-            action_class.class_eval do
-              def view_context_options(req, res)
-                {custom_option: "custom option"}
-              end
-            end
-
-            allow(initial_view_context).to receive(:with).with(
-              custom_option: "custom option"
-            ) { custom_view_context }
-          end
-
-          it "is the view context with the custom options provided" do
-            is_expected.to eq(context: custom_view_context)
-          end
-        end
-
-        context "specialized method (calling super) defined in action class" do
-          let(:request_view_context) { double(:request_view_context) }
-
-          before do
-            allow(initial_view_context).to receive(:with).with(
-              request: req,
-              response: res,
-            ) { request_view_context }
-
-            action_class.class_eval do
-              def view_options(req, res)
-                super.merge(extra_option: "extra option")
-              end
-            end
-          end
-
-          it "includes the options provided by the specialized method" do
-            is_expected.to eq(context: request_view_context, extra_option: "extra option")
-          end
-        end
-      end
     end
   end
 end

--- a/spec/unit/hanami/action/configuration_spec.rb
+++ b/spec/unit/hanami/action/configuration_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe Hanami::Action::Configuration do
     end
   end
 
+  describe '#settings' do
+    it 'returns a set of available settings' do
+      expect(configuration.settings).to be_a(Set)
+      expect(configuration.settings).to include(:handled_exceptions, :formats)
+    end
+  end
+
   describe '#handled_exceptions' do
     it 'is an empty hash by default' do
       expect(configuration.handled_exceptions).to eq({})


### PR DESCRIPTION
This adds an extra piece of automatic integration behaviour to `ApplicationAction` - it will apply any application-level configuration to the Action class as well.

This relies on https://github.com/hanami/hanami/pull/1065, which makes all `Hanami::Action::Configuration` settings available on the application configuration, at `Hanami.application.config.actions`.