### PR TITLE
HEAD request fixes

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -515,9 +515,7 @@ module Hanami
 
     # @since 2.0.0
     # @api private
-    def _requires_empty_headers?(res)
-      _requires_no_body?(res) || res.head?
-    end
+    alias_method :_requires_empty_headers?, :_requires_no_body?
 
     private
 
@@ -669,6 +667,11 @@ module Hanami
       res.headers.select! { |header, _| keep_response_header?(header) }
     end
 
+    # @api private
+    def _empty_body(res)
+      res.body = Response::EMPTY_BODY
+    end
+
     def format(value)
       case value
       when Symbol
@@ -696,6 +699,7 @@ module Hanami
       res.status, res.body = *halted unless halted.nil?
 
       _empty_headers(res) if _requires_empty_headers?(res)
+      _empty_body(res) if res.head?
 
       res.set_format(Action::Mime.detect_format(res.content_type, configuration))
       res[:params] = req.params

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -106,7 +106,7 @@ module Hanami
       end
 
       def redirect_to(url, status: 302)
-        return unless renderable?
+        return unless allow_redirect?
 
         redirect(::String.new(url), status)
         Halt.call(status)
@@ -166,6 +166,12 @@ module Hanami
         return !head? && body.empty? if body.respond_to?(:empty?)
 
         !@sending_file && !head?
+      end
+
+      def allow_redirect?
+        return body.empty? if body.respond_to?(:empty?)
+
+        !@sending_file
       end
 
       alias to_ary to_a

--- a/spec/integration/hanami/controller/head_spec.rb
+++ b/spec/integration/hanami/controller/head_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe "HTTP HEAD" do
     last_response
   end
 
-  it "doesn't cleanup body, but only default headers" do
+  it "Returns headers but an empty body " do
     head "/"
+    headers = response.headers.to_a
 
     expect(response.status).to be(200)
-    expect(response.body).to   eq("index")
-    expect(response.headers.to_a).to_not include(["X-Frame-Options", "DENY"])
+    expect(response.body.to_s).to be_empty
+    expect(headers).to include(["Content-Type", "application/octet-stream; charset=utf-8"])
+    expect(headers).to include(["Content-Length", "5"])
   end
 
   it "allows to bypass restriction on custom headers" do

--- a/spec/unit/hanami/action/response_spec.rb
+++ b/spec/unit/hanami/action/response_spec.rb
@@ -133,4 +133,41 @@ RSpec.describe Hanami::Action::Response do
       end
     end
   end
+
+  describe "#allow_redirect?" do
+    subject {
+      described_class.new(
+        request: double(:request),
+        action: "action",
+        configuration: Hanami::Action::Configuration.new, env: env
+      )
+    }
+    let(:env) { { "REQUEST_METHOD" => "GET" } }
+
+    context "when body isn't set" do
+      it "returns true" do
+        expect(subject.allow_redirect?).to be(true)
+      end
+    end
+
+    context "when body is set" do
+      before do
+        subject.body = "OK"
+      end
+
+      it "returns false" do
+        expect(subject.allow_redirect?).to be(false)
+      end
+    end
+
+    context "when sending file" do
+      before do
+        subject.unsafe_send_file(__FILE__)
+      end
+
+      it "returns false" do
+        expect(subject.renderable?).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses two issues with HEAD requests

### HEAD requests should return the same headers as GET requests without the message body
Currently HEAD requests are returning a message body which causes a `Rack::Lint` error in development. According to the RFC https://datatracker.ietf.org/doc/html/rfc2616#page-54, HEAD requests should return the same headers as the equivalent GET request. Currently headers are being filtered to exclude all but a subset of Entity headers, Content-type and Content-length are also being filtered. This has implications also for HEAD requests that return a redirect response. 

The method `_requires_empty_headers` included a check for HEAD requests. I've removed this and I've added a separate method `_empty_body` that also sets the message body to empty if the request is a HEAD request. 

### HEAD requests for redirects are not returning redirect headers 
The redirect_to method on the response cancels the redirect if there is already a body present or file being sent. This check is made using `#renderable?` which also includes a check for HEAD requests. This is causing requests that would return redirect headers on GET to instead try to render the request on a HEAD request. This has been causing errors in our app as those pages are often not renderable. I've created a new method called `allow_redirect?` that is used instead and retains the check for an existing message body or file but allows redirect headers to be sent with a HEAD request. 