### PR TITLE
Move automatic view rendering to `finish` (from `handle`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Complete, fast and testable actions for Rack
 
 ### Changed
 - [Tim Riley] (Internal) Updated settings to use updated `setting` API in dry-configurable 0.13.0
+- [Sean Collins] Move automatic view rendering from `handle` to `finish`
 
 ## v2.0.0.alpha2 - 2021-05-04
 ### Added

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -87,7 +87,7 @@ module Hanami
 
         def handle(request, response)
           if view
-            response.render view, **request.params
+            response.render(view, **request.params, **response.exposures)
           end
         end
 

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -83,14 +83,6 @@ module Hanami
         attr_reader :view
         attr_reader :view_context
 
-        protected
-
-        def handle(request, response)
-          if view
-            response.render(view, **request.params, **response.exposures)
-          end
-        end
-
         private
 
         def build_response(**options)
@@ -104,6 +96,12 @@ module Hanami
 
         def view_context_options(req, res)
           {request: req, response: res}
+        end
+
+        # Automatically render the view, if the body hasn't been populated yet
+        def finish(req, res, halted)
+          res.render(view, **req.params, **res.exposures) if view && res.body.empty?
+          super
         end
       end
     end

--- a/lib/hanami/action/standalone_action.rb
+++ b/lib/hanami/action/standalone_action.rb
@@ -553,9 +553,7 @@ module Hanami
 
         # Finalize the response
         #
-        # This method is abstract and COULD be implemented by included modules in
-        # order to prepare their data before the response will be returned to the
-        # webserver.
+        # Prepare the data before the response will be returned to the webserver
         #
         # @since 0.1.0
         # @api private

--- a/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
             class Test < Hanami::Action
               def handle(req, res)
                 res[:favorite_number] = 123
-                super
               end
             end
           end
@@ -40,6 +39,88 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
 
       expect(rendered).to eq "<html><body><h1>Hello, Jennifer. Your favorite number is 123, right?</h1></body></html>"
       expect(response.status).to eq 200
+    end
+  end
+
+  it "Doesn't render view automatically when body is already assigned" do
+    within_app do
+      write "slices/main/lib/main/actions/test.rb", <<~RUBY
+        require "hanami/action"
+
+        module Main
+          module Actions
+            class Test < Hanami::Action
+              def handle(req, res)
+                res.body = "200: Okay okay okay"
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/lib/main/views/test.rb", <<~RUBY
+        module Main
+          module Views
+            class Test < Main::View
+              expose :name, :favorite_number
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/web/templates/test.html.slim", <<~'SLIM'
+        h1 Hello, #{name}. Your favorite number is #{favorite_number}, right?
+      SLIM
+
+      require "hanami/init"
+
+      action = Main::Slice["actions.test"]
+      response = action.(name: "Jennifer")
+      rendered = response.body[0]
+
+      expect(rendered).to eq "200: Okay okay okay"
+      expect(response.status).to eq 200
+    end
+  end
+
+  it "Doesn't render view automatically when halt is called" do
+    within_app do
+      write "slices/main/lib/main/actions/test.rb", <<~RUBY
+        require "hanami/action"
+
+        module Main
+          module Actions
+            class Test < Hanami::Action
+              def handle(req, res)
+                halt 404
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/lib/main/views/test.rb", <<~RUBY
+        module Main
+          module Views
+            class Test < Main::View
+              expose :name, :favorite_number
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/web/templates/test.html.slim", <<~'SLIM'
+        h1 Hello, #{name}. Your favorite number is #{favorite_number}, right?
+      SLIM
+
+      require "hanami/init"
+
+      action = Main::Slice["actions.test"]
+      response = action.(name: "Jennifer")
+      rendered = response.body[0]
+
+      expect(rendered).to eq "Not Found"
+      expect(response.status).to eq 404
     end
   end
 


### PR DESCRIPTION
The way `Hanami::Action::ApplicationAction` works right now (which is automatically included in `Hanami::Action`s when in a Hanami application), users will have to remember to include `super` everytime they override `handle` in order to get the automatic view rendering. Implementing that method is the main way people will add functionality to their actions, so forgetting to include a `super` seems like it'll happen a lot and be frustrating for users.

```ruby
module Main
  module Actions
    module Home
      class Index < Main::Action
        def handle(req, res)
          res[:foo] = :bar
          super # This sets res.body with the associated view rendering. If this is removed, nothing is rendered.
        end
      end
    end
  end
end
```

After this PR, that rendering for the view automatically happens (as long as they don't set a `response.body` manually, or `halt` the flow).

```ruby
module Main
  module Actions
    module Home
      class Index < Main::Action
        def handle(req, res)
          res[:foo] = :bar
          # The associated view is rendered and stored in res.body, as long as it's not manually set here.
        end
      end
    end
  end
end
```
This lets users avoid having to write `super` in every implementation of `handle` for their actions.

**NOTE**: This PR is based off the branch for #345. This base branch will need to change to `unstable` if/when that's merged (which should happen first). Wanted to avoid merge conflicts. Happy to rebase this against `unstable` if we want this and not that PR though.