### PR TITLE
Rationalize flash behavior

### DIFF
--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -9,8 +9,7 @@ module Hanami
       # The flash hash for the current request
       alias now __getobj__
 
-      # Setup the next hash when initializing, and treat nil as a new empty
-      # hash
+      # Setup the next hash when initializing, treat nil as a new empty hash
       def initialize(hash = {})
         super(hash || {})
         @next = {}
@@ -23,8 +22,8 @@ module Hanami
 
       # Remove given key from the next hash, or clear the next hash if no
       # argument is given
-      def discard(key = nil)
-        if key.nil?
+      def discard(key = (no_arg = true))
+        if no_arg
           @next.clear
         else
           @next.delete(key)
@@ -34,8 +33,8 @@ module Hanami
       # Copy the entry with the given key from the current hash to the next
       # hash, or copy all entries from the current hash to the next hash if no
       # argument is given
-      def keep(key = nil)
-        if key.nil?
+      def keep(key = (no_arg = true))
+        if no_arg
           @next.merge!(self)
         else
           self[key] = self[key]

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -2,26 +2,67 @@
 
 module Hanami
   class Action
+    # A container to transport data with the HTTP session, with a lifespan of
+    # just one HTTP request or redirect.
+    #
+    # Behaves like a hash, returning entries for the current request, except for
+    # {#[]=}, which updates the hash for the next request.
+    #
+    # @since 0.3.0
+    # @api public
     class Flash < DelegateClass(Hash)
-      # The flash hash for the next request, which gets written to by #[]=
+      # @return [Hash] The flash hash for the next request, written to by {#[]=}.
+      #
+      # @see #[]=
+      #
+      # @since 2.0.0
+      # @api public
       attr_reader :next
 
-      # The flash hash for the current request
-      alias now __getobj__
-
-      # Setup the next hash when initializing, treat nil as a new empty hash
+      # Initializes a new flash instance
+      #
+      # @param hash [Hash, nil] the flash hash for the current request. nil will become an empty hash.
+      #
+      # @since 0.3.0
+      # @api public
       def initialize(hash = {})
         super(hash || {})
         @next = {}
       end
 
-      # Update the next hash with the given key and value
-      def []=(k, v)
-        @next[k] = v
+      # @!attribute [r] now
+      #
+      # @return [Hash] The flash hash for the current request
+      #
+      # @since 2.0.0
+      # @api public
+      def now
+        __getobj__
       end
 
-      # Remove given key from the next hash, or clear the next hash if no
-      # argument is given
+      # Updates the next hash with the given key and value
+      #
+      # @param key [Object] the key
+      # @param value [Object] the value
+      #
+      # @since 0.3.0
+      # @api public
+      def []=(key, value)
+        @next[key] = value
+      end
+
+      # Removes entries from the next hash
+      #
+      # @overload discard(key)
+      #   Removes the given key from the next hash
+      #
+      #   @param key [Object] key to discard
+      #
+      # @overload discard
+      #   Clears the next hash
+      #
+      # @since 2.0.0
+      # @api public
       def discard(key = (no_arg = true))
         if no_arg
           @next.clear
@@ -30,9 +71,19 @@ module Hanami
         end
       end
 
-      # Copy the entry with the given key from the current hash to the next
-      # hash, or copy all entries from the current hash to the next hash if no
-      # argument is given
+      # Copies entries from the current hash to the next hash
+      #
+      # @overload keep(key)
+      #   Copies the entry for the given key from the current hash to the next
+      #   hash
+      #
+      #   @param key [Object] key to copy
+      #
+      # @overload keep
+      #   Copies all entries from the current hash to the next hash
+      #
+      # @since 2.0.0
+      # @api public
       def keep(key = (no_arg = true))
         if no_arg
           @next.merge!(self)
@@ -41,7 +92,10 @@ module Hanami
         end
       end
 
-      # Replace the current hash with the next hash and clear the next hash
+      # Replaces the current hash with the next hash and clears the next hash
+      #
+      # @since 2.0.0
+      # @api public
       def sweep
         replace(@next)
         @next.clear

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -24,8 +24,8 @@ module Hanami
 
       # Remove given key from the next hash, or clear the next hash if
       # no argument is given.
-      def discard(key=(no_arg=true))
-        if no_arg
+      def discard(key = nil)
+        if key.nil?
           @next.clear
         else
           @next.delete(key)
@@ -35,8 +35,8 @@ module Hanami
       # Copy the entry with the given key from the current hash to the
       # next hash, or copy all entries from the current hash to the
       # next hash if no argument is given.
-      def keep(key=(no_arg=true))
-        if no_arg
+      def keep(key = nil)
+        if key.nil?
           @next.merge!(self)
         else
           self[key] = self[key]

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -2,268 +2,52 @@ require 'hanami/utils/json'
 
 module Hanami
   class Action
