### PR TITLE
Send CSP rules as single response header

### DIFF
--- a/lib/hanami/action/application_configuration/content_security_policy.rb
+++ b/lib/hanami/action/application_configuration/content_security_policy.rb
@@ -102,7 +102,7 @@ module Hanami
         def to_str
           @policy.map do |key, value|
             "#{dasherize(key)} #{value}"
-          end.join(";\n")
+          end.join("; ")
         end
 
         private

--- a/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
+++ b/spec/unit/hanami/action/application_configuration/content_security_policy_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Hanami::Action::ApplicationConfiguration, "#content_security_poli
           %(plugin-types application/pdf;),
           %(script-src 'self';),
           %(style-src 'self' 'unsafe-inline' https:)
-        ].join("\n")
+        ].join(' ')
 
         expect(content_security_policy.to_str).to eq(expected)
       end


### PR DESCRIPTION
When I launch Hanami 2 template, it complains about CSP rules and doesn't load styles and script files. I've found that `"\n"` separator used for converting CSP configuration to header line, sends each rule as a separate header (response contains multiple `Content-Security-Policy` headers).

After small research, I've found that when multiple headers are used, then the most strict one (in this case `default-src 'none';`) takes precedence (https://chrisguitarguy.com/2019/07/05/working-with-multiple-content-security-policy-headers/). After playing with the code, it seems that changing separator `"\n"` to `"; "` sends all these rules as a single header and they work correctly (setting specific rule like `style-src`, `script-src`, etc. overrides `default-src`).