### PR TITLE
Raise error for missing view

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -30,7 +30,7 @@ module Hanami
         resolve_context = method(:resolve_view_context)
 
         define_method :initialize do |**deps|
-          # Conditionally assign these to repsect any explictly auto-injected
+          # Conditionally assign these to respect any explictly auto-injected
           # dependencies provided by the class
           @view ||= deps[:view] || resolve_view.(self.class)
           @view_context ||= deps[:view_context] || resolve_context.()

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -76,7 +76,7 @@ module Hanami
       end
 
       def render(view, **options)
-        raise Hanami::Controller::MissingViewError unless view
+        raise Hanami::Controller::MissingViewError.new(action.class) unless view
 
         self.body = view.(**view_options.(request, self), **options).to_str
       end

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -76,6 +76,8 @@ module Hanami
       end
 
       def render(view, **options)
+        raise Hanami::Controller::MissingViewError unless view
+
         self.body = view.(**view_options.(request, self), **options).to_str
       end
 

--- a/lib/hanami/controller/error.rb
+++ b/lib/hanami/controller/error.rb
@@ -11,8 +11,8 @@ module Hanami
     #
     # @since 2.0.0
     class MissingViewError < Error
-      def initialize
-        super("Cannot render a view that is missing")
+      def initialize(klass)
+        super("missing view for #{klass}")
       end
     end
   end

--- a/lib/hanami/controller/error.rb
+++ b/lib/hanami/controller/error.rb
@@ -3,5 +3,17 @@ module Hanami
     # @since 0.5.0
     class Error < ::StandardError
     end
+
+    # Missing view error.
+    #
+    # It's raised when an ApplicationAction should automatically render a view,
+    # but there's no view associated with the instance
+    #
+    # @since 2.0.0
+    class MissingViewError < Error
+      def initialize
+        super("Cannot render a view that is missing")
+      end
+    end
   end
 end

--- a/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
@@ -190,6 +190,29 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
     end
   end
 
+  it "Raises error if render? is true but there's no view available" do
+    within_app do
+      write "slices/main/actions/test.rb", <<~RUBY
+        require "hanami/action"
+
+        module Main
+          module Actions
+            class Test < Hanami::Action
+              def render?(_res)
+                true
+              end
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+
+      action = Main::Slice["actions.test"]
+      expect { action.({}) }.to raise_error(Hanami::Controller::MissingViewError)
+    end
+  end
+
   def within_app
     with_tmp_directory(Dir.mktmpdir) do
       write "config/application.rb", <<~RUBY

--- a/spec/unit/hanami/action/response_spec.rb
+++ b/spec/unit/hanami/action/response_spec.rb
@@ -77,12 +77,18 @@ RSpec.describe Hanami::Action::Response do
     end
 
     context "without view" do
-      let(:view_options) { nil }
+      subject(:response) {
+        described_class.new(
+          request: request,
+          action: double(:action, class: "MyAction"),
+          configuration: Hanami::Action::Configuration.new,
+        )
+      }
 
       it "raises MissingViewError" do
         expect { response.render nil }.to raise_error(
           Hanami::Controller::MissingViewError
-        ).with_message("Cannot render a view that is missing")
+        ).with_message("missing view for MyAction")
       end
     end
   end


### PR DESCRIPTION
Before:
```ruby
view = nil
response.render(view)
# #<NoMethodError: undefined method `call' for nil:NilClass>
```

After
```ruby
view = nil
response.render(view)
#<Hanami::Controller::MissingViewError: Cannot render a view that is missing>
```

We should provide helpful errors to users when possible.

(This came about from implementing the spec for #355)

Happy to change the wording