-    # Container useful to transport data with the HTTP session
-    # It has a life span of one HTTP request or redirect.
-    #
-    # @since 0.3.0
-    # @api private
-    class Flash
-      # Session key where the data is stored
-      #
-      # @since 0.3.0
-      # @api private
-      SESSION_KEY = :__flash
+    class Flash < DelegateClass(Hash)
+      # The flash hash for the next request.  This
+      # is what gets written to by #[]=.
+      attr_reader :next
 
-      # Session key where keep data is store for redirect
-      #
-      # @since 1.3.0
-      # @api private
-      KEPT_KEY = :__kept_key
+      # The flash hash for the current request
+      alias now __getobj__
 
-      # Initialize a new Flash instance
-      #
-      # @param session [Rack::Session::Abstract::SessionHash] the session
-      #
-      # @return [Hanami::Action::Flash] the flash
-      #
-      # @see http://www.rubydoc.info/gems/rack/Rack/Session/Abstract/SessionHash
-      # @see Hanami::Action::Rack#session_id
-      def initialize(session)
-        @session         = session
-        @keep            = false
-
-        session[KEPT_KEY] ||= []
-        session[SESSION_KEY] = {}
+      # Setup the next hash when initializing, and handle treat nil
+      # as a new empty hash.
+      def initialize(hash={})
+        super(hash||{})
+        @next = {}
       end
 
-      # Set the given value for the given key
-      #
-      # @param key [#to_s] the key
-      # @param value [Object] the value
-      #
-      # @since 0.3.0
-      # @api private
-      def []=(key, value)
-        _data[key] = value
+      # Update the next hash with the given key and value.
+      def []=(k, v)
+        @next[k] = v
       end
 
-      # Get the value associated to the given key, if any
-      #
-      # @return [Object,NilClass] the value
-      #
-      # @since 0.3.0
-      # @api private
-      def [](key)
-        _data.fetch(key) { search_in_kept_data(key) }
-      end
-
-      # Iterates through current request data and kept data
-      #
-      # @param blk [Proc]
-      #
-      # @since 1.2.0
-      def each(&blk)
-        _values.each(&blk)
-      end
-
-      # Iterates through current request data and kept data
-      #
-      # @param blk [Proc]
-      # @return [Array]
-      #
-      # @since 1.2.0
-      def map(&blk)
-        _values.map(&blk)
-      end
-
-      # Removes entirely the flash from the session if it has stale contents
-      # or if empty.
-      #
-      # @return [void]
-      #
-      # @since 0.3.0
-      # @api private
-      def clear
-        # FIXME we're just before a release and I can't find a proper way to reproduce
-        # this bug that I've found via a browser.
-        #
-        # It may happen that `#flash` is nil, and those two methods will fail
-        unless _data.nil?
-          update_kept_request_count
-          keep_data if @keep
-          expire_kept
-          remove
+      # Remove given key from the next hash, or clear the next hash if
+      # no argument is given.
+      def discard(key=(no_arg=true))
+        if no_arg
+          @next.clear
+        else
+          @next.delete(key)
         end
       end
 
-      # Check if there are contents stored in the flash from the current or the
-      # previous request.
-      #
-      # @return [TrueClass,FalseClass] the result of the check
-      #
-      # @since 0.3.0
-      # @api private
-      def empty?
-        _values.empty?
-      end
-
-      # @return [String]
-      #
-      # @since 1.0.0
-      def inspect
-        "#<#{self.class}:#{'0x%x' % (__id__ << 1)} {:data=>#{_data.inspect}, :kept=>#{kept_data.inspect}} >"
-      end
-
-      # Set @keep to true, is use when triggering a redirect, and the content of _data is not empty.
-      # @return [TrueClass, NilClass]
-      #
-      # @since 1.3.0
-      # @api private
-      #
-      # @see Hanami::Action::Flash#empty?
-      def keep!
-        return if empty?
-        @keep = true
-      end
-
-      private
-
-      # The flash registry that holds the data for the current requests
-      #
-      # @return [Hash] the flash
-      #
-      # @since 0.3.0
-      # @api private
-      def _data
-        @session[SESSION_KEY] || {}
-      end
-
-      # Remove the flash entirely from the session if empty.
-      #
-      # @return [void]
-      #
-      # @since 0.3.0
-      # @api private
-      #
-      # @see Hanami::Action::Flash#empty?
-      def remove
-        if empty?
-          @session.delete(SESSION_KEY)
-          @session.delete(KEPT_KEY)
+      # Copy the entry with the given key from the current hash to the
+      # next hash, or copy all entries from the current hash to the
+      # next hash if no argument is given.
+      def keep(key=(no_arg=true))
+        if no_arg
+          @next.merge!(self)
+        else
+          self[key] = self[key]
         end
       end
 
