### PR TITLE
Do not automatically render halted requests.

### DIFF
--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -109,7 +109,7 @@ module Hanami
         end
 
         def finish(req, res, halted)
-          res.render(view, **req.params) if render?(res, halted)
+          res.render(view, **req.params) if !halted && render?(res)
           super
         end
 
@@ -122,8 +122,8 @@ module Hanami
         #
         # @since 2.0.0
         # @api public
-        def render?(res, halted)
-          view && res.body.empty? && halted.nil?
+        def render?(res)
+          view && res.body.empty?
         end
       end
     end

--- a/lib/hanami/action/application_action.rb
+++ b/lib/hanami/action/application_action.rb
@@ -109,7 +109,7 @@ module Hanami
         end
 
         def finish(req, res, halted)
-          res.render(view, **req.params) if render?(res)
+          res.render(view, **req.params) if render?(res, halted)
           super
         end
 
@@ -122,8 +122,8 @@ module Hanami
         #
         # @since 2.0.0
         # @api public
-        def render?(res)
-          view && res.body.empty?
+        def render?(res, halted)
+          view && res.body.empty? && halted.nil?
         end
       end
     end

--- a/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
                   res[:favorite_number] = 123
                 end
 
-                def render?(_res)
+                def render?(_res, _halted)
                   false
                 end
               end
@@ -173,6 +173,57 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
 
       expect(rendered).to eq "Not Found"
       expect(response.status).to eq 404
+    end
+  end
+
+  it "Doesn't render view automatically when redirect_to is called" do
+    within_app do
+      write "slices/main/actions/profile/show.rb", <<~RUBY
+        module Main
+          module Actions
+            module Profile
+              class Show < Main::Action::Base
+                before :redirect_unless_name
+
+                def handle(req, res)
+                  res[:name] = req.params[:name]
+                end
+
+                private
+
+                def redirect_unless_name(req, res)
+                  res.redirect_to "/" unless req.params[:name]
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/views/profile/show.rb", <<~RUBY
+        module Main
+          module Views
+            module Profile
+              class Show < Main::View::Base
+                expose :name
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/templates/profile/show.html.slim", <<~'SLIM'
+        h1 Hello, #{name.upcase}
+      SLIM
+
+      require "hanami/prepare"
+
+      action = Main::Slice["actions.profile.show"]
+      response = action.({})
+      rendered = response.body[0]
+
+      expect(rendered).to eq "Found"
+      expect(response.status).to eq 302
     end
   end
 

--- a/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/hanami/controller/application_action/view_rendering/automatic_rendering_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Application actions / View rendering / Automatic rendering", :ap
                   res[:favorite_number] = 123
                 end
 
-                def render?(_res, _halted)
+                def render?(_res)
                   false
                 end
               end


### PR DESCRIPTION
When upgrading a hanami 2 application from the unstable branch to hanami 2.0.0.alpha6, I discovered that redirected requests are unexpectedly rendering their views (resulting in errors where variables in slim templates are not present and ultimately in failed redirects).

i.e. calling the following action with no name param results in the slim being rendered (and a `NoMethodError: undefined method 'upcase' for nil:NilClass`), despite the redirect_to being invoked:

```ruby
# slices/main/actions/profile/show.rb
module Main
  module Actions
    module Profile
      class Show < Action::Base
        before :redirect_unless_name

        def handle(req, res)
          res[:name] = req.params[:name]
        end

        private

        def redirect_unless_name(req, res)
          res.redirect_to "/" unless req.params[:name]
        end
      end
    end
  end
end

# slices/main/templates/profile/show.html.slim
h1 Hello #{name.upcase}
```

This PR adds a check to confirm that a request is not halted before automatically rendering its view. Without this check, the spec added here fails with `NoMethodError: undefined method 'upcase' for nil:NilClass`.
