### PR TITLE
Render view automatically within application actions

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -70,6 +70,14 @@ module Hanami
         attr_reader :view
         attr_reader :view_context
 
+        protected
+
+        def handle(request, response)
+          if view
+            response.render view, **request.params
+          end
+        end
+
         private
 
         def build_response(**options)

--- a/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
@@ -1,0 +1,97 @@
+require "hanami"
+
+RSpec.describe "Application actions / View rendering / Automatic rendering", :application_integration do
+  it "Renders a view automatically, passing all params" do
+    within_app do
+      write "slices/main/lib/main/actions/test.rb", <<~RUBY
+        require "hanami/action"
+
+        module Main
+          module Actions
+            class Test < Hanami::Action
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/lib/main/views/test.rb", <<~RUBY
+        require "main/view"
+
+        module Main
+          module Views
+            class Test < Main::View
+              expose :name
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/web/templates/test.html.slim", <<~'SLIM'
+        h1 Hello, #{name}
+      SLIM
+
+      require "hanami/init"
+
+      action = Main::Slice["actions.test"]
+      response = action.(name: "Jennifer")
+      rendered = response.body[0]
+
+      expect(rendered).to eq "<html><body><h1>Hello, Jennifer</h1></body></html>"
+      expect(response.status).to eq 200
+    end
+  end
+
+  it "Does not render if no view is available" do
+    within_app do
+      write "slices/main/lib/main/actions/test.rb", <<~RUBY
+        require "hanami/action"
+
+        module Main
+          module Actions
+            class Test < Hanami::Action
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+
+      action = Main::Slice["actions.test"]
+      response = action.({})
+      expect(response.body).to eq []
+      expect(response.status).to eq 200
+    end
+  end
+
+  def within_app
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "slices/main/lib/main/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module Main
+          class View < Hanami::View
+          end
+        end
+      RUBY
+
+      write "slices/main/web/templates/layouts/application.html.slim", <<~SLIM
+        html
+          body
+            == yield
+      SLIM
+
+      yield
+    end
+  end
+end


### PR DESCRIPTION
This removes the last piece of boilerplate for basic application actions: if a view is available (either through paired view inference or explicit auto-injection), it will be called, with all the request parameters passed to it.

Along with the paired view inference, this means we can now create an action like this:

```ruby
module Main
  module Actions
    module Articles
      class Index < Hanami::Action
      end
    end
  end
end
```

And it will automatically render the `Main::Views::Articles::Index`!