-      # Returns the values from current session and kept.
-      #
-      # @return [Hash]
-      #
-      # @since 0.3.0
-      # @api private
-      def _values
-        _data.merge(kept_data)
-      end
-
-      # Get the kept request data
-      #
-      # @return [Array]
-      #
-      # @since 1.3.0
-      # @api private
-      def kept
-        @session[KEPT_KEY] || []
-      end
-
-      # Merge current data into KEPT_KEY hash
-      #
-      # @return [Hash] the current value of KEPT_KEY
-      #
-      # @since 1.3.0
-      # @api private
-      def keep_data
-        new_kept_data = kept << Hanami::Utils::Json.generate({ count: 0, data: _data })
-
-        update_kept(new_kept_data)
-      end
-
-      # Removes from kept data those who have lived for more than two requests
-      #
-      # @return [Hash] the current value of KEPT_KEY
-      #
-      # @since 1.3.0
-      # @api private
-      def expire_kept
-        new_kept_data = kept.reject do |kept_data|
-          parsed = Hanami::Utils::Json.parse(kept_data)
-          parsed['count'] >= 2 if is_hash?(parsed) && parsed['count'].is_a?(Integer)
-        end
-
-        update_kept(new_kept_data)
-      end
-
-      # Update the count of request for each kept data
-      #
-      # @return [Hash] the current value of KEPT_KEY
-      #
-      # @since 1.3.0
-      # @api private
-      def update_kept_request_count
-        new_kept_data = kept.map do |kept_data|
-          parsed = Hanami::Utils::Json.parse(kept_data)
-          parsed['count'] += 1 if is_hash?(parsed) && parsed['count'].is_a?(Integer)
-          Hanami::Utils::Json.generate(parsed)
-        end
-
-        update_kept(new_kept_data)
-      end
-
-      # Search in the kept data for a match on the key
-      #
-      # @param key [#to_s] the key
-      # @return [Object, NilClass]
-      #
-      # @since 1.3.0
-      # @api private
-      def search_in_kept_data(key)
-        string_key = key.to_s
-
-        data = kept.find do |kept_data|
-          parsed = Hanami::Utils::Json.parse(kept_data)
-          parsed['data'].fetch(string_key, nil) if is_hash?(parsed['data'])
-        end
-
-        Hanami::Utils::Json.parse(data)['data'][string_key] if data
-      end
-
-      # Set the given new_kept_data to KEPT_KEY
-      #
-      # @param new_kept_data
-      # @return [Hash] the current value of KEPT_KEY
-      #
-      # @since 1.3.0
-      # @api private
-      def update_kept(new_kept_data)
-        @session[KEPT_KEY] = new_kept_data
-      end
-
-      # Values from kept
-      #
-      # @return [Hash]
-      #
-      # @since 1.3.0
-      # @api private
-      def kept_data
-        kept.each_with_object({}) { |kept_data, result| result.merge!(Hanami::Utils::Json.parse(kept_data)['data']) }
-      end
-
-      # Check if data is a hash
-      #
-      # @param data
-      # @return [TrueClass, FalseClass]
-      #
-      # @since 1.3.0
-      # @api private
-      def is_hash?(data)
-        data && data.is_a?(::Hash)
+      # Replace the current hash with the next hash and clear the next hash.
+      def sweep
+        replace(@next)
+        @next.clear
+        self
       end
     end
   end

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -12,7 +12,7 @@ module Hanami
 
       # Setup the next hash when initializing, and handle treat nil
       # as a new empty hash.
-      def initialize(hash={})
+      def initialize(hash = {})
         super(hash||{})
         @next = {}
       end

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -1,4 +1,3 @@
-require 'hanami/utils/json'
 
 module Hanami
   class Action

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Hanami
   class Action

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -8,6 +8,13 @@ module Hanami
     # Behaves like a hash, returning entries for the current request, except for
     # {#[]=}, which updates the hash for the next request.
     #
+    # This implementation is derived from Roda's FlashHash, also released under
+    # the MIT Licence:
+    #
+    # Copyright (c) 2014-2020 Jeremy Evans
+    # Copyright (c) 2010-2014 Michel Martens, Damian Janowski and Cyril David
+    # Copyright (c) 2008-2009 Christian Neukirchen
+    #
     # @since 0.3.0
     # @api public
     class Flash

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -30,8 +30,6 @@ module Hanami
         @next = {}
       end
 
-      # @!attribute [r] now
-      #
       # @return [Hash] The flash hash for the current request
       #
       # @since 2.0.0
@@ -39,6 +37,10 @@ module Hanami
       def now
         @flash
       end
+
+      # @since 2.0.0
+      # @api public
+      alias to_h now
 
       # Returns a value associated with the given key
       #
