### PR TITLE
Pass exposures to view (in addition to params)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Complete, fast and testable actions for Rack
 ## v2.0.0.alpha3 - Unreleased
 ### Added
 - [Luca Guidi] Automatically include session behavior in `Hanami::Action` when sessions are enabled via Hanami application config
+- [Sean Collins] Pass exposures from action to view
 
 ### Changed
 - [Tim Riley] (Internal) Updated settings to use updated `setting` API in dry-configurable 0.13.0

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -87,7 +87,7 @@ module Hanami
 
         def handle(request, response)
           if view
-            response.render view, **request.params
+            response.render(view, **request.params, **response.exposures)
           end
         end
 


### PR DESCRIPTION
We should automatically send all exposures (which are definfed with `response[:foo] = :bar`) to the view, when one exists. 

If there are most tests to add for this, let me know and I'd be happy to add them :)