### PR TITLE
Provide full ApplicationConfiguration object, along with new view_context_identifier setting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :validations do
 end
 
 group :test do
-  gem 'hanami', github: 'hanami/hanami', branch: 'unstable'
+  gem 'hanami', github: 'hanami/hanami', branch: 'enhancement/unstable/use-action-application-configuration'
   gem 'hanami-view', github: 'hanami/view', branch: 'master'
   gem 'slim'
 end

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -34,8 +34,7 @@ module Hanami
       end
 
       def resolve_view_context
-        # TODO: make identifier configurable
-        identifier = "view.context"
+        identifier = application.config.actions.view_context_identifier
 
         if provider.key?(identifier)
           provider[identifier]

--- a/lib/hanami/action/application_configuration.rb
+++ b/lib/hanami/action/application_configuration.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "configuration"
+
+module Hanami
+  class Action
+    class ApplicationConfiguration
+      include Dry::Configurable
+
+      setting :view_context_identifier, "view.context"
+
+      Configuration._settings.each do |action_setting|
+        _settings << action_setting.dup
+      end
+
+      def initialize(*)
+        super
+
+        config.default_request_format = :html
+        config.default_response_format = :html
+      end
+
+      # Returns the list of available settings
+      #
+      # @return [Set]
+      #
+      # @since 2.0.0
+      # @api private
+      def settings
+        self.class.settings
+      end
+
+      private
+
+      def method_missing(name, *args, &block)
+        if config.respond_to?(name)
+          config.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, _incude_all = false)
+        config.respond_to?(name) || super
+      end
+    end
+  end
+end

--- a/lib/hanami/action/configuration.rb
+++ b/lib/hanami/action/configuration.rb
@@ -233,7 +233,7 @@ module Hanami
       #
       # @!method default_response_format
       #
-      #   Return the configured default response format
+      #   Returns the configured default response format
       #
       #   @return [Symbol] format
       #
@@ -261,7 +261,7 @@ module Hanami
       #
       # @!method default_charset
       #
-      #   Return the configured default charset.
+      #   Returns the configured default charset.
       #
       #   @return [String,nil] the charset, if present
       #
@@ -388,7 +388,7 @@ module Hanami
       #   @see public_directory
       setting :public_directory, DEFAULT_PUBLIC_DIRECTORY
 
-      # Return the configured public directory, appended onto the root directory.
+      # Returns the configured public directory, appended onto the root directory.
       #
       # @return [String] the fill directory path
       #

--- a/spec/integration/hanami/controller/application_action/view_integration_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_integration_spec.rb
@@ -49,14 +49,12 @@ RSpec.describe "Application actions / view integration", :application_integratio
     describe "#view_context" do
       subject(:view_context) { action.view_context }
 
-      shared_examples "injected view context" do
-        context "view context provided to initializer" do
-          let(:view_context) { double(:view_context) }
-          let(:action_args) { {view_context: view_context} }
+      context "Explicitly injected object" do
+        let(:view_context) { double(:view_context) }
+        let(:action_args) { {view_context: view_context} }
 
-          it "is the provided context object" do
-            is_expected.to eql view_context
-          end
+        it "returns the injected object" do
+          is_expected.to eql view_context
         end
       end
 
@@ -67,36 +65,45 @@ RSpec.describe "Application actions / view integration", :application_integratio
           it "is nil" do
             is_expected.to be_nil
           end
-
-          it_behaves_like "injected view context"
         end
 
-        context "view context registered in slice" do
-          let(:slice_view_context) { double(:slice_view_context) }
+        context "default view context identifier" do
+          context "view context registered in slice" do
+            let(:slice_view_context) { double(:slice_view_context) }
 
-          before do
-            Main::Slice.register "view.context", slice_view_context
+            before do
+              Main::Slice.register "view.context", slice_view_context
+            end
+
+            it "is the slice's view context" do
+              is_expected.to eql slice_view_context
+            end
           end
 
-          it "is the slice's view context" do
-            is_expected.to eql slice_view_context
-          end
+          context "view context registered in application" do
+            let(:application_view_context) { double(:application_view_context) }
 
