### PR TITLE
What should go here to configure Hanami router?

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ module Web
 end
 
 configuration = Hanami::Controller::Configuration.new
-router = Hanami::Router.new(configuration: configuration, namespace: Web::Controllers) do
+router = Hanami::Router.new(???, namespace: Web::Controllers) do
   get "/books/:id", "books#show"
 end
 ```


### PR DESCRIPTION
If we're using `hanami-router` 2.0.0.alpha3 + `hanami-controller` 2.0.0.alpha1 and attempt to use the syntax as suggested in hanami-controller's README, we see this error:

```
ArgumentError:
  unknown keyword: :configuration
```

We can define routes without this keyword:

```ruby
module Twist
  module Web
    Router = Hanami::Router.new do
      if ENV['APP_ENV'] == "development"
        require 'sidekiq/web'
        mount Sidekiq::Web, at: '/sidekiq'
      end

      post '/graphql', to: Controllers::Graphql::Run.new
      options '/graphql', to: Controllers::Graphql::Run.new

      post '/books/:permalink/receive', to: Controllers::Books::Receive.new

      get '/oauth/authorize', to: Controllers::Oauth::Authorize.new
      get '/oauth/callback', to: Controllers::Oauth::Callback.new
    end
  end
end
```

However, each `new` call here apparently needs a `configuration` keyword:

```
ArgumentError:
  missing keyword: :configuration
# ./lib/twist_web/router.rb:9:in `block in <module:Web>'
```

---

Looks like if I use the `unstable` branches of both `hanami-controller` + `hanami-router`, I can get away without providing a `configuration` key (using the above router configuration). 

So perhaps this PR should be to remove the `configuration` and possibly also the `namespace` options from the `Hanami::Router` call?


