### PR TITLE
Enable CSRF protection automatically

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -16,6 +16,7 @@ module Hanami
 
         define_initialize action_class
         configure_action action_class
+        extend_behavior action_class
       end
 
       def inspect
@@ -63,6 +64,13 @@ module Hanami
         action_class.config.settings.each do |setting|
           application_value = application.config.actions.public_send(:"#{setting}")
           action_class.config.public_send :"#{setting}=", application_value
+        end
+      end
+
+      def extend_behavior(action_class)
+        if application.config.actions.csrf_protection
+          require "hanami/action/csrf_protection"
+          action_class.include Hanami::Action::CSRFProtection
         end
       end
 

--- a/lib/hanami/action/application_configuration.rb
+++ b/lib/hanami/action/application_configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "application_configuration/sessions"
 require_relative "configuration"
 require_relative "view_name_inferrer"
 
@@ -8,20 +9,28 @@ module Hanami
     class ApplicationConfiguration
       include Dry::Configurable
 
+      setting(:sessions) { |storage, *options| Sessions.new(storage, *options) }
+      setting :csrf_protection
+
       setting :name_inference_base, "actions"
       setting :view_context_identifier, "view.context"
       setting :view_name_inferrer, ViewNameInferrer
       setting :view_name_inference_base, "views"
 
-      Configuration._settings.each do |action_setting|
-        _settings << action_setting.dup
-      end
-
       def initialize(*)
         super
 
-        config.default_request_format = :html
-        config.default_response_format = :html
+        @base_configuration = Configuration.new
+
+        # Adjust defaults for base configuration settings
+        self.default_request_format = :html
+        self.default_response_format = :html
+      end
+
+      def finalize!
+        # A nil value for `csrf_protection` means it has not been explicitly configured
+        # (neither true nor false), so we can default it to whether sessions are enabled
+        self.csrf_protection = sessions.enabled? if csrf_protection.nil?
       end
 
       # Returns the list of available settings
@@ -31,21 +40,25 @@ module Hanami
       # @since 2.0.0
       # @api private
       def settings
-        self.class.settings
+        base_configuration.settings + self.class.settings
       end
 
       private
 
+      attr_reader :base_configuration
+
       def method_missing(name, *args, &block)
         if config.respond_to?(name)
           config.public_send(name, *args, &block)
+        elsif base_configuration.respond_to?(name)
+          base_configuration.public_send(name, *args, &block)
         else
           super
         end
       end
 
       def respond_to_missing?(name, _incude_all = false)
-        config.respond_to?(name) || super
+        config.respond_to?(name) || base_configuration.respond_to?(name) || super
       end
     end
   end

--- a/lib/hanami/action/application_configuration/sessions.rb
+++ b/lib/hanami/action/application_configuration/sessions.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "dry/core/constants"
+require "hanami/utils/string"
+require "hanami/utils/class"
+
+module Hanami
+  class Action
+    class ApplicationConfiguration
+      # Configuration for HTTP sessions in Hanami actions
+      #
+      # @since 2.0.0
+      class Sessions
+        attr_reader :storage, :options
+
+        def initialize(storage = nil, *options)
+          @storage = storage
+          @options = options
+        end
+
+        def enabled?
+          !storage.nil?
+        end
+
+        def middleware
+          return [] if !enabled?
+
+          [[storage_middleware, options]]
+        end
+
+        private
+
+        def storage_middleware
+          require_storage
+
+          name = Utils::String.classify(storage)
+          Utils::Class.load!(name, ::Rack::Session)
+        end
+
+        def require_storage
+          require "rack/session/#{storage}"
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/controller/application_action/csrf_protection_spec.rb
+++ b/spec/integration/hanami/controller/application_action/csrf_protection_spec.rb
@@ -1,0 +1,82 @@
+require "hanami"
+require "hanami/action"
+require "hanami/action/csrf_protection"
+
+RSpec.describe "Application actions / CSRF protection", :application_integration do
+  describe "Outside Hanami app" do
+    subject(:action_class) { Class.new(Hanami::Action) }
+
+    before do
+      allow(Hanami).to receive(:respond_to?).with(:application?) { nil }
+    end
+
+    it "does not have CSRF protection enabled" do
+      expect(action_class.ancestors).not_to include Hanami::Action::CSRFProtection
+    end
+  end
+
+  describe "Inside Hanami app" do
+    before do
+      application_class
+
+      module Main
+      end
+
+      Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+      Hanami.init
+    end
+
+    subject(:action_class) {
+      module Main
+        class Action < Hanami::Action
+        end
+      end
+
+      Main::Action
+    }
+
+    context "application sessions enabled" do
+      context "CSRF protection not explicitly configured" do
+        subject(:application_class) {
+          module TestApp
+            class Application < Hanami::Application
+              config.actions.sessions = :cookie, {secret: "abc123"}
+            end
+          end
+        }
+
+        it "has CSRF protection enabled" do
+          expect(action_class.ancestors).to include Hanami::Action::CSRFProtection
+        end
+      end
+
+      context "CSRF protection explicitly disabled" do
+        subject(:application_class) {
+          module TestApp
+            class Application < Hanami::Application
+              config.sessions = :cookie, {secret: "abc123"}
+              config.actions.csrf_protection = false
+            end
+          end
+        }
+
+        it "does not have CSRF protection enabled" do
+          expect(action_class.ancestors).not_to include Hanami::Action::CSRFProtection
+        end
+      end
+    end
+
+    context "application sessions not enabled" do
+      subject(:application_class) {
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      }
+
+      it "does not have CSRF protection enabled" do
+        expect(action_class.ancestors).not_to include Hanami::Action::CSRFProtection
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/controller/application_action/view_integration_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_integration_spec.rb
@@ -3,7 +3,7 @@
 require "hanami"
 require "hanami/action"
 
