### PR TITLE
Introduce `Hanami::Action::ApplicationConfiguration#content_security_policy`

### DIFF
--- a/lib/hanami/action/application_configuration.rb
+++ b/lib/hanami/action/application_configuration.rb
@@ -15,7 +15,7 @@ module Hanami
       setting :sessions, constructor: proc { |storage, *options| Sessions.new(storage, *options) }
       setting :csrf_protection
 
-      setting :content_security_policy, default: ContentSecurityPolicy.new
+      setting :content_security_policy, constructor: -> (value) { value === false ? value : ContentSecurityPolicy.new }
 
       setting :name_inference_base, default: "actions"
       setting :view_context_identifier, default: "view.context"

--- a/lib/hanami/action/application_configuration.rb
+++ b/lib/hanami/action/application_configuration.rb
@@ -15,17 +15,23 @@ module Hanami
       setting :sessions, constructor: proc { |storage, *options| Sessions.new(storage, *options) }
       setting :csrf_protection
 
-      setting :content_security_policy, constructor: -> (value) { value === false ? value : ContentSecurityPolicy.new }
-
       setting :name_inference_base, default: "actions"
       setting :view_context_identifier, default: "view.context"
       setting :view_name_inferrer, default: ViewNameInferrer
       setting :view_name_inference_base, default: "views"
 
-      def initialize(*)
-        super
+      attr_accessor :content_security_policy
+
+      def initialize(*, **options)
+        super()
 
         @base_configuration = Configuration.new
+        @content_security_policy = ContentSecurityPolicy.new do |csp|
+          if assets_server_url = options[:assets_server_url]
+            csp[:script_src] += " #{assets_server_url}"
+            csp[:style_src] += " #{assets_server_url}"
+          end
+        end
 
         configure_defaults
       end

--- a/lib/hanami/action/application_configuration/content_security_policy.rb
+++ b/lib/hanami/action/application_configuration/content_security_policy.rb
@@ -9,7 +9,7 @@ module Hanami
       class ContentSecurityPolicy
         # @since 2.0.0
         # @api private
-        def initialize
+        def initialize(&blk)
           @policy = {
             base_uri: "'self'",
             child_src: "'self'",
@@ -26,6 +26,15 @@ module Hanami
             script_src: "'self'",
             style_src: "'self' 'unsafe-inline' https:"
           }
+
+          blk&.(self)
+        end
+
+        # @since 2.0.0
+        # @api private
+        def initialize_copy(original_object)
+          @policy = original_object.instance_variable_get(:@policy).dup
+          super
         end
 
         # Get a CSP setting

--- a/lib/hanami/action/application_configuration/content_security_policy.rb
+++ b/lib/hanami/action/application_configuration/content_security_policy.rb
@@ -52,7 +52,7 @@ module Hanami
         #   end
         # end
         def [](key)
-          @policy.fetch(key, nil)
+          @policy[key]
         end
 
         # Set a CSP setting

--- a/lib/hanami/action/application_configuration/content_security_policy.rb
+++ b/lib/hanami/action/application_configuration/content_security_policy.rb
@@ -80,6 +80,23 @@ module Hanami
           @policy[key] = value
         end
 
+        # Deletes a CSP key
+        #
+        # @param key [Symbol] the underscored name of the CPS setting
+        #
+        # @since 2.0.0
+        # @api public
+        #
+        # @example
+        # module MyApp
+        #   class Application < Hanami::Application
+        #     config.actions.content_security_policy.delete(:object_src)
+        #   end
+        # end
+        def delete(key)
+          @policy.delete(key)
+        end
+
         # @since 2.0.0
         # @api private
         def to_str

--- a/lib/hanami/action/application_configuration/content_security_policy.rb
+++ b/lib/hanami/action/application_configuration/content_security_policy.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    class ApplicationConfiguration
+      # Configuration for Content Security Policy in Hanami applications
+      #
+      # @since 2.0.0
+      class ContentSecurityPolicy
+        # @since 2.0.0
+        # @api private
+        def initialize
+          @policy = {
+            base_uri: "'self'",
+            child_src: "'self'",
+            connect_src: "'self'",
+            default_src: "'none'",
+            font_src: "'self'",
+            form_action: "'self'",
+            frame_ancestors: "'self'",
+            frame_src: "'self'",
+            img_src: "'self' https: data:",
+            media_src: "'self'",
+            object_src: "'none'",
+            plugin_types: "application/pdf",
+            script_src: "'self'",
+            style_src: "'self' 'unsafe-inline' https:"
+          }
+        end
+
+        # Get a CSP setting
+        #
+        # @param key [Symbol] the underscored name of the CPS setting
+        # @return [String,NilClass] the CSP setting, if any
+        #
+        # @since 2.0.0
+        # @api public
+        #
+        # @example
+        # module MyApp
+        #   class Application < Hanami::Application
+        #     config.actions.content_security_policy[:base_uri] # => "'self'"
+        #   end
+        # end
+        def [](key)
+          @policy.fetch(key, nil)
+        end
+
+        # Set a CSP setting
+        #
+        # @param key [Symbol] the underscored name of the CPS setting
+        # @param value [String] the CSP setting value
+        #
+        # @since 2.0.0
+        # @api public
+        #
+        # @example Replace a default value
+        # module MyApp
+        #   class Application < Hanami::Application
+        #     config.actions.content_security_policy[:plugin_types] = nil
+        #   end
+        # end
+        #
+        # @example Append to a default value
+        # module MyApp
+        #   class Application < Hanami::Application
+        #     config.actions.content_security_policy[:script_src] += " https://my.cdn.test"
+        #   end
+        # end
+        def []=(key, value)
+          @policy[key] = value
+        end
+
+        # @since 2.0.0
+        # @api private
+        def to_str
+          @policy.map do |key, value|
+            "#{dasherize(key)} #{value}"
+          end.join(";\n")
+        end
+
+        private
+
+        # @since 2.0.0
+        # @api private
+        def dasherize(key)
+          key.to_s.gsub("_", "-")
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe Hanami::Action::ApplicationConfiguration, "#content_security_poli
 
   context "no CSP config specified" do
     it "has defaults" do
