### PR TITLE
Remove Action#with

### DIFF
--- a/lib/hanami/action/standalone_action.rb
+++ b/lib/hanami/action/standalone_action.rb
@@ -321,18 +321,6 @@ module Hanami
           @_deps = deps
         end
 
-        # Returns a new copy of the action with new arguments merged with those
-        # previously passed to `.new`
-        #
-        # @param new_args [Hash] new arguments
-        #
-        # @return [Hanami::Action] New action object
-        #
-        # @since 2.0.0
-        def with(**new_args)
-          self.class.new(@_deps.merge(new_args))
-        end
-
         protected
 
         # Hook for subclasses to apply behavior as part of action invocation

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -75,30 +75,6 @@ RSpec.describe Hanami::Action do
     end
   end
 
-  # FIXME #with isn't needed anymore
-  describe "#with" do
-    let(:action_class) {
-      Class.new(Hanami::Action) do
-        attr_reader :dep_one, :dep_two
-
-        def initialize(dep_one:, dep_two:, **deps)
-          @dep_one = dep_one
-          @dep_two = dep_two
-          super
-        end
-      end
-    }
-
-    it "returns a copy of the action with updated options" do
-      action = action_class.new(dep_one: "one", dep_two: "two")
-
-      new_action = action.with(dep_two: "due")
-      expect(new_action).to be_an(action.class)
-      expect(new_action.dep_one).to eq "one"
-      expect(new_action.dep_two).to eq "due"
-    end
-  end
-
   describe "#call" do
     it "calls an action" do
       response = CallAction.new.call({})


### PR DESCRIPTION
This was introduced to make actions compatible with the previous incarnation of Hanami::Router. With the latest changes to the router, it is no longer required.