### PR TITLE
Enable CSRF protection automatically

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -16,6 +16,7 @@ module Hanami
 
         define_initialize action_class
         configure_action action_class
+        extend_behavior action_class
       end
 
       def inspect
@@ -63,6 +64,13 @@ module Hanami
         action_class.config.settings.each do |setting|
           application_value = application.config.actions.public_send(:"#{setting}")
           action_class.config.public_send :"#{setting}=", application_value
+        end
+      end
+
+      def extend_behavior(action_class)
+        if application.config.actions.csrf_protection
+          require "hanami/action/csrf_protection"
+          action_class.include Hanami::Action::CSRFProtection
         end
       end
 

--- a/lib/hanami/action/application_configuration.rb
+++ b/lib/hanami/action/application_configuration.rb
@@ -8,6 +8,7 @@ module Hanami
     class ApplicationConfiguration
       include Dry::Configurable
 
+      setting :csrf_protection
       setting :name_inference_base, "actions"
       setting :view_context_identifier, "view.context"
       setting :view_name_inferrer, ViewNameInferrer
@@ -17,11 +18,22 @@ module Hanami
         _settings << action_setting.dup
       end
 
-      def initialize(*)
-        super
+      def initialize(application_config, *args)
+        super(*args)
 
+        @application_config = application_config
+
+        # Adjust defaults for base configuration
         config.default_request_format = :html
         config.default_response_format = :html
+      end
+
+      def finalize!
+        # A nil value for `csrf_protection` means it has not been explicitly configured
+        # (neither true nor false), so we can defaut it to whether sessions are enabled
+        if config.csrf_protection.nil?
+          config.csrf_protection = application_config.sessions.enabled?
+        end
       end
 
       # Returns the list of available settings
@@ -35,6 +47,8 @@ module Hanami
       end
 
       private
+
+      attr_reader :application_config
 
       def method_missing(name, *args, &block)
         if config.respond_to?(name)

--- a/spec/integration/hanami/controller/application_action/csrf_protection_spec.rb
+++ b/spec/integration/hanami/controller/application_action/csrf_protection_spec.rb
@@ -1,0 +1,82 @@
+require "hanami"
+require "hanami/action"
+require "hanami/action/csrf_protection"
+
+RSpec.describe "Application actions / CSRF protection", :application_integration do
+  describe "Outside Hanami app" do
+    subject(:action_class) { Class.new(Hanami::Action) }
+
+    before do
+      allow(Hanami).to receive(:respond_to?).with(:application?) { nil }
+    end
+
+    it "does not have CSRF protection enabled" do
+      expect(action_class.ancestors).not_to include Hanami::Action::CSRFProtection
+    end
+  end
+
+  describe "Inside Hanami app" do
+    before do
+      application_class
+
+      module Main
+      end
+
+      Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+      Hanami.init
+    end
+
+    subject(:action_class) {
+      module Main
+        class Action < Hanami::Action
+        end
+      end
+
+      Main::Action
+    }
+
+    context "application sessions enabled" do
+      context "CSRF protection not explicitly configured" do
+        subject(:application_class) {
+          module TestApp
+            class Application < Hanami::Application
+              config.sessions = :cookie, {secret: "abc123"}
+            end
+          end
+        }
+
+        it "has CSRF protection enabled" do
+          expect(action_class.ancestors).to include Hanami::Action::CSRFProtection
+        end
+      end
+
+      context "CSRF protection explicitly disabled" do
+        subject(:application_class) {
+          module TestApp
+            class Application < Hanami::Application
+              config.sessions = :cookie, {secret: "abc123"}
+              config.actions.csrf_protection = false
+            end
+          end
+        }
+
+        it "does not have CSRF protection enabled" do
+          expect(action_class.ancestors).not_to include Hanami::Action::CSRFProtection
+        end
+      end
+    end
+
+    context "application sessions not enabled" do
+      subject(:application_class) {
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      }
+
+      it "does not have CSRF protection enabled" do
+        expect(action_class.ancestors).not_to include Hanami::Action::CSRFProtection
+      end
+    end
+  end
+end


### PR DESCRIPTION
Enabled CSRF protection automatically on application actions if the application config has `sessions.enabled?`.

Provide a `config.actions.csrf_protection` setting to allow the application author to explicitly opt out of this if they want (by setting it to false).

This behaviour relies on the change in https://github.com/hanami/hanami/pull/1074, which passes the application config object directly to the nested actions config, so it can inspect it and find out whether it has `sessions.enabled?`. Doing it this way felt like a nicer approach than e.g. passing the `sessions` config directly, or making another `sessions_enabled` setting on the actions config and setting that directly from the outside, because both of those feel too specific to this one feature, rather than something that can be generalisable to any 3rd-party provided config objects.

