### PR TITLE
Readd helpful errors when sessions are not enabled

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -18,6 +18,7 @@ require_relative 'action/mime'
 require_relative 'action/rack/file'
 require_relative 'action/request'
 require_relative 'action/response'
+require_relative 'action/error'
 
 module Hanami
   # An HTTP endpoint
@@ -679,6 +680,28 @@ module Hanami
       else
         raise Hanami::Controller::UnknownFormatError.new(value)
       end
+    end
+
+    # Raise error when `Hanami::Action::Session` isn't included.
+    #
+    # To use `session`, include `Hanami::Action::Session`.
+    #
+    # @raise [Hanami::Action::MissingSessionError]
+    #
+    # @since 2.0.0
+    def session
+      raise Hanami::Action::MissingSessionError.new(:session)
+    end
+
+    # Raise error when `Hanami::Action::Session` isn't included.
+    #
+    # To use `flash`, include `Hanami::Action::Session`.
+    #
+    # @raise [Hanami::Action::MissingSessionError]
+    #
+    # @since 2.0.0
+    def flash
+      raise Hanami::Action::MissingSessionError.new(:flash)
     end
 
     # Finalize the response

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -682,28 +682,6 @@ module Hanami
       end
     end
 
-    # Raise error when `Hanami::Action::Session` isn't included.
-    #
-    # To use `session`, include `Hanami::Action::Session`.
-    #
-    # @raise [Hanami::Action::MissingSessionError]
-    #
-    # @since 2.0.0
-    def session
-      raise Hanami::Action::MissingSessionError.new(:session)
-    end
-
-    # Raise error when `Hanami::Action::Session` isn't included.
-    #
-    # To use `flash`, include `Hanami::Action::Session`.
-    #
-    # @raise [Hanami::Action::MissingSessionError]
-    #
-    # @since 2.0.0
-    def flash
-      raise Hanami::Action::MissingSessionError.new(:flash)
-    end
-
     # Finalize the response
     #
     # Prepare the data before the response will be returned to the webserver

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -1,0 +1,23 @@
+module Hanami
+  class Action
+    # @since 2.0.0
+    class Error < ::StandardError
+    end
+
+    # Missing session error
+    #
+    # This error is raised when an action sends either `session` or `flash` to
+    # itself and it does not include `Hanami::Action::Session`.
+    #
+    # @since 2.0.0
+    #
+    # @see Hanami::Action::Session
+    # @see Hanami::Action#session
+    # @see Hanami::Action#flash
+    class MissingSessionError < Error
+      def initialize(session_method)
+        super("To use `#{session_method}', add `include Hanami::Action::Session`.")
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -39,4 +39,11 @@ RSpec.describe "Flash application" do
       expect(last_response.body).to match(/flash_map: \[\[:hello, "world"\]\]/)
     end
   end
+
+  context 'when sessions not enabled' do
+    it "raises Hanami::Action::MissingSessionError" do
+      expected = Hanami::Action::MissingSessionError
+      expect { get "/disabled" }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+    end
+  end
 end

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe "HTTP sessions" do
 
   let(:router) do
     Hanami::Router.new do
-      get    '/',       to: Dashboard::Index.new
-      post   '/login',  to: Sessions::Create.new
-      delete '/logout', to: Sessions::Destroy.new
+      get    '/',         to: Dashboard::Index.new
+      post   '/login',    to: Sessions::Create.new
+      delete '/logout',   to: Sessions::Destroy.new
+      get    '/disabled', to: Sessions::Disabled.new
     end
   end
 
@@ -49,6 +50,13 @@ RSpec.describe "HTTP sessions" do
 
     get "/"
     expect(response.status).to be(401)
+  end
+
+  context "when sessions not enabled" do
+    it "raises Hanami::Action::MissingSessionError" do
+      expected = Hanami::Action::MissingSessionError
+      expect { get "/disabled" }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+    end
   end
 end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -855,7 +855,7 @@ module Sessions
 
   class Disabled < Hanami::Action
     def handle(*, res)
-      res.sessions[:user_id] = 23
+      res.session[:user_id] = 23
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -349,14 +349,14 @@ class YieldAfterBlockAction < AfterBlockAction
 end
 
 class MissingSessionAction < Hanami::Action
-  def handle(*)
-    session
+  def handle(_, res)
+    res.session[:user_id] = 23
   end
 end
 
 class MissingFlashAction < Hanami::Action
-  def handle(*)
-    flash
+  def handle(_, res)
+    res.flash[:error] = "ouch"
   end
 end
 
@@ -850,6 +850,12 @@ module Sessions
 
     def handle(*, res)
       res.session[:user_id] = nil
+    end
+  end
+
+  class Disabled < Hanami::Action
+    def handle(*, res)
+      res.sessions[:user_id] = 23
     end
   end
 end
@@ -1822,6 +1828,12 @@ module Flash
           res.body = "flash_map: #{res.flash.map { |type, message| [type, message] }}"
         end
       end
+
+      class Disabled < Hanami::Action
+        def handle(_, res)
+          res.flash[:error] = "ouch"
+        end
+      end
     end
   end
 
@@ -1837,6 +1849,7 @@ module Flash
         get "/each_redirect",  to: Flash::Controllers::Home::EachRedirect.new
         get "/map",            to: Flash::Controllers::Home::Map.new
         get "/each",           to: Flash::Controllers::Home::Each.new
+        get "/disabled",       to: Flash::Controllers::Home::Disabled.new
       end
 
       @middleware = Rack::Builder.new do

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -140,6 +140,20 @@ RSpec.describe Hanami::Action do
         expect(response.body).to   eq([])
       end
     end
+
+    context "when invoking the session method with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
+      end
+    end
+
+    context "when invoking the flash method with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingFlashAction.new.call({}) }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+      end
+    end
   end
 
   describe "#name" do


### PR DESCRIPTION
Tracked by https://trello.com/c/MJtJHbcC/104-re-add-helpful-errors-when-session-is-accessed-off-response-but-sessions-are-not-enabled.

Basically [copy-pasted](https://github.com/hanami/controller/pull/326/files) the old error class, `#flash` and `#session` under the `Hanami::Action` namespace/class.