### PR TITLE
Forward all args from `.new` to `#initialize`

### DIFF
--- a/lib/hanami/action/standalone_action.rb
+++ b/lib/hanami/action/standalone_action.rb
@@ -249,22 +249,22 @@ module Hanami
 
         # Returns a new action
         #
-        # @overload new(**args)
-        #   @param args [Hash] action dependencies
+        # @overload new(**deps, ...)
+        #   @param deps [Hash] action dependencies
         #
-        # @overload new(configuration:, **args)
+        # @overload new(configuration:, **deps, ...)
         #   @param configuration [Hanami::Controller::Configuration] action configuration
-        #   @param args [Hash] action dependencies
+        #   @param deps [Hash] action dependencies
         #
         # @return [Hanami::Action] Action object
         #
         # @since 2.0.0
-        def new(configuration: self.configuration, **args)
+        def new(*args, configuration: self.configuration, **kwargs, &block)
           allocate.tap do |obj|
             obj.instance_variable_set(:@name, Name[name])
             obj.instance_variable_set(:@configuration, configuration.dup.finalize!)
             obj.instance_variable_set(:@accepted_mime_types, Mime.restrict_mime_types(configuration, accepted_formats))
-            obj.send(:initialize, **args)
+            obj.send(:initialize, *args, **kwargs, &block)
             obj.freeze
           end
         end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -49,9 +49,29 @@ RSpec.describe Hanami::Action do
     end
   end
 
-  describe "#initialize" do
+  describe ".new" do
+    let(:action_class) {
+      Class.new(Hanami::Action) do
+        attr_reader :args, :kwargs, :block
+
+        def initialize(*args, **kwargs, &block)
+          @args = args
+          @kwargs = kwargs
+          @block = block
+        end
+      end
+    }
+
     it "instantiates a frozen action" do
       expect(action).to be_frozen
+    end
+
+    it "forwards arguments to `#initialize`" do
+      action = action_class.new(1, 2, 3, a: 4, b: 5) { 6 }
+
+      expect(action.args).to eq([1, 2, 3])
+      expect(action.kwargs).to eq({a: 4, b: 5})
+      expect(action.block.call).to eq(6)
     end
   end
 


### PR DESCRIPTION
Previously only forwarded keyword arguments. Now also forwards
positional and block arguments.

Closes #330