### PR TITLE
When configuration public directory isn't set, fallback to default value

### DIFF
--- a/lib/hanami/action/configuration.rb
+++ b/lib/hanami/action/configuration.rb
@@ -407,7 +407,7 @@ module Hanami
       # @see root_directory=
       def public_directory
         # This must be a string, for Rack compatibility
-        root_directory.join(super).to_s
+        root_directory.join(super || DEFAULT_PUBLIC_DIRECTORY).to_s
       end
 
       private

--- a/spec/unit/hanami/action/configuration_spec.rb
+++ b/spec/unit/hanami/action/configuration_spec.rb
@@ -245,5 +245,15 @@ RSpec.describe Hanami::Action::Configuration do
       configuration.public_directory = File.join(__dir__, 'absolute')
       expect(configuration.public_directory).to eql(File.join(root_directory, "absolute"))
     end
+
+    context "when public directory isn't set" do
+      before do
+        configuration.public_directory = nil
+      end
+
+      it "returns default public directory" do
+        expect(configuration.public_directory).to eql(File.join(root_directory, "public"))
+      end
+    end
   end
 end


### PR DESCRIPTION
https://github.com/hanami/hanami-2-application-template/commit/9a23a1b331dc0ee7629099d0d6320a3f341e4885 [crashes](https://gist.github.com/jodosha/99254d58c7e7432830184dc5d4bc5085) when I try to run the specs:

---

The [current implementation](https://github.com/hanami/controller/blob/d59d5b6eda2fa5229f4291bb503c031abd31899e/lib/hanami/action/configuration.rb#L408-L411) of `Hanami::Action::Configuration#public_directory` is:

```ruby
def public_directory
  root_directory.join(super).to_s
end
```

For the App Template `super` returns `nil`, which makes the `Pathname#join` (`root_directory` is an instance of `Pathname`) to crash.

---

This fix aims to fallback to the default value if `super` returns `nil`.

---

**EDIT: ⚠️ I'm not sure this is the right approach. Given the default value is assigned via `dry-configurable`, I would have expected `super` to return the default value, instead of `nil`.**