### PR TITLE
Provide access to routes inside all application actions

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -14,7 +14,7 @@ module Hanami
       def included(action_class)
         action_class.include InstanceMethods
 
-        define_initialize action_class
+        define_initialize
         configure_action action_class
         extend_behavior action_class
       end
@@ -25,7 +25,7 @@ module Hanami
 
       private
 
-      def define_initialize(action_class)
+      def define_initialize
         resolve_view = method(:resolve_paired_view)
         resolve_context = method(:resolve_view_context)
         resolve_routes = method(:resolve_routes)

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -106,6 +106,16 @@ module Hanami
           super
         end
 
+        # Access application routes
+        #
+        # @return [Hanami::Application::RoutesHelper]
+        #
+        # @since 2.0.0
+        # @see Hanami::Application::RoutesHelper
+        def routes
+          Hanami.application[:routes_helper]
+        end
+
         # Decide whether to render the current response with the associated view.
         # This can be overridden to enable/disable automatic rendering.
         #

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -28,24 +28,16 @@ module Hanami
       def define_initialize(action_class)
         resolve_view = method(:resolve_paired_view)
         resolve_context = method(:resolve_view_context)
+        resolve_routes = method(:resolve_routes)
 
         define_method :initialize do |**deps|
           # Conditionally assign these to repsect any explictly auto-injected
           # dependencies provided by the class
           @view ||= deps[:view] || resolve_view.(self.class)
           @view_context ||= deps[:view_context] || resolve_context.()
+          @routes ||= deps[:routes] || resolve_routes.()
 
           super(**deps)
-        end
-      end
-
-      def resolve_view_context
-        identifier = application.config.actions.view_context_identifier
-
-        if provider.key?(identifier)
-          provider[identifier]
-        elsif application.key?(identifier)
-          application[identifier]
         end
       end
 
@@ -58,6 +50,20 @@ module Hanami
         view_identifiers.detect { |identifier|
           break provider[identifier] if provider.key?(identifier)
         }
+      end
+
+      def resolve_view_context
+        identifier = application.config.actions.view_context_identifier
+
+        if provider.key?(identifier)
+          provider[identifier]
+        elsif application.key?(identifier)
+          application[identifier]
+        end
+      end
+
+      def resolve_routes
+        application[:routes_helper] if application.key?(:routes_helper)
       end
 
       def configure_action(action_class)
@@ -87,6 +93,7 @@ module Hanami
       module InstanceMethods
         attr_reader :view
         attr_reader :view_context
+        attr_reader :routes
 
         def build_response(**options)
           options = options.merge(view_options: method(:view_options))
@@ -104,16 +111,6 @@ module Hanami
         def finish(req, res, halted)
           res.render(view, **req.params) if render?(res)
           super
-        end
-
-        # Access application routes
-        #
-        # @return [Hanami::Application::RoutesHelper]
-        #
-        # @since 2.0.0
-        # @see Hanami::Application::RoutesHelper
-        def routes
-          Hanami.application[:routes_helper]
         end
 
         # Decide whether to render the current response with the associated view.

--- a/spec/integration/hanami/controller/application_action/routes_spec.rb
+++ b/spec/integration/hanami/controller/application_action/routes_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/action"
+
+RSpec.describe "Routes", :application_integration do
+  specify "Access application routes from an action" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Application::Routes
+            define do
+              slice :main, at: "/" do
+                root to: "test_action"
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/actions/test_action.rb", <<~RUBY
+        module Main
+          module Actions
+            class TestAction < Hanami::Action
+              def handle(req, res)
+                res.body = "Hello, world!"
+              end
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+
+      action = Main::Slice["actions.test_action"]
+
+      expect(action.routes.path(:root)).to eq("/")
+    end
+  end
+end

--- a/spec/integration/hanami/controller/application_action/routes_spec.rb
+++ b/spec/integration/hanami/controller/application_action/routes_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Routes", :application_integration do
           module Actions
             class TestAction < Hanami::Action
               def handle(req, res)
-                res.body = "Hello, world!"
+                res.body = routes.path(:root)
               end
             end
           end
@@ -41,9 +41,8 @@ RSpec.describe "Routes", :application_integration do
 
       require "hanami/init"
 
-      action = Main::Slice["actions.test_action"]
-
-      expect(action.routes.path(:root)).to eq("/")
+      response = Main::Slice["actions.test_action"].call({})
+      expect(response.body).to eq ["/"]
     end
   end
 end


### PR DESCRIPTION
This builds upon @waiting-for-dev's work in #357 and makes the routes an injectable dependency of application actions.

This needed a complementary change in Hanami (https://github.com/hanami/hanami/pull/1132) to make it so the Hanami application's endpoint resolver doesn't eagerly initialize an action instance for each of the endpoints. If it continued to do that, with this change here in this PR, we run into a deadlock error around accessing/loading the router inside `Hanami::Application.router`.

This reason for this can hopefully be made clear through stepping through the sequence of fetching the first action from the container (like we do in the test added in #357):

1. An  action is resolved from a (non-booted) Hanami application's slice
2. The action's `#initialize` will resolve the `router_helper` from the application container
3. The router_helper boot file will get the `Hanami.application.router`
4. This begins to load the router, which, using the application's endpoint resolver, will eagerly create an action instance for each of the declared routes
5. The first action instance has an `#initialize` that will resolve the `router_helper` from the application's container
6. And we're back at step 2 again, so we're now in an endless loop

As for the changes inside this PR in particular, I think it's the right way to do it. The routes helper _should_ be an injectable dependency, defaulting to the framework-provided helper if its available.

As for the changes to the Hanami router initialization and behaviour, there's likely a whole variety of different approaches we can take to make it complement the change here, and be more flexible in general. I think there's a lot to be said for _not_ eagerly initializing every action whenever you load the router, because it makes Hanami more suited to different deployment modes (e.g. deployed to a Lambda for a subset of routes only; in this case it is a waste of resources and cold boot time to initialize every action when you're not necessarily going to use them all).

To put it another way, one of the key features we offer in Hanami 2 is giving the user maximal control over their application boot, and I think we should make sure our router doesn't compromise this.

I think the change I've done in https://github.com/hanami/hanami/pull/1132 is a reasonable starting point, however, and we can consider more comprehensive changes at a later moment.

What do you think, @waiting-for-dev, @jodosha?

