### PR TITLE
Prefer NoMethodError over NotImplementedError

### DIFF
--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -43,52 +43,52 @@ module Hanami
         @accept ||= @env[HTTP_ACCEPT] || DEFAULT_ACCEPT
       end
 
-      # @raise [NotImplementedError]
+      # @raise [NoMethodError]
       #
       # @since 0.3.1
       # @api private
       def content_type
-        raise NotImplementedError, 'Please use Action#content_type'
+        raise NoMethodError, 'Please use Action#content_type'
       end
 
-      # @raise [NotImplementedError]
+      # @raise [NoMethodError]
       #
       # @since 0.3.1
       # @api private
       def update_param(*)
-        raise NotImplementedError, 'Please use params passed to Action#call'
+        raise NoMethodError, 'Please use params passed to Action#call'
       end
 
-      # @raise [NotImplementedError]
+      # @raise [NoMethodError]
       #
       # @since 0.3.1
       # @api private
       def delete_param(*)
-        raise NotImplementedError, 'Please use params passed to Action#call'
+        raise NoMethodError, 'Please use params passed to Action#call'
       end
 
-      # @raise [NotImplementedError]
+      # @raise [NoMethodError]
       #
       # @since 0.3.1
       # @api private
       def [](*)
-        raise NotImplementedError, 'Please use params passed to Action#call'
+        raise NoMethodError, 'Please use params passed to Action#call'
       end
 
-      # @raise [NotImplementedError]
+      # @raise [NoMethodError]
       #
       # @since 0.3.1
       # @api private
       def []=(*)
-        raise NotImplementedError, 'Please use params passed to Action#call'
+        raise NoMethodError, 'Please use params passed to Action#call'
       end
 
-      # @raise [NotImplementedError]
+      # @raise [NoMethodError]
       #
       # @since 0.3.1
       # @api private
       def values_at(*)
-        raise NotImplementedError, 'Please use params passed to Action#call'
+        raise NoMethodError, 'Please use params passed to Action#call'
       end
     end
   end

--- a/spec/unit/hanami/action/request_spec.rb
+++ b/spec/unit/hanami/action/request_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Hanami::Action::Request do
   end
 
   describe 'request methods that are implemented elsewhere' do
-    it 'should reject with a NotImplementedError' do
+    it 'should reject with a NoMethodError' do
       methods = %i(
         content_type
         update_param
@@ -160,7 +160,7 @@ RSpec.describe Hanami::Action::Request do
       )
       request = described_class.new({}, {})
       methods.each do |method|
-        expect { request.send(method) }.to raise_error(NotImplementedError)
+        expect { request.send(method) }.to raise_error(NoMethodError)
       end
     end
   end


### PR DESCRIPTION
See the discussion at https://github.com/rmosolgo/graphql-ruby/issues/2067

We could as well implement a custom error, like is done in graphql-ruby with `RequiredImplementationMissingError`. I used `NoMethodError` for now as this was already thrown for the missing params method in https://github.com/hanami/controller/blob/main/spec/isolation/without_hanami_validations_spec.rb#L23.