@@ -68,6 +70,7 @@ module Hanami
       # @param blk [Proc]
       #
       # @since 1.2.0
+      # @api public
       def each(&blk)
         @flash.each(&blk)
       end
@@ -78,19 +81,29 @@ module Hanami
       # @return [Array]
       #
       # @since 1.2.0
+      # @api public
       def map(&blk)
         @flash.map(&blk)
       end
 
-      # Check if there are contents stored in the flash from the current or the
-      # previous request.
+      # Check if flash is empty.
       #
       # @return [TrueClass,FalseClass] the result of the check
       #
       # @since 0.3.0
-      # @api private
+      # @api public
       def empty?
         @flash.empty?
+      end
+
+      # Check if there is a value associated with the given key.
+      #
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @since 2.0.0
+      # @api public
+      def key?(key)
+        @flash.key?(key)
       end
 
       # Removes entries from the next hash

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -45,11 +45,11 @@ module Hanami
         @flash
       end
 
-      # Returns a value associated with the given key
+      # Returns the value for the given key in the current hash
       #
       # @param key [Object] the key
       #
-      # @return value [Object,NilClass] the value
+      # @return [Object, nil] the value
       #
       # @since 0.3.0
       # @api public

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -38,10 +38,6 @@ module Hanami
         @flash
       end
 
-      # @since 2.0.0
-      # @api public
-      alias to_h now
-
       # Returns a value associated with the given key
       #
       # @param key [Object] the key
@@ -65,30 +61,31 @@ module Hanami
         @next[key] = value
       end
 
-      # Iterates through current request data and kept data
+      # Calls the given block once for each element in the current hash
       #
-      # @param blk [Proc]
+      # @param block [Proc]
       #
       # @since 1.2.0
       # @api public
-      def each(&blk)
-        @flash.each(&blk)
+      def each(&block)
+        @flash.each(&block)
       end
 
-      # Iterates through current request data and kept data
+      # Returns a new array with the results of running block once for every
+      # element in the current hash
       #
-      # @param blk [Proc]
+      # @param block [Proc]
       # @return [Array]
       #
       # @since 1.2.0
       # @api public
-      def map(&blk)
-        @flash.map(&blk)
+      def map(&block)
+        @flash.map(&block)
       end
 
-      # Check if flash is empty.
+      # Returns `true` if the current hash contains no elements.
       #
-      # @return [TrueClass,FalseClass] the result of the check
+      # @return [Boolean]
       #
       # @since 0.3.0
       # @api public
@@ -96,9 +93,9 @@ module Hanami
         @flash.empty?
       end
 
-      # Check if there is a value associated with the given key.
+      # Returns `true` if the given key is present in the current hash.
       #
-      # @return [TrueClass,FalseClass] the result of the check
+      # @return [Boolean]
       #
       # @since 2.0.0
       # @api public

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -10,7 +10,7 @@ module Hanami
     #
     # @since 0.3.0
     # @api public
-    class Flash < DelegateClass(Hash)
+    class Flash
       # @return [Hash] The flash hash for the next request, written to by {#[]=}.
       #
       # @see #[]=
@@ -26,7 +26,7 @@ module Hanami
       # @since 0.3.0
       # @api public
       def initialize(hash = {})
-        super(hash || {})
+        @flash = hash || {}
         @next = {}
       end
 
@@ -37,7 +37,19 @@ module Hanami
       # @since 2.0.0
       # @api public
       def now
-        __getobj__
+        @flash
+      end
+
+      # Returns a value associated with the given key
+      #
+      # @param key [Object] the key
+      #
+      # @return value [Object,NilClass] the value
+      #
+      # @since 0.3.0
+      # @api public
+      def [](key)
+        @flash[key]
       end
 
       # Updates the next hash with the given key and value
@@ -49,6 +61,36 @@ module Hanami
       # @api public
       def []=(key, value)
         @next[key] = value
+      end
+
+      # Iterates through current request data and kept data
+      #
+      # @param blk [Proc]
+      #
+      # @since 1.2.0
+      def each(&blk)
+        @flash.each(&blk)
+      end
+
+      # Iterates through current request data and kept data
+      #
+      # @param blk [Proc]
+      # @return [Array]
+      #
+      # @since 1.2.0
+      def map(&blk)
+        @flash.map(&blk)
+      end
+
+      # Check if there are contents stored in the flash from the current or the
+      # previous request.
+      #
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @since 0.3.0
+      # @api private
+      def empty?
+        @flash.empty?
       end
 
       # Removes entries from the next hash
@@ -86,7 +128,7 @@ module Hanami
       # @api public
       def keep(key = (no_arg = true))
         if no_arg
-          @next.merge!(self)
+          @next.merge!(@flash)
         else
           self[key] = self[key]
         end
