### PR TITLE
Refactor/standardize spec file paths

### DIFF
--- a/lib/hanami/action/standalone_action.rb
+++ b/lib/hanami/action/standalone_action.rb
@@ -559,7 +559,6 @@ module Hanami
         # @api private
         # @abstract
         #
-        # @see Hanami::Action::Callable#finish
         # @see Hanami::Action::Session#finish
         # @see Hanami::Action::Cookies#finish
         # @see Hanami::Action::Cache#finish

--- a/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
@@ -3,7 +3,7 @@ require "hanami"
 RSpec.describe "Application actions / View rendering / Automatic rendering", :application_integration do
   it "Renders a view automatically, passing all params and exposures" do
     within_app do
-      write "slices/main/lib/actions/test.rb", <<~RUBY
+      write "slices/main/actions/test.rb", <<~RUBY
         require "hanami/action"
 
         module Main
@@ -17,7 +17,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
         end
       RUBY
 
-      write "slices/main/lib/views/test.rb", <<~RUBY
+      write "slices/main/views/test.rb", <<~RUBY
         module Main
           module Views
             class Test < Main::View
@@ -44,7 +44,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
 
   it "Doesn't render view automatically when body is already assigned" do
     within_app do
-      write "slices/main/lib/actions/test.rb", <<~RUBY
+      write "slices/main/actions/test.rb", <<~RUBY
         require "hanami/action"
 
         module Main
@@ -58,7 +58,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
         end
       RUBY
 
-      write "slices/main/lib/views/test.rb", <<~RUBY
+      write "slices/main/views/test.rb", <<~RUBY
         module Main
           module Views
             class Test < Main::View
@@ -85,7 +85,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
 
   it "Doesn't render view automatically when halt is called" do
     within_app do
-      write "slices/main/lib/actions/test.rb", <<~RUBY
+      write "slices/main/actions/test.rb", <<~RUBY
         require "hanami/action"
 
         module Main
@@ -99,7 +99,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
         end
       RUBY
 
-      write "slices/main/lib/views/test.rb", <<~RUBY
+      write "slices/main/views/test.rb", <<~RUBY
         module Main
           module Views
             class Test < Main::View


### PR DESCRIPTION
With https://github.com/hanami/hanami/pull/1123 we use compact source directories. 

The specs work either way, but we should be consistent