### PR TITLE
Do not render view when application action halts with a body

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -109,9 +109,9 @@ module Hanami
         end
 
         def finish(req, res, halted)
-          res.status, res.body = *halted unless halted.nil?
+          result = super
           res.render(view, **req.params) if render?(res)
-          super
+          result
         end
 
         # Decide whether to render the current response with the associated view.

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -109,6 +109,7 @@ module Hanami
         end
 
         def finish(req, res, halted)
+          res.status, res.body = *halted unless halted.nil?
           res.render(view, **req.params) if render?(res)
           super
         end

--- a/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
       RUBY
 
       write "slices/main/web/templates/test.html.slim", <<~'SLIM'
-        #{raise("Oh no"}
+        == raise("This should not be rendered")
       SLIM
 
       require "hanami/init"


### PR DESCRIPTION
Previously, halting inside of an application would not actually prevent a view from rendering. This patch fixes that by making sure to set the response status and body if a request was halted. 

cc @timriley 