### PR TITLE
Application action: dynamically include behavior according to app configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,5 @@ gem 'hanami-devtools', github: 'hanami/devtools', branch: 'main'
 # associated gem updates)
 gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "master"
 gem "dry-system", github: "dry-rb/dry-system", branch: "master"
+
+gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "enhancement/new-default-acronyms"

--- a/Gemfile
+++ b/Gemfile
@@ -33,5 +33,3 @@ gem 'hanami-devtools', github: 'hanami/devtools', branch: 'main'
 # associated gem updates)
 gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "master"
 gem "dry-system", github: "dry-rb/dry-system", branch: "master"
-
-gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "enhancement/new-default-acronyms"

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -68,6 +68,11 @@ module Hanami
       end
 
       def extend_behavior(action_class)
+        if application.config.actions.sessions.enabled?
+          require "hanami/action/session"
+          action_class.include Hanami::Action::Session
+        end
+
         if application.config.actions.csrf_protection
           require "hanami/action/csrf_protection"
           action_class.include Hanami::Action::CSRFProtection

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -1,5 +1,6 @@
 require 'rack/test'
 require 'hanami/router'
+require 'hanami'
 
 RSpec.describe "HTTP sessions" do
   include Rack::Test::Methods
@@ -70,5 +71,81 @@ RSpec.describe "HTTP Standalone Sessions" do
     get "/"
     expect(response.status).to be(200)
     expect(response.headers.fetch("Set-Cookie")).to match(/\Arack\.session/)
+  end
+end
+
+RSpec.describe "Application actions / HTTP sessions", :application_integration do
+  describe "Outside Hanami app" do
+    subject(:action_class) { Class.new(Hanami::Action) }
+
+    before do
+      allow(Hanami).to receive(:respond_to?).with(:application?) { nil }
+    end
+
+    it "does not have HTTP sessions enabled" do
+      expect(action_class.ancestors).not_to include(Hanami::Action::Session)
+    end
+  end
+
+  describe "Inside Hanami app" do
+    before do
+      application_class
+
+      module Main
+      end
+
+      Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+      Hanami.init
+    end
+
+    subject(:action_class) {
+      module Main
+        class Action < Hanami::Action
+        end
+      end
+
+      Main::Action
+    }
+
+    context "with HTTP sessions enabled" do
+      subject(:application_class) {
+        module TestApp
+          class Application < Hanami::Application
+            config.actions.sessions = :cookie, {secret: "abc123"}
+          end
+        end
+      }
+
+      it "has HTTP sessions enabled" do
+        expect(action_class.ancestors).to include(Hanami::Action::Session)
+      end
+    end
+
+    context "CSRF protection explicitly disabled" do
+      subject(:application_class) {
+        module TestApp
+          class Application < Hanami::Application
+            config.sessions = nil
+          end
+        end
+      }
+
+      it "does not have HTTP sessions enabled" do
+        expect(action_class.ancestors).not_to include(Hanami::Action::Session)
+      end
+    end
+
+    context "HTTP sessions not enabled" do
+      subject(:application_class) {
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      }
+
+      it "does not have HTTP session enabled" do
+        expect(action_class.ancestors).not_to include(Hanami::Action::Session)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Enhancement

Look at the application configuration, and dynamically include behavior if certain features are enabled. The destination of the inclusion is the slice base action (e.g. `Main::Action` or `Admin::Action`).

Check and include:

  - [x] HTTP session (`Hanami::Action::Session`)
  - [x] Cookies (`Hanami::Action::Cookies`) [it was already done by @timriley in #337]
  - [x] CSRF Protection (`Hanami::Action::CSRFProtection`) [it was already done by @timriley in #332]

---

Ref: https://trello.com/c/KANJluUV