@@ -97,7 +139,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def sweep
-        replace(@next)
+        @flash = @next.dup
         @next.clear
         self
       end

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -3,27 +3,26 @@ require 'hanami/utils/json'
 module Hanami
   class Action
     class Flash < DelegateClass(Hash)
-      # The flash hash for the next request.  This
-      # is what gets written to by #[]=.
+      # The flash hash for the next request, which gets written to by #[]=
       attr_reader :next
 
       # The flash hash for the current request
       alias now __getobj__
 
-      # Setup the next hash when initializing, and handle treat nil
-      # as a new empty hash.
+      # Setup the next hash when initializing, and treat nil as a new empty
+      # hash
       def initialize(hash = {})
-        super(hash||{})
+        super(hash || {})
         @next = {}
       end
 
-      # Update the next hash with the given key and value.
+      # Update the next hash with the given key and value
       def []=(k, v)
         @next[k] = v
       end
 
-      # Remove given key from the next hash, or clear the next hash if
-      # no argument is given.
+      # Remove given key from the next hash, or clear the next hash if no
+      # argument is given
       def discard(key = nil)
         if key.nil?
           @next.clear
@@ -32,9 +31,9 @@ module Hanami
         end
       end
 
-      # Copy the entry with the given key from the current hash to the
-      # next hash, or copy all entries from the current hash to the
-      # next hash if no argument is given.
+      # Copy the entry with the given key from the current hash to the next
+      # hash, or copy all entries from the current hash to the next hash if no
+      # argument is given
       def keep(key = nil)
         if key.nil?
           @next.merge!(self)
@@ -43,7 +42,7 @@ module Hanami
         end
       end
 
-      # Replace the current hash with the next hash and clear the next hash.
+      # Replace the current hash with the next hash and clear the next hash
       def sweep
         replace(@next)
         @next.clear

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack'
 require 'rack/response'
 require 'hanami/utils/kernel'
@@ -13,23 +15,23 @@ module Hanami
     class Response < ::Rack::Response
       DEFAULT_VIEW_OPTIONS = -> * { {} }.freeze
 
-      REQUEST_METHOD = "REQUEST_METHOD".freeze
-      HTTP_ACCEPT = "HTTP_ACCEPT".freeze
-      SESSION_KEY = "rack.session".freeze
-      REQUEST_ID  = "hanami.request_id".freeze
-      LOCATION    = "Location".freeze
+      REQUEST_METHOD = "REQUEST_METHOD"
+      HTTP_ACCEPT = "HTTP_ACCEPT"
+      SESSION_KEY = "rack.session"
+      REQUEST_ID  = "hanami.request_id"
+      LOCATION    = "Location"
 
-      X_CASCADE = "X-Cascade".freeze
-      CONTENT_LENGTH = "Content-Length".freeze
+      X_CASCADE = "X-Cascade"
+      CONTENT_LENGTH = "Content-Length"
       NOT_FOUND = 404
 
       RACK_STATUS  = 0
       RACK_HEADERS = 1
       RACK_BODY    = 2
 
-      HEAD = "HEAD".freeze
+      HEAD = "HEAD"
 
-      FLASH_SESSION_KEY = "_flash".freeze
+      FLASH_SESSION_KEY = "_flash"
 
       EMPTY_BODY = [].freeze
 

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -29,6 +29,8 @@ module Hanami
 
       HEAD = "HEAD".freeze
 
+      FLASH_SESSION_KEY = "_flash".freeze
+
       EMPTY_BODY = [].freeze
 
       FILE_SYSTEM_ROOT = Pathname.new("/").freeze
@@ -98,7 +100,7 @@ module Hanami
       end
 
       def flash
-        @flash ||= Flash.new(session[:_flash])
+        @flash ||= Flash.new(session[FLASH_SESSION_KEY])
       end
 
       def redirect_to(url, status: 302)

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -98,14 +98,11 @@ module Hanami
       end
 
       def flash
-        @flash ||= Flash.new(session)
+        @flash ||= Flash.new(session[:_flash])
       end
 
       def redirect_to(url, status: 302)
         return unless renderable?
-
-        # This trick avoids to instantiate `flash` if it wasn't already.
-        flash.keep! if defined?(@flash)
 
         redirect(::String.new(url), status)
         Halt.call(status)

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -16,17 +16,6 @@ module Hanami
 
       private
 
-      # Container useful to transport data with the HTTP session
-      #
-      # @return [Hanami::Action::Flash] a Flash instance
-      #
-      # @since 0.3.0
-      #
-      # @see Hanami::Action::Flash
-      def flash
-        @flash ||= Flash.new(session)
-      end
-
       # Finalize the response
       #
       # @return [void]
@@ -36,9 +25,12 @@ module Hanami
       #
       # @see Hanami::Action#finish
       def finish(req, res, *)
