### PR TITLE
Late bind default value of root_directory

### DIFF
--- a/lib/hanami/action/configuration.rb
+++ b/lib/hanami/action/configuration.rb
@@ -364,7 +364,9 @@ module Hanami
       #   @since 1.0.0
       #
       #   @api private
-      setting :root_directory, Dir.pwd do |dir|
+      setting :root_directory do |dir|
+        dir ||= Dir.pwd
+
         Pathname(dir).realpath
       end
 


### PR DESCRIPTION
Previously, putting the default of Dir.pwd directly into the definition of the `root_directory` setting meant that in the case of the Hanami framework integration tests, where applications are created, torn down, and recreated in new working directories, a stale root_directory would be used, and result in errors since its no longer an existent path.

Adjusting this setting to default to Dir.pwd _inside_ the setting’s processor still results in the same default being applied, just without the downsides of it being captured early and persisted.