### PR TITLE
Reintroduce CSRFProtection module

### DIFF
--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -1,0 +1,214 @@
+require "hanami/utils/blank"
+require "rack/utils"
+require "securerandom"
+
+module Hanami
+  # @api private
+  class Action
+    # Invalid CSRF Token
+    #
+    # @since 0.4.0
+    class InvalidCSRFTokenError < ::StandardError
+    end
+
+    # CSRF Protection
+    #
+    # This security mechanism is enabled automatically if sessions are turned on.
+    #
+    # It stores a "challenge" token in session. For each "state changing request"
+    # (eg. <tt>POST</tt>, <tt>PATCH</tt> etc..), we should send a special param:
+    # <tt>_csrf_token</tt>.
+    #
+    # If the param matches with the challenge token, the flow can continue.
+    # Otherwise the application detects an attack attempt, it reset the session
+    # and <tt>Hanami::Action::InvalidCSRFTokenError</tt> is raised.
+    #
+    # We can specify a custom handling strategy, by overriding <tt>#handle_invalid_csrf_token</tt>.
+    #
+    # Form helper (<tt>#form_for</tt>) automatically sets a hidden field with the
+    # correct token. A special view method (<tt>#csrf_token</tt>) is available in
+    # case the form markup is manually crafted.
+    #
+    # We can disable this check on action basis, by overriding <tt>#verify_csrf_token?</tt>.
+    #
+    # @since 0.4.0
+    #
+    # @see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29
+    # @see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
+    #
+    # @example Custom Handling
+    #   module Web::Controllers::Books
+    #     class Create
+    #       include Web::Action
+    #
+    #       def call(params)
+    #         # ...
+    #       end
+    #
+    #       private
+    #
+    #       def handle_invalid_csrf_token
+    #         Web::Logger.warn "CSRF attack: expected #{ session[:_csrf_token] }, was #{ params[:_csrf_token] }"
+    #         # manual handling
+    #       end
+    #     end
+    #   end
+    #
+    # @example Bypass Security Check
+    #   module Web::Controllers::Books
+    #     class Create
+    #       include Web::Action
+    #
+    #       def call(params)
+    #         # ...
+    #       end
+    #
+    #       private
+    #
+    #       def verify_csrf_token?
+    #         false
+    #       end
+    #     end
+    #   end
+    module CSRFProtection
+      # Session and params key for CSRF token.
+      #
+      # This key is shared with <tt>hanami-controller</tt> and <tt>hanami-helpers</tt>
+      #
+      # @since 0.4.0
+      # @api private
+      CSRF_TOKEN = :_csrf_token
+
+      # Idempotent HTTP methods
+      #
+      # By default, the check isn't performed if the request method is included
+      # in this list.
+      #
+      # @since 0.4.0
+      # @api private
+      IDEMPOTENT_HTTP_METHODS = Hash[
+        "GET" => true,
+        "HEAD" => true,
+        "TRACE" => true,
+        "OPTIONS" => true
+      ].freeze
+
+      # @since 0.4.0
+      # @api private
+      def self.included(action)
+        action.class_eval do
+          before :set_csrf_token, :verify_csrf_token
+        end unless Hanami.respond_to?(:env?) && Hanami.env?(:test)
+      end
+
+      private
+
+      # Set CSRF Token in session
+      #
+      # @since 0.4.0
+      # @api private
+      def set_csrf_token(req, res)
+        res.session[CSRF_TOKEN] ||= generate_csrf_token
+      end
+
+      # Verify if CSRF token from params, matches the one stored in session.
+      # If not, it raises an error.
+      #
+      # Don't override this method.
+      #
+      # To bypass the security check, please override <tt>#verify_csrf_token?</tt>.
+      # For custom handling of an attack, please override <tt>#handle_invalid_csrf_token</tt>.
+      #
+      # @since 0.4.0
+      # @api private
+      def verify_csrf_token(req, res)
+        handle_invalid_csrf_token(req, res) if invalid_csrf_token?(req, res)
+      end
+
+      # Verify if CSRF token from params, matches the one stored in session.
+      #
+      # Don't override this method.
+      #
+      # @since 0.4.0
+      # @api private
+      def invalid_csrf_token?(req, res)
+        return false unless verify_csrf_token?(req, res)
+
+        missing_csrf_token?(req, res) ||
+          !::Rack::Utils.secure_compare(req.session[CSRF_TOKEN], req.params[CSRF_TOKEN])
+      end
+
+      # Verify the CSRF token was passed in params.
+      #
+      # @api private
+      def missing_csrf_token?(req, res)
+        Hanami::Utils::Blank.blank?(req.params[CSRF_TOKEN])
+      end
+
+      # Generates a random CSRF Token
+      #
+      # @since 0.4.0
+      # @api private
+      def generate_csrf_token
+        SecureRandom.hex(32)
+      end
+
+      # Decide if perform the check or not.
+      #
+      # Override and return <tt>false</tt> if you want to bypass security check.
+      #
+      # @since 0.4.0
+      #
+      # @example
+      #   module Web::Controllers::Books
+      #     class Create
+      #       include Web::Action
+      #
+      #       def call(params)
+      #         # ...
+      #       end
+      #
+      #       private
+      #
+      #       def verify_csrf_token?
+      #         false
+      #       end
+      #     end
+      #   end
+      def verify_csrf_token?(req, res)
+        !IDEMPOTENT_HTTP_METHODS[req.request_method]
+      end
+
+      # Handle CSRF attack.
+      #
+      # The default policy resets the session and raises an exception.
+      #
+      # Override this method, for custom handling.
+      #
+      # @raise [Hanami::Action::InvalidCSRFTokenError]
+      #
+      # @since 0.4.0
+      #
+      # @example
+      #   module Web::Controllers::Books
+      #     class Create
+      #       include Web::Action
+      #
+      #       def call(params)
+      #         # ...
+      #       end
+      #
+      #       private
+      #
+      #       def handle_invalid_csrf_token
+      #         # custom invalid CSRF management goes here
+      #       end
+      #     end
+      #   end
+      def handle_invalid_csrf_token(req, res)
+        res.session.clear
+        raise InvalidCSRFTokenError
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/action/csrf_protection_spec.rb
+++ b/spec/unit/hanami/action/csrf_protection_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "hanami/action"
+require "hanami/action/csrf_protection"
+
+RSpec.describe Hanami::Action::CSRFProtection do
+  subject(:action) {
+    Class.new(Hanami::Action) {
+      include Hanami::Action::CSRFProtection
+    }.new
+  }
+
+  let(:response) { action.(request) }
+
+  describe "Requests requiring protection (Non-idempotent request methods)" do
+    let(:request) { {"REQUEST_METHOD" => "POST"} }
+
+    context "No existing session" do
+      let(:request) { super().merge("rack.session" => {}) }
+
+      context "non-matching CSRF token in request" do
+        let(:request) { super().merge(_csrf_token: "non-matching") }
+
+        it "rejects the request" do
+          expect { response }.to raise_error Hanami::Action::InvalidCSRFTokenError
+        end
+      end
+
+      context "missing CSRF token in request" do
+        it "rejects the request" do
+          expect { response }.to raise_error Hanami::Action::InvalidCSRFTokenError
+        end
+      end
+    end
+
+    context "Existing session" do
+      let(:request) { super().merge("rack.session" => session) }
+      let(:session) { {_csrf_token: session_token} }
+      let(:session_token) { "abc123" }
+
+      context "matching CSRF token in request" do
+        let(:request) { super().merge(_csrf_token: session_token) }
+
+        it "accepts the request" do
+          expect(response.status).to eq 200
+        end
+      end
+
+      context "non-matching CSRF token in request" do
+        let(:request) { super().merge(_csrf_token: "non-matching") }
+
+        it "rejects the request" do
+          expect { response }.to raise_error Hanami::Action::InvalidCSRFTokenError
+        end
+      end
+
+      context "missing CSRF token in request" do
+        it "rejects the request" do
+          expect { response }.to raise_error Hanami::Action::InvalidCSRFTokenError
+        end
+      end
+
+      context "CSRF checks skipped" do
+        subject(:action) {
+          Class.new(Hanami::Action) {
+            include Hanami::Action::CSRFProtection
+
+            def verify_csrf_token?(req, res)
+              false
+            end
+          }.new
+        }
+
+        context "missing CSRF token in request" do
+          it "accepts the request" do
+            expect(response.status).to eq 200
+          end
+        end
+
+        context "non-matching CSRF token in request" do
+          let(:request) { super().merge(_csrf_token: "non-matching") }
+
+          it "accepts the request" do
+            expect(response.status).to eq 200
+          end
+        end
+      end
+    end
+  end
+
+  context "Requests not requiring protection (Idempotent request methods)" do
+    %w[GET HEAD TRACE OPTIONS].each do |request_method|
+      describe request_method do
+        let(:request) { {"REQUEST_METHOD" => request_method} }
+
+        context "No existing session" do
+          it "sets a CSRF token in the response session" do
+            expect(response.session[:_csrf_token]).to be_a_kind_of String
+          end
+        end
+
+        context "Existing session" do
+          let(:request) { super().merge("rack.session" => session) }
+          let(:session) { {_csrf_token: session_token} }
+          let(:session_token) { "abc123" }
+
+          it "includes the existing CSRF token in the response session" do
+            expect(response.session[:_csrf_token]).to eq session_token
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This module disappeared from the hanami repo during the beginnings of the 2.0 overhaul. Adding it back to hanami-controller makes sense, since this is where the CSRF protection will be taking place.

This introduces the module (and some corresponding shiny new unit tests), but does not yet automatically enable it if sessions are enabled. I'll do the automatic enablement in a follow-up PR.