-        res.flash.clear
-        res[:session] = res.session
-        res[:flash]   = res.flash
+        if (next_flash = res.flash.next).any?
+          res.session['_flash'] = next_flash
+        else
+          res.session.delete('_flash')
+        end
+
         super
       end
     end

--- a/lib/hanami/action/standalone_action.rb
+++ b/lib/hanami/action/standalone_action.rb
@@ -574,17 +574,6 @@ module Hanami
           raise Hanami::Controller::MissingSessionError.new(:session)
         end
 
-        # Raise error when `Hanami::Action::Session` isn't included.
-        #
-        # To use `flash`, include `Hanami::Action::Session`.
-        #
-        # @raise [Hanami::Controller::MissingSessionError]
-        #
-        # @since 1.2.0
-        def flash
-          raise Hanami::Controller::MissingSessionError.new(:flash)
-        end
-
         # Finalize the response
         #
         # This method is abstract and COULD be implemented by included modules in

--- a/lib/hanami/action/standalone_action.rb
+++ b/lib/hanami/action/standalone_action.rb
@@ -563,17 +563,6 @@ module Hanami
           end
         end
 
-        # Raise error when `Hanami::Action::Session` isn't included.
-        #
-        # To use `session`, include `Hanami::Action::Session`.
-        #
-        # @raise [Hanami::Controller::MissingSessionError]
-        #
-        # @since 1.2.0
-        def session
-          raise Hanami::Controller::MissingSessionError.new(:session)
-        end
-
         # Finalize the response
         #
         # This method is abstract and COULD be implemented by included modules in

--- a/lib/hanami/controller.rb
+++ b/lib/hanami/controller.rb
@@ -44,21 +44,5 @@ module Hanami
         super("Cannot find a corresponding Mime type for '#{ format }'. Please configure it with Hanami::Controller::Configuration#format.")
       end
     end
-
-    # Missing session error
-    #
-    # This error is raised when an action sends either `session` or `flash` to
-    # itself and it does not include `Hanami::Action::Session`.
-    #
-    # @since 1.2.0
-    #
-    # @see Hanami::Action::Session
-    # @see Hanami::Action#session
-    # @see Hanami::Action#flash
-    class MissingSessionError < Hanami::Controller::Error
-      def initialize(session_method)
-        super("To use `#{session_method}', add `include Hanami::Action::Session`.")
-      end
-    end
   end
 end

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Flash application" do
     get "/"
     follow_redirect!
 
-    expect(last_response.body).to match(/Hanami::Action::Flash:0x[\d\w]* {:data=>{}, :kept=>{"hello"=>"world"}}/)
+    expect(last_response.body).to match(/{:hello=>"world"}/)
     expect(last_response.body).to match(/flash_empty: false/)
   end
 
@@ -27,7 +27,7 @@ RSpec.describe "Flash application" do
       get "/each_redirect"
       follow_redirect!
 
-      expect(last_response.body).to match(/flash_each: \[\["hello", "world"\]\]/)
+      expect(last_response.body).to match(/flash_each: \[\[:hello, "world"\]\]/)
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe "Flash application" do
       get "/map_redirect"
       follow_redirect!
 
-      expect(last_response.body).to match(/flash_map: \[\["hello", "world"\]\]/)
+      expect(last_response.body).to match(/flash_map: \[\[:hello, "world"\]\]/)
     end
   end
 end

--- a/spec/support/renderer.rb
+++ b/spec/support/renderer.rb
@@ -26,7 +26,7 @@ class Renderer
     return unless response.respond_to?(:status)
 
     if response.status == 200
-      response.body = "#{action.class.name} #{response.exposures} params: #{response[:params].to_h} flash: #{response[:flash].inspect}"
+      response.body = "#{action.class.name} #{response.exposures} params: #{response[:params].to_h} flash: #{response.session[:_flash].inspect}"
     end
 
     true

--- a/spec/unit/hanami/action/flash_spec.rb
+++ b/spec/unit/hanami/action/flash_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe Hanami::Action::Flash do
     it "returns raw data for the current request" do
       expect(flash.now).to be(input_hash)
     end
-
-    it "is aliased as #to_h" do
-      expect(flash.to_h).to be(input_hash)
-    end
   end
 
   describe "#next" do

