### PR TITLE
Add RSS MIME type to TYPES

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -58,6 +58,7 @@ module Hanami
         png: 'image/png',
         psd: 'image/vnd.adobe.photoshop',
         rtf: 'application/rtf',
+        rss: 'application/rss+xml',
         sh: 'application/x-sh',
         svg: 'image/svg+xml',
         swf: 'application/x-shockwave-flash',


### PR DESCRIPTION
When trying to use RSS I noticed that the content type wasn't listed as
valid in the `TYPES` hash.