-RSpec.describe "Application actions / view integration", :application_integration do
+RSpec.describe "Application actions / View integration", :application_integration do
   describe "Outside Hanami app" do
     subject(:action) { Class.new(Hanami::Action).new }
 
@@ -25,10 +25,13 @@ RSpec.describe "Application actions / view integration", :application_integratio
 
       module Main
       end
-
       Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+
+      Hanami.application.tap(&pre_app_init_hook)
       Hanami.init
     end
+
+    let(:pre_app_init_hook) { proc { } }
 
     let(:action_module) { Main }
 
@@ -96,8 +99,13 @@ RSpec.describe "Application actions / view integration", :application_integratio
         context "custom view context identifier" do
           let(:custom_view_context) { double(:custom_view_context) }
 
+          let(:pre_app_init_hook) {
+            proc do |app|
+              app.config.actions.view_context_identifier = "view.custom_context"
+            end
+          }
+
           before do
-            Hanami.application.config.actions.view_context_identifier = "view.custom_context"
             Main::Slice.register "view.custom_context", custom_view_context
           end
 

--- a/spec/unit/hanami/action/application_configuration/csrf_protection_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/csrf_protection_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration, "#csrf_protection" do
+  let(:configuration) { described_class.new }
+  subject(:value) { configuration.csrf_protection }
+
+  context "non-finalized configuration" do
+    it "returns a default of nil" do
+      is_expected.to be_nil
+    end
+
+    it "can be explicitly enabled" do
+      configuration.csrf_protection = true
+      is_expected.to be true
+    end
+
+    it "can be explicitly disabled" do
+      configuration.csrf_protection = false
+      is_expected.to be false
+    end
+  end
+
+  context "finalized configuration" do
+    context "sessions enabled" do
+      before do
+        configuration.sessions = :cookie, {secret: "abc"}
+        configuration.finalize!
+      end
+
+      it "is true" do
+        is_expected.to be true
+      end
+
+      context "explicitly disabled" do
+        before do
+          configuration.csrf_protection = false
+        end
+
+        it "is false" do
+          is_expected.to be false
+        end
+      end
+    end
+
+    context "sessions not enabled" do
+      before do
+        configuration.finalize!
+      end
+
+      it "is true" do
+        is_expected.to be false
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/action/application_configuration/sessions_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/sessions_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration, "#sessions" do
+  let(:configuration) { described_class.new }
+  subject(:sessions) { configuration.sessions }
+
+  context "no session config specified" do
+    it "is not enabled" do
+      expect(sessions).not_to be_enabled
+    end
+
+    it "returns nil storage" do
+      expect(sessions.storage).to be_nil
+    end
+
+    it "returns empty options" do
+      expect(sessions.options).to eq []
+    end
+
+    it "returns no session middleware" do
+      expect(sessions.middleware).to eq []
+    end
+  end
+
+  context "valid session config provided" do
+    before do
+      configuration.sessions = :cookie, {secret: "abc"}
+    end
+
+    it "is enabled" do
+      expect(sessions).to be_enabled
+    end
+
+    it "returns the given storage" do
+      expect(sessions.storage).to eq :cookie
+    end
+
+    it "returns the given options" do
+      expect(sessions.options).to eq [secret: "abc"]
+    end
+
+    it "returns an array of middleware classes and options" do
+      expect(sessions.middleware).to eq [
+        [Rack::Session::Cookie, [secret: "abc"]]
+      ]
+    end
+  end
+end

--- a/spec/unit/hanami/action/application_configuration_spec.rb
+++ b/spec/unit/hanami/action/application_configuration_spec.rb
@@ -4,6 +4,20 @@ require "hanami/action/configuration"
 RSpec.describe Hanami::Action::ApplicationConfiguration do
   subject(:configuration) { described_class.new }
 
+  it "configures base settings" do
+    expect { configuration.default_request_format = :json }
+      .to change { configuration.default_request_format }
+      .to :json
+  end
+
+  it "configures base settings using custom methods" do
+    configuration.formats = {}
+
+    expect { configuration.format json: "application/json" }
+      .to change { configuration.formats }
+      .to("application/json" => :json)
+  end
+
   describe "#settings" do
     it "returns a set of available settings" do
       expect(configuration.settings).to be_a(Set)


### PR DESCRIPTION
Enable CSRF protection automatically on application actions if the application config has `sessions.enabled?`.

What it does is:

- Move the `sessions` config into hanami-controller, so it is accessible via `config.actions.sessions` (as part of `ApplicationConfiguration`)
- Adds a `csrf_protection` setting to `ApplicationConfiguration`, defaulting to `nil`
- Uses `ApplicationConfiguration#finalize!` to set `csrf_protection` to true or false based on whether sessions are enabled (but _only_ if it was previously `nil`, which allows the application author to explicitly disable it if they desire)

This relies upon https://github.com/hanami/hanami/pull/1078, which calls `finalize!` on the `config.actions` and `config.views` objects.

In addition to this, it also makes it possible to use _all_ the public methods on methods on `Hanami::Action::Configuration` when accessing it via an `ApplicationConfiguration`, i.e. via `Hanami.application.config.actions`. To support this, we now delegate to `Hanami::Action::Configuration` as a "base configuration" from within `Hanami::Action::ApplicationConfiguration`, which means all methods work now, not just the defined settings.