--- a/spec/unit/hanami/action/flash_spec.rb
+++ b/spec/unit/hanami/action/flash_spec.rb
@@ -1,0 +1,134 @@
+require "hanami/action/flash"
+
+RSpec.describe Hanami::Action::Flash do
+  let(:flash) { described_class.new(input_hash) }
+  let(:input_hash) { {} }
+
+  describe ".new" do
+    context "nil given" do
+      let(:input_hash) { nil }
+
+      it "creates an empty hash" do
+        expect(flash.now).to eq({})
+        expect(flash.next).to eq({})
+      end
+    end
+
+    context "existing hash given" do
+      let(:input_hash) { {1 => 2} }
+
+      it "assigns the hash as the now hash" do
+        expect(flash.now).to eq(1=>2)
+        expect(flash.next).to eq({})
+      end
+    end
+  end
+
+  describe "#[]=" do
+    it "asigns to the next hash" do
+      expect { flash[:a] = "val" }
+        .to change { flash.next }
+        .to(a: "val")
+    end
+  end
+
+  describe "#discard" do
+    context "key argument given" do
+      before do
+        flash[:a] = "a val"
+        flash[:b] = "b val"
+      end
+
+      it "removes the given key from the next hash" do
+        expect { flash.discard :a }
+          .to change { flash.next }
+          .from(a: "a val", b: "b val")
+          .to(b: "b val")
+
+        expect { flash.discard :b }
+          .to change { flash.next }
+          .to({})
+      end
+    end
+
+    context "nil key argument given" do
+      before do
+        flash[:a] = "a val"
+        flash[nil] = "nil val"
+      end
+
+      it "removes the given key from the next hash" do
+        expect { flash.discard nil }
+          .to change { flash.next }
+          .from(a: "a val", nil => "nil val")
+          .to(a: "a val")
+      end
+    end
+
+    context "no argument given" do
+      before do
+        flash[:a] = "a val"
+      end
+
+      it "removes all entries from the next hash" do
+        expect { flash.discard }
+          .to change { flash.next }
+          .from(a: "a val")
+          .to({})
+      end
+    end
+  end
+
+  describe "#keep" do
+    context "key argument given" do
+      before do
+        flash.now[:a] = "val"
+      end
+
+      it "copies entry for key from current hash to next hash" do
+        expect { flash.keep(:a) }
+          .to change { flash.next }
+          .from({})
+          .to(a: "val")
+      end
+    end
+
+    context "nil key argument given" do
+      before do
+        flash.now[nil] = "val"
+      end
+
+      it "copies entry for key from current hash to next hash" do
+        expect { flash.keep(nil) }
+          .to change { flash.next }
+          .from({})
+          .to(nil => "val")
+      end
+    end
+
+    context "no argument given" do
+      before do
+        flash.now[:a] = "val"
+      end
+
+      it "copies all entries from current hash to next hash" do
+        expect { flash.keep }
+          .to change { flash.next }
+          .from({})
+          .to(a: "val")
+      end
+    end
+  end
+
+  describe "#sweep" do
+    before do
+      flash[:a] = "val"
+    end
+
+    it "replaces the now hash with the next hash" do
+      expect { flash.sweep }
+        .to change { flash.next }.from(a: "val").to({})
+        .and change { flash.now }.from({}).to(a: "val")
+    end
+  end
+end

--- a/spec/unit/hanami/action/flash_spec.rb
+++ b/spec/unit/hanami/action/flash_spec.rb
@@ -24,11 +24,83 @@ RSpec.describe Hanami::Action::Flash do
     end
   end
 
+  describe "#now" do
+    let(:input_hash) { { a: "val" } }
+
+    it "returns raw data for the current request" do
+      expect(flash.now).to be(input_hash)
+    end
+
+    it "is aliased as #to_h" do
+      expect(flash.to_h).to be(input_hash)
+    end
+  end
+
+  describe "#next" do
+    it "returns raw data for the current request" do
+      flash[:a] = "val"
+      expect(flash.next).to eq(a: "val")
+    end
+  end
+
+  describe "#[]" do
+    let(:input_hash) { {a: "val"} }
+
+    it "reads from the current request hash" do
+      flash[:b] = "val2"
+
+      expect(flash[:a]).to eq("val")
+      expect(flash[:b]).to be(nil)
+    end
+  end
+
   describe "#[]=" do
-    it "asigns to the next hash" do
+    it "assigns to the next hash" do
       expect { flash[:a] = "val" }
         .to change { flash.next }
         .to(a: "val")
+    end
+  end
+
+  describe "#each" do
+    let(:input_hash) { {a: "val"} }
+
+    it "iterates data" do
+      accumulator = []
+
+      flash.each do |k, v|
+        accumulator << [k, v]
+      end
+
+      expect(accumulator).to eq(input_hash.to_a)
+    end
+  end
+
+  describe "#map" do
+    let(:input_hash) { {a: "val"} }
+
+    it "iterates data and returns an Array" do
+      accumulator = flash.map do |k, v|
+        [k, v]
+      end
+
+      expect(accumulator).to eq(input_hash.to_a)
+    end
+  end
+
+  describe "#empty?" do
+    it "checks if current request data is empty" do
+      expect(flash.empty?).to be(true)
+    end
+  end
+
+  describe "#key?" do
+    let(:input_hash) { {a: "val"} }
+
+    it "checks if current request data has a value associated with the given key" do
+      expect(flash.key?(:a)).to be(true)
+      expect(flash.key?("a")).to be(false)
+      expect(flash.key?(:b)).to be(false)
     end
   end
 

