### PR TITLE
Enable cookie support in application actions, based on config

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -72,6 +72,11 @@ module Hanami
           require "hanami/action/csrf_protection"
           action_class.include Hanami::Action::CSRFProtection
         end
+
+        if application.config.actions.cookies.enabled?
+          require "hanami/action/cookies"
+          action_class.include Hanami::Action::Cookies
+        end
       end
 
       module InstanceMethods

--- a/lib/hanami/action/application_configuration.rb
+++ b/lib/hanami/action/application_configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "application_configuration/cookies"
 require_relative "application_configuration/sessions"
 require_relative "configuration"
 require_relative "view_name_inferrer"
@@ -9,6 +10,7 @@ module Hanami
     class ApplicationConfiguration
       include Dry::Configurable
 
+      setting(:cookies, {}) { |options| Cookies.new(options) }
       setting(:sessions) { |storage, *options| Sessions.new(storage, *options) }
       setting :csrf_protection
 

--- a/lib/hanami/action/application_configuration/cookies.rb
+++ b/lib/hanami/action/application_configuration/cookies.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    class ApplicationConfiguration
+      # Wrapper for application-level configuration of HTTP cookies for Hanami actions.
+      # This decorates the hash of cookie options that is otherwise directly configurable
+      # on actions, and adds the `enabled?` method to allow `ApplicationAction` to
+      # determine whether to include the `Action::Cookies` module.
+      #
+      # @since 2.0.0
+      class Cookies
+        attr_reader :options
+
+        def initialize(options)
+          @options = options
+        end
+
+        def enabled?
+          !options.nil?
+        end
+
+        def to_h
+          options.to_h
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/action/configuration.rb
+++ b/lib/hanami/action/configuration.rb
@@ -333,7 +333,9 @@ module Hanami
       #
       #   @see cookies=
       setting :cookies, {} do |cookie_options|
-        cookie_options.compact
+        # Call `to_h` here to permit `ApplicationConfiguration::Cookies` object to be
+        # provided when application actions are configured
+        cookie_options.to_h.compact
       end
 
       # @!method root_directory=(dir)

--- a/spec/integration/hanami/controller/application_action/cookies_spec.rb
+++ b/spec/integration/hanami/controller/application_action/cookies_spec.rb
@@ -1,0 +1,82 @@
+require "hanami"
+require "hanami/action"
+require "hanami/action/cookies"
+
+RSpec.describe "Application actions / Cookies", :application_integration do
+  describe "Outside Hanami app" do
+    subject(:action_class) { Class.new(Hanami::Action) }
+
+    before do
+      allow(Hanami).to receive(:respond_to?).with(:application?) { nil }
+    end
+
+    it "does not have cookies enabled" do
+      expect(action_class.ancestors).not_to include Hanami::Action::Cookies
+    end
+  end
+
+  describe "Inside Hanami app" do
+    before do
+      module TestApp
+        class Application < Hanami::Application
+        end
+      end
+
+      Hanami.application.instance_eval(&application_hook) if respond_to?(:application_hook)
+
+      module Main
+      end
+
+      Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+
+      Hanami.init
+    end
+
+    subject(:action_class) {
+      module Main
+        class Action < Hanami::Action
+        end
+      end
+
+      Main::Action
+    }
+
+    context "default configuration" do
+      it "has cookie support enabled" do
+        expect(action_class.ancestors).to include Hanami::Action::Cookies
+      end
+    end
+
+    context "custom cookie options given in application-level config" do
+      subject(:application_hook) {
+        proc do
+          config.actions.cookies = {max_age: 300}
+        end
+      }
+
+      it "has cookie support enabled" do
+        expect(action_class.ancestors).to include Hanami::Action::Cookies
+      end
+
+      it "has the cookie options configured" do
+        expect(action_class.config.cookies).to eq(max_age: 300)
+      end
+    end
+
+    context "cookies disabled in application-level config" do
+      subject(:application_hook) {
+        proc do
+          config.actions.cookies = nil
+        end
+      }
+
+      it "does not have cookie support enabled" do
+        expect(action_class.ancestors).not_to include Hanami::Action::Cookies
+      end
+
+      it "has no cookie options configured" do
+        expect(action_class.config.cookies).to eq({})
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/action/application_configuration/cookies_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/cookies_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration, "#cookies" do
+  let(:configuration) { described_class.new }
+  subject(:cookies) { configuration.cookies }
+
+  context "default config" do
+    it "is enabled" do
+      expect(cookies).to be_enabled
+    end
+
+    it "is an empty hash" do
+      expect(cookies.to_h).to eq({})
+    end
+  end
+
+  context "options given" do
+    before do
+      configuration.cookies = {max_age: 300}
+    end
+
+    it "is enabled" do
+      expect(cookies).to be_enabled
+    end
+
+    it "returns the given options" do
+      expect(cookies.to_h).to eq(max_age: 300)
+    end
+  end
+
+  context "nil value given" do
+    before do
+      configuration.cookies = nil
+    end
+
+    it "is not enabled" do
+      expect(cookies).not_to be_enabled
+    end
+
+    it "returns an empty hash" do
+      expect(cookies.to_h).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
For application actions, include the `Action::Cookies` module automatically if cookies are enabled on the application-level actions config (`config.actions.cookies.enabled?`). Along with this, ensure the application-level configured cookie options still properly pass through to the action.

Allow automatic cookie support to be disabled by setting `config.actions.cookies = nil`.