### PR TITLE
Auto-inject inferred paired view into application actions

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -3,34 +3,23 @@
 module Hanami
   class Action
     class ApplicationAction < Module
-      DynamicInstanceMethods = Class.new(Module)
-
       attr_reader :provider
       attr_reader :application
-      attr_reader :instance_mod
 
       def initialize(provider)
         @provider = provider
         @application = provider.respond_to?(:application) ? provider.application : Hanami.application
-        @instance_mod = DynamicInstanceMethods.new
       end
 
       def included(action_class)
-        # TODO: I think we should probably do:
-        #
-        #   instance_mod.include StaticInstanceMethods
-        #
-        # And just include the single instance_mod, rather than these two
-        # modules, for a simpler ancestors chain
-        action_class.include StaticInstanceMethods
-        action_class.include instance_mod
+        action_class.include InstanceMethods
 
         define_initialize action_class
         configure_action action_class
       end
 
       def inspect
-        "#<#{self.class.name}[#{provider}]>"
+        "#<#{self.class.name}[#{provider.name}]>"
       end
 
       private
@@ -74,7 +63,7 @@ module Hanami
         end
       end
 
-      module StaticInstanceMethods
+      module InstanceMethods
         # FIXME: Can I turn these into attr_readers?
         def view
           @view

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -30,8 +30,11 @@ module Hanami
 
         define_method :initialize do |**deps|
           super(**deps)
-          @view = deps[:view] || resolve_view.(action_class)
-          @view_context = deps[:view_context] || resolve_context.()
+
+          # Conditionally assign these to repsect any explictly auto-injected
+          # dependencies provided by the class
+          @view ||= deps[:view] || resolve_view.(action_class)
+          @view_context ||= deps[:view_context] || resolve_context.()
         end
       end
 

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -54,7 +54,7 @@ module Hanami
           provider: provider
         )
 