-          it_behaves_like "injected view context"
+            before do
+              Hanami.application.register "view.context", application_view_context
+            end
+
+            it "is the applications's view context" do
+              is_expected.to eql application_view_context
+            end
+          end
         end
 
-        context "view context registered in application" do
-          let(:application_view_context) { double(:application_view_context) }
+        context "custom view context identifier" do
+          let(:custom_view_context) { double(:custom_view_context) }
 
           before do
-            Hanami.application.register "view.context", application_view_context
+            Hanami.application.config.actions.view_context_identifier = "view.custom_context"
+            Main::Slice.register "view.custom_context", custom_view_context
           end
 
-          it "is the applications's view context" do
-            is_expected.to eql application_view_context
+          it "is the context registered with the custom identifier" do
+            is_expected.to eql custom_view_context
           end
-
-          it_behaves_like "injected view context"
         end
       end
 
@@ -107,8 +114,6 @@ RSpec.describe "Application actions / view integration", :application_integratio
           it "is nil" do
             is_expected.to be_nil
           end
-
-          it_behaves_like "injected view context"
         end
 
         context "view context registered in application" do
@@ -121,8 +126,6 @@ RSpec.describe "Application actions / view integration", :application_integratio
           it "is the applications's view context" do
             is_expected.to eql application_view_context
           end
-
-          it_behaves_like "injected view context"
         end
       end
     end

--- a/spec/unit/hanami/action/application_configuration/default_request_format_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/default_request_format_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration, "#default_request_format" do
+  let(:configuration) { described_class.new }
+  subject(:value) { configuration.default_request_format }
+
+  it "returns the default" do
+    is_expected.to eq :html
+  end
+
+  it "can be set" do
+    configuration.default_request_format = :json
+    is_expected.to eq :json
+  end
+end

--- a/spec/unit/hanami/action/application_configuration/default_response_format_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/default_response_format_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration, "#default_response_format" do
+  let(:configuration) { described_class.new }
+  subject(:value) { configuration.default_response_format }
+
+  it "returns the default" do
+    is_expected.to eq :html
+  end
+
+  it "can be set" do
+    configuration.default_response_format = :json
+    is_expected.to eq :json
+  end
+end

--- a/spec/unit/hanami/action/application_configuration/view_context_identifier_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/view_context_identifier_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration, "#view_context_identifier" do
+  let(:configuration) { described_class.new }
+  subject(:value) { configuration.view_context_identifier }
+
+  it "returns 'view.context' by default" do
+    is_expected.to eq "view.context"
+  end
+
+  it "can be set" do
+    configuration.view_context_identifier = "view.another_context"
+    is_expected.to eq "view.another_context"
+  end
+end

--- a/spec/unit/hanami/action/application_configuration_spec.rb
+++ b/spec/unit/hanami/action/application_configuration_spec.rb
@@ -1,0 +1,17 @@
+require "hanami/action/application_configuration"
+require "hanami/action/configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration do
+  subject(:configuration) { described_class.new }
+
+  describe "#settings" do
+    it "returns a set of available settings" do
+      expect(configuration.settings).to be_a(Set)
+      expect(configuration.settings).to include(:view_context_identifier, :handled_exceptions)
+    end
+
+    it "includes all action settings" do
+      expect(configuration.settings).to include(Hanami::Action::Configuration.settings)
+    end
+  end
+end


### PR DESCRIPTION
This PR makes hanami-controller responsible for all the details of its application integration, by providing an `Hanami::Action::ApplicationConfiguration` class that the hanami gem will expose as `Hanami.application.config.actions`.

This class includes all the settings from `Hanami::Action::Configuration` (as was the case with the previous arrangement), but it _also_ provides a place for new integration-level settings that do _not_ apply direction to an individual action's config.

The first of these is `view_context_identifier`, which the `ApplicationAction` mixin uses to find the right view context object from the application to use when rendering views within actions.

This PR goes along with a counterpart in hanami/hanami: https://github.com/hanami/hanami/pull/1068