--- a/spec/unit/hanami/action/session_spec.rb
+++ b/spec/unit/hanami/action/session_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe Hanami::Action do
       expect(response.session).to eq({})
     end
 
-    it "exposes session" do
-      action = SessionAction.new
-      response = action.call("rack.session" => { "foo" => "bar" })
-
-      expect(response[:session]).to eq(foo: "bar")
-    end
-
     it "allows value access via symbols" do
       action   = SessionAction.new
       response = action.call("rack.session" => { "foo" => "bar" })
@@ -30,39 +23,38 @@ RSpec.describe Hanami::Action do
   end
 
   describe "flash" do
-    it "exposes flash" do
-      action = FlashAction.new
-      response = action.call({})
+    # it "exposes flash" do
+    #   action = FlashAction.new
+    #   response = action.call({})
 
-      expect(response[:flash]).to be_kind_of(Hanami::Action::Flash)
-      expect(response[:flash][:error]).to eq("ouch")
-    end
+    #   expect(response[:flash][:error]).to eq("ouch")
+    # end
 
-    describe "#each" do
-      it "iterates through data" do
-        action = FlashAction.new
-        response = action.call({})
+    # describe "#each" do
+    #   it "iterates through data" do
+    #     action = FlashAction.new
+    #     response = action.call({})
 
-        result = []
-        response.flash.each do |type, message|
-          result << [type, message]
-        end
+    #     result = []
+    #     response[:flash].each do |type, message|
+    #       result << [type, message]
+    #     end
 
-        expect(result).to eq([[:error, "ouch"]])
-      end
-    end
+    #     expect(result).to eq([[:error, "ouch"]])
+    #   end
+    # end
 
-    describe "#map" do
-      it "iterates through data" do
-        action = FlashAction.new
-        response = action.call({})
+    # describe "#map" do
+    #   it "iterates through data" do
+    #     action = FlashAction.new
+    #     response = action.call({})
 
-        result = response.flash.map do |type, message|
-          [type, message]
-        end
+    #     result = response.flash.map do |type, message|
+    #       [type, message]
+    #     end
 
-        expect(result).to eq([[:error, "ouch"]])
-      end
-    end
+    #     expect(result).to eq([[:error, "ouch"]])
+    #   end
+    # end
   end
 end

--- a/spec/unit/hanami/action/session_spec.rb
+++ b/spec/unit/hanami/action/session_spec.rb
@@ -21,40 +21,4 @@ RSpec.describe Hanami::Action do
       expect(response.session[:foo]).to eq("bar")
     end
   end
-
-  describe "flash" do
-    # it "exposes flash" do
-    #   action = FlashAction.new
-    #   response = action.call({})
-
-    #   expect(response[:flash][:error]).to eq("ouch")
-    # end
-
-    # describe "#each" do
-    #   it "iterates through data" do
-    #     action = FlashAction.new
-    #     response = action.call({})
-
-    #     result = []
-    #     response[:flash].each do |type, message|
-    #       result << [type, message]
-    #     end
-
-    #     expect(result).to eq([[:error, "ouch"]])
-    #   end
-    # end
-
-    # describe "#map" do
-    #   it "iterates through data" do
-    #     action = FlashAction.new
-    #     response = action.call({})
-
-    #     result = response.flash.map do |type, message|
-    #       [type, message]
-    #     end
-
-    #     expect(result).to eq([[:error, "ouch"]])
-    #   end
-    # end
-  end
 end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -144,20 +144,6 @@ RSpec.describe Hanami::Action do
         expect(response.body).to   eq([])
       end
     end
-
-    context "when invoking the session method with sessions disabled" do
-      it "raises an informative exception" do
-        expected = Hanami::Controller::MissingSessionError
-        expect { MissingSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
-      end
-    end
-
-    context "when invoking the flash method with sessions disabled" do
-      it "raises an informative exception" do
-        expected = Hanami::Controller::MissingSessionError
-        expect { MissingFlashAction.new.call({}) }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
-      end
-    end
   end
 
   describe "#name" do


### PR DESCRIPTION
Our Flash object was very complicated, and did not work like you'd expect (i.e. it didn't behave identically to the flash from Rails or other Ruby web toolkits). For example, in some manual testing, I had to explicitly call `.keep!` to keep added flash messages around for the next request.

This PR drops in in the `Flash` object from Roda, along with its matching unit tests, and ensures existing integration tests continue to pass.

Along with this, it also removes the `#flash` and `#session` instance methods from `Action`, which are no longer needed now actions are stateless and both the session and flash are accessible off the `response` objects.