-        view_identifiers.each_with_object(nil) { |identifier|
+        view_identifiers.detect { |identifier|
           break provider[identifier] if provider.key?(identifier)
         }
       end

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -57,23 +57,14 @@ module Hanami
       end
 
       def resolve_paired_view(action_class)
-        # TODO: This is naive, needs to be expanded (should also be extracted into a standalone, testable class)
-        # TODO: it should also use a setting for the "views." bit
-        identifier = "views.#{action_identifier(action_class)}"
+        view_identifiers = application.config.actions.view_name_inferrer.(
+          action_name: action_class.name,
+          provider: provider
+        )
 
-        provider[identifier] if provider.key?(identifier)
-      end
-
-      def action_identifier(action_class)
-        # TODO: replace last .sub with something like this:
-        # .sub(/^#{view_class.config.template_inference_base}\//, "")
-
-        provider
-          .inflector
-          .underscore(action_class.name)
-          .sub(/^#{provider.namespace_path}\//, "")
-          .sub(/^actions\//, "")
-          .gsub("/", ".")
+        view_identifiers.each_with_object(nil) { |identifier|
+          break provider[identifier] if provider.key?(identifier)
+        }
       end
 
       def configure_action(action_class)

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -67,14 +67,8 @@ module Hanami
       end
 
       module InstanceMethods
-        # FIXME: Can I turn these into attr_readers?
-        def view
-          @view
-        end
-
-        def view_context
-          @view_context
-        end
+        attr_reader :view
+        attr_reader :view_context
 
         private
 

--- a/lib/hanami/action/application_configuration.rb
+++ b/lib/hanami/action/application_configuration.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 require_relative "configuration"
+require_relative "view_name_inferrer"
 
 module Hanami
   class Action
     class ApplicationConfiguration
       include Dry::Configurable
 
+      setting :name_inference_base, "actions"
       setting :view_context_identifier, "view.context"
+      setting :view_name_inferrer, ViewNameInferrer
+      setting :view_name_inference_base, "views"
 
       Configuration._settings.each do |action_setting|
         _settings << action_setting.dup

--- a/lib/hanami/action/view_name_inferrer.rb
+++ b/lib/hanami/action/view_name_inferrer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    class ViewNameInferrer
+      ALTERNATIVE_NAMES = {
+        "create" => "new",
+        "update" => "edit"
+      }.freeze
+
+      class << self
+        def call(action_name:, provider:)
+          application = provider.respond_to?(:application) ? provider.application : Hanami.application
+
+          action_identifier_base = application.config.actions.name_inference_base
+          view_identifier_base = application.config.actions.view_name_inference_base
+
+          identifier = action_identifier_name(action_name, provider, action_identifier_base)
+
+          view_name = [view_identifier_base, identifier].compact.join(".")
+
+          [view_name, alternative_view_name(view_name)].compact
+        end
+
+        private
+
+        def action_identifier_name(action_name, provider, name_base)
+          provider
+            .inflector
+            .underscore(action_name)
+            .sub(/^#{provider.namespace_path}\//, "")
+            .sub(/^#{name_base}\//, "")
+            .gsub("/", ".")
+        end
+
+        def alternative_view_name(view_name)
+          parts = view_name.split(".")
+
+          alternative_name = ALTERNATIVE_NAMES[parts.last]
+
+          [parts[0..-2], alternative_name].join(".") if alternative_name
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe "Application actions / View rendering / Paired view inference", :
     Hanami.init
   end
 
-
-
   let(:action) { action_class.new }
 
   context "Regular action" do

--- a/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
@@ -13,35 +13,77 @@ RSpec.describe "Application actions / View rendering / Paired view inference", :
     Hanami.init
   end
 
-  let(:action_class) {
-    module Main
-      module Actions
-        module Articles
-          class Index < Hanami::Action
-          end
-        end
-      end
-    end
-    Main::Actions::Articles::Index
-  }
+
 
   let(:action) { action_class.new }
 
-  context "Paired view exists" do
-    let(:view) { double(:view) }
+  context "Regular action" do
+    let(:action_class) {
+      module Main
+        module Actions
+          module Articles
+            class Index < Hanami::Action
+            end
+          end
+        end
+      end
+      Main::Actions::Articles::Index
+    }
 
-    before do
-      Main::Slice.register "views.articles.index", view
+    context "Paired view exists" do
+      let(:view) { double(:view) }
+
+      before do
+        Main::Slice.register "views.articles.index", view
+      end
+
+      it "auto-injects a paired view from a matching container identifier" do
+        expect(action.view).to be view
+      end
     end
 
-    it "auto-injects a paired view from a matching container identifier" do
-      expect(action.view).to be view
+    context "No paired view exists" do
+      it "does not auto-inject any view" do
+        expect(action.view).to be_nil
+      end
     end
   end
 
-  context "No paired view exists" do
-    it "does not auto-inject any view" do
-      expect(action.view).to be_nil
+  context "RESTful action" do
+    let(:action_class) {
+      module Main
+        module Actions
+          module Articles
+            class Create < Hanami::Action
+            end
+          end
+        end
+      end
+      Main::Actions::Articles::Create
+    }
+
+    let(:direct_paired_view) { double(:direct_paired_view) }
+    let(:alternative_paired_view) { double(:alternative_paired_view) }
+
+    context "Direct paired view exists" do
+      before do
+        Main::Slice.register "views.articles.create", direct_paired_view
+        Main::Slice.register "views.articles.new", alternative_paired_view
+      end
+
+      it "auto-injects the directly paired view" do
+        expect(action.view).to be direct_paired_view
+      end
+    end
+
+    context "Alternative paired view exists" do
+      before do
+        Main::Slice.register "views.articles.new", alternative_paired_view
+      end
+
+      it "auto-injects the alternative paired view" do
+        expect(action.view).to be alternative_paired_view
+      end
     end
   end
 end

--- a/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
@@ -1,0 +1,47 @@
+require "hanami"
+
+RSpec.describe "Application actions / View rendering / Paired view inference", :application_integration do
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    module Main; end
+    Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+
+    Hanami.init
+  end
+
+  let(:action_class) {
+    module Main
+      module Actions
+        module Articles
+          class Index < Hanami::Action
+          end
+        end
+      end
+    end
+    Main::Actions::Articles::Index
+  }
+
+  let(:action) { action_class.new }
+
+  context "Paired view exists" do
+    let(:view) { double(:view) }
+
+    before do
+      Main::Slice.register "views.articles.index", view
+    end
+
+    it "auto-injects a paired view from a matching container identifier" do
+      expect(action.view).to be view
+    end
+  end
+
+  context "No paired view exists" do
+    it "does not auto-inject any view" do
+      expect(action.view).to be_nil
+    end
+  end
+end

--- a/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/paired_view_inference_spec.rb
@@ -38,6 +38,31 @@ RSpec.describe "Application actions / View rendering / Paired view inference", :
       it "auto-injects a paired view from a matching container identifier" do
         expect(action.view).to be view
       end
+
+      context "Another view explicitly auto-injected" do
+        let(:action_class) {
+          module Main
+            module Actions
+              module Articles
+                class Index < Hanami::Action
+                  include Deps[view: "views.articles.custom"]
+                end
+              end
+            end
+          end
+          Main::Actions::Articles::Index
+        }
+
+        let(:explicit_view) { double(:explicit_view) }
+
+        before do
+          Main::Slice.register "views.articles.custom", explicit_view
+        end
+
+        it "respects the explicitly auto-injected view" do
+          expect(action.view).to be explicit_view
+        end
+      end
     end
 
     context "No paired view exists" do

--- a/spec/unit/hanami/action/view_name_inferrer_spec.rb
+++ b/spec/unit/hanami/action/view_name_inferrer_spec.rb
@@ -1,0 +1,48 @@
+require "hanami/action/view_name_inferrer"
+
+require "dry/inflector"
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ViewNameInferrer, ".call" do
+  subject(:view_name) {
+    described_class.(
+      action_name: action_name,
+      provider: provider
+    )
+  }
+
+  let(:provider) {
+    double(
+      :provider,
+      application: application,
+      inflector: Dry::Inflector.new,
+      namespace_path: provider_namespace_path
+    )
+  }
+  let(:provider_namespace_path) { "main" }
+
+  let(:application) { double(:application) }
+  let(:application_actions_config) { Hanami::Action::ApplicationConfiguration.new }
+
+  before do
+    allow(application).to receive_message_chain("config.actions") { application_actions_config }
+  end
+
+  context "named action" do
+    let(:action_name) { "Main::Actions::Articles::Index" }
+
+    it { is_expected.to eq ["views.articles.index"] }
+  end
+
+  context "RESTful create action" do
+    let(:action_name) { "Main::Actions::Articles::Create" }
+
+    it { is_expected.to eq ["views.articles.create", "views.articles.new"] }
+  end
+
+  context "RESTful update action" do
+    let(:action_name) { "Main::Actions::Articles::Update" }
+
+    it { is_expected.to eq ["views.articles.update", "views.articles.edit"] }
+  end
+end


### PR DESCRIPTION
Update the `ApplicationAction` behavior to automatically auto-inject a "paired" view into any action, based on the action name. This behavior is provided by a configurable `ViewNameInferrer`.

For example, for an action named `Main::Actions::Articles::Index`, inject the view found at the `"views.articles.index"` registration.

It will not attempt to inject the view if no such registration exists.

This auto-injected view is also manually overridable for testing purposes, etc., i.e. `Actions::Articles::Index.new(view: my_custom_view)`.

Special behavior is also provided for RESTful actions named `Create` or `Update`. In these cases, the view name inferrer will return two view identifiers: `["views.articles.create", "views.articles.new"]`, where the second identifier is an "alternative" view, matching the expected view that would have led to the given RESTful request ("create"->"new" and "update"->"edit"). This is useful because it will allow the application author to easily re-render the matching view with error messages in the case of an invalid record.

In this case, where two potential view names are provided by the inferrer, the action will attempt to look them up in order, so in the example above, if a view is _actually_ registered at `"views.articles.create"`, then that will be provided instead of `"views.articles.new"`.