-      configuration = described_class.new
-      content_security_policy = configuration.content_security_policy
-
       expect(content_security_policy[:base_uri]).to eq("'self'")
 
       expected = [

--- a/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
@@ -7,27 +7,40 @@ RSpec.describe Hanami::Action::ApplicationConfiguration, "#content_security_poli
   subject(:content_security_policy) { configuration.content_security_policy }
 
   context "no CSP config specified" do
-    it "has defaults" do
-      expect(content_security_policy[:base_uri]).to eq("'self'")
+    context "without assets_server_url" do
 
-      expected = [
-        %(base-uri 'self';),
-        %(child-src 'self';),
-        %(connect-src 'self';),
-        %(default-src 'none';),
-        %(font-src 'self';),
-        %(form-action 'self';),
-        %(frame-ancestors 'self';),
-        %(frame-src 'self';),
-        %(img-src 'self' https: data:;),
-        %(media-src 'self';),
-        %(object-src 'none';),
-        %(plugin-types application/pdf;),
-        %(script-src 'self';),
-        %(style-src 'self' 'unsafe-inline' https:)
-      ].join("\n")
+      it "has defaults" do
+        expect(content_security_policy[:base_uri]).to eq("'self'")
 
-      expect(content_security_policy.to_str).to eq(expected)
+        expected = [
+          %(base-uri 'self';),
+          %(child-src 'self';),
+          %(connect-src 'self';),
+          %(default-src 'none';),
+          %(font-src 'self';),
+          %(form-action 'self';),
+          %(frame-ancestors 'self';),
+          %(frame-src 'self';),
+          %(img-src 'self' https: data:;),
+          %(media-src 'self';),
+          %(object-src 'none';),
+          %(plugin-types application/pdf;),
+          %(script-src 'self';),
+          %(style-src 'self' 'unsafe-inline' https:)
+        ].join("\n")
+
+        expect(content_security_policy.to_str).to eq(expected)
+      end
+    end
+
+    context "with assets_server_url" do
+      let(:configuration) { described_class.new(assets_server_url: assets_server_url) }
+      let(:assets_server_url) { "http://localhost:8080" }
+
+      it "includes server url" do
+        expect(content_security_policy[:script_src]).to eq("'self' #{assets_server_url}")
+        expect(content_security_policy[:style_src]).to eq("'self' 'unsafe-inline' https: #{assets_server_url}")
+      end
     end
   end
 

--- a/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
@@ -67,6 +67,20 @@ RSpec.describe Hanami::Action::ApplicationConfiguration, "#content_security_poli
       expect(content_security_policy[:plugin_types]).to be(nil)
       expect(content_security_policy.to_str).to match("plugin-types ;")
     end
+
+    it "deletes key" do
+      content_security_policy.delete(:object_src)
+
+      expect(content_security_policy[:object_src]).to be(nil)
+      expect(content_security_policy.to_str).to_not match("object-src")
+    end
+
+    it "adds a custom key" do
+      content_security_policy[:a_custom_key] = "foo"
+
+      expect(content_security_policy[:a_custom_key]).to eq("foo")
+      expect(content_security_policy.to_str).to match("a-custom-key foo")
+    end
   end
 
   context "with CSP enabled" do

--- a/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "hanami/action/application_configuration"
+
+RSpec.describe Hanami::Action::ApplicationConfiguration, "#content_security_policy" do
+  let(:configuration) { described_class.new }
+  subject(:content_security_policy) { configuration.content_security_policy }
+
+  context "no CSP config specified" do
+    it "has defaults" do
+      configuration = described_class.new
+      content_security_policy = configuration.content_security_policy
+
+      expect(content_security_policy[:base_uri]).to eq("'self'")
+
+      expected = [
+        %(base-uri 'self';),
+        %(child-src 'self';),
+        %(connect-src 'self';),
+        %(default-src 'none';),
+        %(font-src 'self';),
+        %(form-action 'self';),
+        %(frame-ancestors 'self';),
+        %(frame-src 'self';),
+        %(img-src 'self' https: data:;),
+        %(media-src 'self';),
+        %(object-src 'none';),
+        %(plugin-types application/pdf;),
+        %(script-src 'self';),
+        %(style-src 'self' 'unsafe-inline' https:)
+      ].join("\n")
+
+      expect(content_security_policy.to_str).to eq(expected)
+    end
+  end
+
+  context "CSP settings specified" do
+    let(:cdn_url) { "https://assets.hanamirb.test" }
+
+    it "appends to default values" do
+      content_security_policy[:script_src] += " #{cdn_url}"
+
+      expect(content_security_policy[:script_src]).to eq("'self' #{cdn_url}")
+      expect(content_security_policy.to_str).to match("'self' #{cdn_url}")
+    end
+
+    it "overrides default values" do
+      content_security_policy[:style_src] = cdn_url
+
+      expect(content_security_policy[:style_src]).to eq(cdn_url)
+      expect(content_security_policy.to_str).to match(cdn_url)
+    end
+
+    it "nullifies value" do
+      content_security_policy[:plugin_types] = nil
+
+      expect(content_security_policy[:plugin_types]).to be(nil)
+      expect(content_security_policy.to_str).to match("plugin-types ;")
+    end
+  end
+
+  context "with CSP enabled" do
+    it "sets default header" do
+      configuration.finalize!
+
+      expect(configuration.default_headers.fetch("Content-Security-Policy")).to eq(content_security_policy.to_str)
+    end
+  end
+
+  context "with CSP disabled" do
+    it "doesn't set default header" do
+      configuration.content_security_policy = false
+      configuration.finalize!
+
+      expect(configuration.default_headers.key?("Content-Security-Policy")).to be(false)
+    end
+  end
+end

--- a/spec/unit/hanami/action/application_configuration/default_values_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/default_values_spec.rb
@@ -32,27 +32,19 @@ RSpec.describe Hanami::Action::ApplicationConfiguration, "default values" do
       specify { expect(configuration.default_response_format).to eq :html }
     end
 
+    describe "content_security_policy" do
+      specify { expect(configuration.content_security_policy).to be_kind_of(Hanami::Action::ApplicationConfiguration::ContentSecurityPolicy) }
+    end
+
     describe "default_headers" do
       specify {
+        configuration.finalize!
+
         expect(configuration.default_headers).to eq(
           "X-Frame-Options" => "DENY",
           "X-Content-Type-Options" => "nosniff",
           "X-XSS-Protection" => "1; mode=block",
-          "Content-Security-Policy" => "" \
-            "base-uri 'self'; " \
-            "child-src 'self'; " \
-            "connect-src 'self'; " \
-            "default-src 'none'; " \
-            "font-src 'self'; " \
-            "form-action 'self'; " \
-            "frame-ancestors 'self'; " \
-            "frame-src 'self'; " \
-            "img-src 'self' https: data:; " \
-            "media-src 'self'; " \
-            "object-src 'none'; " \
-            "plugin-types application/pdf; " \
-            "script-src 'self'; " \
-            "style-src 'self' 'unsafe-inline' https:"
+          "Content-Security-Policy" => configuration.content_security_policy.to_str
         )
       }
     end


### PR DESCRIPTION
## Feature

Provide a human friendly API to interact with Content Security Policy settings.

## Reasoning

Content Security Policy (CSP) is a default HTTP response header.
We have a feature that handles default headers, but giving that CSP is a large blob of text, if a dev needed to alter just a bit, they need to rewrite the entire CSP header. That wasn't human friendly.

This PR introduces an easier API to deal with CSP, by splitting the several settings into a Hash manipulation experience.

## Examples

### Read a setting

```ruby
module MyApp
  class Application < Hanami::Application
    config.actions.content_security_policy[:base_uri] # => "'self'"
  end
end
```

### Override a setting

```ruby
module MyApp
  class Application < Hanami::Application
    # This line will generate the following CSP fragment
    # plugin-types ;
    config.actions.content_security_policy[:plugin_types] = nil
  end
end
```

### Append to a default value

```ruby
module MyApp
  class Application < Hanami::Application
    # This line will generate the following CSP fragment
    # script-src 'self' https://my.cdn.test;
    config.actions.content_security_policy[:script_src] += " https://my.cdn.test"
  end
end
```

### Add a custom setting

```ruby
module MyApp
  class Application < Hanami::Application
    # This line will generate the following CSP fragment
    # my-custom-setting 'self';
    config.actions.content_security_policy[:my-custom-setting] = "'self'"
  end
end
```

### Delete a setting

```ruby
module MyApp
  class Application < Hanami::Application
    config.actions.content_security_policy.delete(:object_src)
  end
end
```

### Disable CSP

```ruby
module MyApp
  class Application < Hanami::Application
    config.actions.content_security_policy = false
  end
end
```
