### PR TITLE
Fix view inference for deeper class hierarchies

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -29,12 +29,12 @@ module Hanami
         resolve_context = method(:resolve_view_context)
 
         define_method :initialize do |**deps|
-          super(**deps)
-
           # Conditionally assign these to repsect any explictly auto-injected
           # dependencies provided by the class
-          @view ||= deps[:view] || resolve_view.(action_class)
+          @view ||= deps[:view] || resolve_view.(self.class)
           @view_context ||= deps[:view_context] || resolve_context.()
+
+          super(**deps)
         end
       end
 


### PR DESCRIPTION
This proves we need to cover this expected typical use case (a `SliceName::Action` base action class, with all other slice actions inheriting from it) in specs for _every_ feature of application actions.