### PR TITLE
Extract Hanami::Action::ApplicationAction#render?

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -101,10 +101,14 @@ module Hanami
           {request: req, response: res}
         end
 
-        # Automatically render the view, if the body hasn't been populated yet
         def finish(req, res, halted)
-          res.render(view, **req.params, **res.exposures) if view && res.body.empty?
+          res.render(view, **req.params, **res.exposures) if render?(res)
           super
+        end
+
+        # This can be overridden to enable/disable automatic rendering
+        def render?(res)
+          view && res.body.empty?
         end
       end
     end

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -106,7 +106,15 @@ module Hanami
           super
         end
 
-        # This can be overridden to enable/disable automatic rendering
+        # Decide whether to render the current response with the associated view.
+        # This can be overridden to enable/disable automatic rendering.
+        #
+        # @param response [Hanami::Action::Response]
+        #
+        # @return [TrueClass,FalseClass]
+        #
+        # @since 2.0.0
+        # @api public
         def render?(res)
           view && res.body.empty?
         end


### PR DESCRIPTION
See https://github.com/hanami/controller/pull/346/files\#r744831907Implementing the work suggested in this comment: https://github.com/hanami/controller/pull/346/files#r744831907

We don't have a way to document that it's a part of the public api (e.g. `# @api public`) yet. I expect we'll go through during a later pass and do that then. It would be strange to document just this one method with YARD