### PR TITLE
Readd session errors

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -22,6 +22,7 @@ require_relative "action/mime"
 require_relative "action/rack/file"
 require_relative "action/request"
 require_relative "action/response"
+require_relative 'action/error'
 
 module Hanami
   # An HTTP endpoint
@@ -595,6 +596,28 @@ module Hanami
       else
         raise Hanami::Controller::UnknownFormatError.new(value)
       end
+    end
+
+    # Raise error when `Hanami::Action::Session` isn't included.
+    #
+    # To use `session`, include `Hanami::Action::Session`.
+    #
+    # @raise [Hanami::Action::MissingSessionError]
+    #
+    # @since 2.0.0
+    def session
+      raise Hanami::Action::MissingSessionError.new(:session)
+    end
+
+    # Raise error when `Hanami::Action::Session` isn't included.
+    #
+    # To use `flash`, include `Hanami::Action::Session`.
+    #
+    # @raise [Hanami::Action::MissingSessionError]
+    #
+    # @since 2.0.0
+    def flash
+      raise Hanami::Action::MissingSessionError.new(:flash)
     end
 
     # Finalize the response

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -598,28 +598,6 @@ module Hanami
       end
     end
 
-    # Raise error when `Hanami::Action::Session` isn't included.
-    #
-    # To use `session`, include `Hanami::Action::Session`.
-    #
-    # @raise [Hanami::Action::MissingSessionError]
-    #
-    # @since 2.0.0
-    def session
-      raise Hanami::Action::MissingSessionError.new(:session)
-    end
-
-    # Raise error when `Hanami::Action::Session` isn't included.
-    #
-    # To use `flash`, include `Hanami::Action::Session`.
-    #
-    # @raise [Hanami::Action::MissingSessionError]
-    #
-    # @since 2.0.0
-    def flash
-      raise Hanami::Action::MissingSessionError.new(:flash)
-    end
-
     # Finalize the response
     #
     # Prepare the data before the response will be returned to the webserver

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -325,7 +325,7 @@ module Hanami
 
       halted = catch :halt do
         params   = self.class.params_class.new(env)
-        request  = build_request(env, params)
+        request  = build_request(env: env, params: params, sessions_enabled: sessions_enabled)
         response = build_response(
           request: request,
           action: name,
@@ -453,8 +453,8 @@ module Hanami
 
     # @since 2.0.0
     # @api private
-    def build_request(env, params)
-      Request.new(env, params, sessions_enabled)
+    def build_request(**options)
+      Request.new(**options)
     end
 
     # @since 2.0.0

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -22,7 +22,7 @@ require_relative "action/mime"
 require_relative "action/rack/file"
 require_relative "action/request"
 require_relative "action/response"
-require_relative 'action/error'
+require_relative "action/error"
 
 module Hanami
   # An HTTP endpoint
@@ -332,7 +332,7 @@ module Hanami
           configuration: configuration,
           content_type: Mime.calculate_content_type_with_charset(configuration, request, accepted_mime_types),
           env: env,
-          headers: configuration.default_headers
+          headers: configuration.default_headers,
           sessions_enabled: sessions_enabled
         )
 

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -454,7 +454,7 @@ module Hanami
     # @since 2.0.0
     # @api private
     def build_request(env, params)
-      Request.new(env, params)
+      Request.new(env, params, sessions_enabled)
     end
 
     # @since 2.0.0

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -333,6 +333,7 @@ module Hanami
           content_type: Mime.calculate_content_type_with_charset(configuration, request, accepted_mime_types),
           env: env,
           headers: configuration.default_headers
+          sessions_enabled: sessions_enabled
         )
 
         _run_before_callbacks(request, response)
@@ -444,6 +445,10 @@ module Hanami
       end
 
       nil
+    end
+
+    def sessions_enabled
+      false
     end
 
     # @since 2.0.0

--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -96,6 +96,7 @@ module Hanami
       # @api private
       def self.included(action)
         unless Hanami.respond_to?(:env?) && Hanami.env?(:test)
+          action.include Hanami::Action::Session
           action.class_eval do
             before :set_csrf_token, :verify_csrf_token
           end

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -12,11 +12,12 @@ module Hanami
     # @since 2.0.0
     #
     # @see Hanami::Action::Session
+    # @see Hanami::Action::Request#session
     # @see Hanami::Action::Response#session
     # @see Hanami::Action::Response#flash
     class MissingSessionError < Error
       def initialize(session_method)
-        super("To use `#{session_method}', add `include Hanami::Action::Session`.")
+        super("To use `#{session_method}`, add `include Hanami::Action::Session`.")
       end
     end
   end

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   class Action
     # @since 2.0.0
@@ -6,7 +8,7 @@ module Hanami
 
     # Missing session error
     #
-    # This error is raised when `session` or `flash` is accessed/set on request/response objects 
+    # This error is raised when `session` or `flash` is accessed/set on request/response objects
     # in actions which do not include `Hanami::Action::Session`.
     #
     # @since 2.0.0

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -1,0 +1,23 @@
+module Hanami
+  class Action
+    # @since 2.0.0
+    class Error < ::StandardError
+    end
+
+    # Missing session error
+    #
+    # This error is raised when an action sends either `session` or `flash` to
+    # itself and it does not include `Hanami::Action::Session`.
+    #
+    # @since 2.0.0
+    #
+    # @see Hanami::Action::Session
+    # @see Hanami::Action#session
+    # @see Hanami::Action#flash
+    class MissingSessionError < Error
+      def initialize(session_method)
+        super("To use `#{session_method}', add `include Hanami::Action::Session`.")
+      end
+    end
+  end
+end

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -6,14 +6,14 @@ module Hanami
 
     # Missing session error
     #
-    # This error is raised when an action sends either `session` or `flash` to
-    # itself and it does not include `Hanami::Action::Session`.
+    # This error is raised when `session` or `flash` is accessed/set on request/response objects 
+    # in actions which do not include `Hanami::Action::Session`.
     #
     # @since 2.0.0
     #
     # @see Hanami::Action::Session
-    # @see Hanami::Action#session
-    # @see Hanami::Action#flash
+    # @see Hanami::Action::Response#session
+    # @see Hanami::Action::Response#flash
     class MissingSessionError < Error
       def initialize(session_method)
         super("To use `#{session_method}', add `include Hanami::Action::Session`.")

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -16,7 +16,7 @@ module Hanami
     class Request < ::Rack::Request
       attr_reader :params, :sessions_enabled
 
-      def initialize(env, params, sessions_enabled = false)
+      def initialize(env:, params:, sessions_enabled: false)
         super(env)
 
         @params = params

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -16,9 +16,11 @@ module Hanami
     class Request < ::Rack::Request
       attr_reader :params
 
-      def initialize(env, params)
+      def initialize(env, params, sessions_enabled = false)
         super(env)
+
         @params = params
+        @sessions_enabled = sessions_enabled
       end
 
       def id
@@ -34,6 +36,12 @@ module Hanami
 
       def accept_header?
         accept != Action::DEFAULT_ACCEPT
+      end
+
+      def session
+        raise Hanami::Action::MissingSessionError.new("session") unless @sessions_enabled
+
+        super
       end
 
       # @since 0.1.0

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -14,7 +14,7 @@ module Hanami
     #
     # @see http://www.rubydoc.info/gems/rack/Rack/Request
     class Request < ::Rack::Request
-      attr_reader :params
+      attr_reader :params, :sessions_enabled
 
       def initialize(env, params, sessions_enabled = false)
         super(env)
@@ -39,7 +39,9 @@ module Hanami
       end
 
       def session
-        raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session") unless @sessions_enabled
+        unless sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
+        end
 
         super
       end

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -39,7 +39,7 @@ module Hanami
       end
 
       def session
-        raise Hanami::Action::MissingSessionError.new("session") unless @sessions_enabled
+        raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session") unless @sessions_enabled
 
         super
       end

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -27,7 +27,7 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      attr_reader :request, :action, :exposures, :format, :env, :view_options
+      attr_reader :request, :action, :exposures, :format, :env, :view_options, :sessions_enabled
 
       # @since 2.0.0
       # @api private
@@ -43,9 +43,13 @@ module Hanami
         end
       end
 
+<<<<<<< HEAD
       # @since 2.0.0
       # @api private
       def initialize(request:, action:, configuration:, content_type: nil, env: {}, headers: {}, view_options: nil) # rubocop:disable Metrics/ParameterLists
+=======
+      def initialize(request:, action:, configuration:, content_type: nil, env: {}, headers: {}, view_options: nil, sessions_enabled: false)
+>>>>>>> 7c29362 (Raise error in Hanami::Action::Response#flash and Hanami::Action::Response#session when sessions are not enabled)
         super([], 200, headers.dup)
         set_header(Action::CONTENT_TYPE, content_type)
 
@@ -57,6 +61,7 @@ module Hanami
         @env = env
         @view_options = view_options || DEFAULT_VIEW_OPTIONS
 
+        @sessions_enabled = sessions_enabled
         @sending_file = false
       end
 
@@ -103,7 +108,13 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
+<<<<<<< HEAD
         env[Action::RACK_SESSION] ||= {}
+=======
+        raise Hanami::Action::MissingSessionError.new("session") unless sessions_enabled
+
+        env[SESSION_KEY] ||= {}
+>>>>>>> 7c29362 (Raise error in Hanami::Action::Response#flash and Hanami::Action::Response#session when sessions are not enabled)
       end
 
       # @since 2.0.0
@@ -115,7 +126,13 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
+<<<<<<< HEAD
         @flash ||= Flash.new(session[Flash::KEY])
+=======
+        raise Hanami::Action::MissingSessionError.new("flash") unless sessions_enabled
+
+        @flash ||= Flash.new(session[FLASH_SESSION_KEY])
+>>>>>>> 7c29362 (Raise error in Hanami::Action::Response#flash and Hanami::Action::Response#session when sessions are not enabled)
       end
 
       # @since 2.0.0

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -197,7 +197,8 @@ module Hanami
       def request_id
         env.fetch(Action::REQUEST_ID) do
           # FIXME: raise a meaningful error, by inviting devs to include Hanami::Action::Session
-          raise "Can't find request ID"
+          # raise "Can't find request ID"
+          raise Hanami::Action::MissingSessionError.new('request_id')
         end
       end
 

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -43,13 +43,9 @@ module Hanami
         end
       end
 
-<<<<<<< HEAD
       # @since 2.0.0
       # @api private
-      def initialize(request:, action:, configuration:, content_type: nil, env: {}, headers: {}, view_options: nil) # rubocop:disable Metrics/ParameterLists
-=======
-      def initialize(request:, action:, configuration:, content_type: nil, env: {}, headers: {}, view_options: nil, sessions_enabled: false)
->>>>>>> 7c29362 (Raise error in Hanami::Action::Response#flash and Hanami::Action::Response#session when sessions are not enabled)
+      def initialize(request:, action:, configuration:, content_type: nil, env: {}, headers: {}, view_options: nil, sessions_enabled: false) # rubocop:disable Metrics/ParameterLists
         super([], 200, headers.dup)
         set_header(Action::CONTENT_TYPE, content_type)
 
@@ -108,13 +104,9 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
-<<<<<<< HEAD
-        env[Action::RACK_SESSION] ||= {}
-=======
-        raise Hanami::Action::MissingSessionError.new("session") unless sessions_enabled
+        raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session") unless sessions_enabled
 
-        env[SESSION_KEY] ||= {}
->>>>>>> 7c29362 (Raise error in Hanami::Action::Response#flash and Hanami::Action::Response#session when sessions are not enabled)
+        env[Action::RACK_SESSION] ||= {}
       end
 
       # @since 2.0.0
@@ -126,13 +118,9 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
-<<<<<<< HEAD
-        @flash ||= Flash.new(session[Flash::KEY])
-=======
-        raise Hanami::Action::MissingSessionError.new("flash") unless sessions_enabled
+        raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash") unless sessions_enabled
 
-        @flash ||= Flash.new(session[FLASH_SESSION_KEY])
->>>>>>> 7c29362 (Raise error in Hanami::Action::Response#flash and Hanami::Action::Response#session when sessions are not enabled)
+        @flash ||= Flash.new(session[Flash::KEY])
       end
 
       # @since 2.0.0

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -45,7 +45,9 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      def initialize(request:, action:, configuration:, content_type: nil, env: {}, headers: {}, view_options: nil, sessions_enabled: false) # rubocop:disable Metrics/ParameterLists
+      def initialize(request:, action:, configuration:, # rubocop:disable Metrics/ParameterLists
+                     content_type: nil, env: {}, headers: {}, view_options: nil,
+                     sessions_enabled: false)
         super([], 200, headers.dup)
         set_header(Action::CONTENT_TYPE, content_type)
 
@@ -190,7 +192,7 @@ module Hanami
         env.fetch(Action::REQUEST_ID) do
           # FIXME: raise a meaningful error, by inviting devs to include Hanami::Action::Session
           # raise "Can't find request ID"
-          raise Hanami::Action::MissingSessionError.new('request_id')
+          raise Hanami::Action::MissingSessionError.new("request_id")
         end
       end
 

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -104,7 +104,9 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
-        raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session") unless sessions_enabled
+        unless sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session")
+        end
 
         env[Action::RACK_SESSION] ||= {}
       end
@@ -118,7 +120,9 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
-        raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash") unless sessions_enabled
+        unless sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash")
+        end
 
         @flash ||= Flash.new(session[Flash::KEY])
       end

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -13,6 +13,10 @@ module Hanami
       def self.included(base)
         base.class_eval do
           before { |req, _| req.id }
+
+          def sessions_enabled
+            true
+          end
         end
       end
 

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Flash application" do
   context 'when sessions not enabled' do
     it "raises Hanami::Action::MissingSessionError" do
       expected = Hanami::Action::MissingSessionError
-      expect { get "/disabled" }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+      expect { get "/disabled" }.to raise_error(expected, "To use `Hanami::Action::Response#flash`, add `include Hanami::Action::Session`.")
     end
   end
 end

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -41,4 +41,11 @@ RSpec.describe "Flash application" do
       expect(last_response.body).to match(/flash_map: \[\[:hello, "world"\]\]/)
     end
   end
+
+  context 'when sessions not enabled' do
+    it "raises Hanami::Action::MissingSessionError" do
+      expected = Hanami::Action::MissingSessionError
+      expect { get "/disabled" }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+    end
+  end
 end

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Flash application" do
     end
   end
 
-  context 'when sessions not enabled' do
+  context "when sessions not enabled" do
     it "raises Hanami::Action::MissingSessionError" do
       expected = Hanami::Action::MissingSessionError
       expect { get "/disabled" }.to raise_error(expected, "To use `Hanami::Action::Response#flash`, add `include Hanami::Action::Session`.")

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "HTTP sessions" do
   context "when sessions not enabled" do
     it "raises Hanami::Action::MissingSessionError" do
       expected = Hanami::Action::MissingSessionError
-      expect { get "/disabled" }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
+      expect { get "/disabled" }.to raise_error(expected, "To use `Hanami::Action::Response#session`, add `include Hanami::Action::Session`.")
     end
   end
 end

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "HTTP sessions" do
       get    "/",       to: Dashboard::Index.new
       post   "/login",  to: Sessions::Create.new
       delete "/logout", to: Sessions::Destroy.new
+      get    "/disabled", to: Sessions::Disabled.new
     end
   end
 
@@ -51,6 +52,13 @@ RSpec.describe "HTTP sessions" do
 
     get "/"
     expect(response.status).to be(401)
+  end
+
+  context "when sessions not enabled" do
+    it "raises Hanami::Action::MissingSessionError" do
+      expected = Hanami::Action::MissingSessionError
+      expect { get "/disabled" }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+    end
   end
 end
 

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "HTTP sessions" do
   context "when sessions not enabled" do
     it "raises Hanami::Action::MissingSessionError" do
       expected = Hanami::Action::MissingSessionError
-      expect { get "/disabled" }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+      expect { get "/disabled" }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -857,7 +857,7 @@ module Sessions
 
   class Disabled < Hanami::Action
     def handle(*, res)
-      res.sessions[:user_id] = 23
+      res.session[:user_id] = 23
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -347,13 +347,19 @@ class YieldAfterBlockAction < AfterBlockAction
   end
 end
 
-class MissingSessionAction < Hanami::Action
+class MissingRequestSessionAction < Hanami::Action
+  def handle(req, _)
+    req.session[:user_id]
+  end
+end
+
+class MissingResponseSessionAction < Hanami::Action
   def handle(_, res)
     res.session[:user_id] = 23
   end
 end
 
-class MissingFlashAction < Hanami::Action
+class MissingResponseFlashAction < Hanami::Action
   def handle(_, res)
     res.flash[:error] = "ouch"
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -348,14 +348,14 @@ class YieldAfterBlockAction < AfterBlockAction
 end
 
 class MissingSessionAction < Hanami::Action
-  def handle(*)
-    session
+  def handle(_, res)
+    res.session[:user_id] = 23
   end
 end
 
 class MissingFlashAction < Hanami::Action
-  def handle(*)
-    flash
+  def handle(_, res)
+    res.flash[:error] = "ouch"
   end
 end
 
@@ -852,6 +852,12 @@ module Sessions
 
     def handle(*, res)
       res.session[:user_id] = nil
+    end
+  end
+
+  class Disabled < Hanami::Action
+    def handle(*, res)
+      res.sessions[:user_id] = 23
     end
   end
 end
@@ -1806,6 +1812,12 @@ module Flash
           res.body = "flash_map: #{res.flash.map { |type, message| [type, message] }}"
         end
       end
+
+      class Disabled < Hanami::Action
+        def handle(_, res)
+          res.flash[:error] = "ouch"
+        end
+      end
     end
   end
 
@@ -1821,6 +1833,7 @@ module Flash
         get "/each_redirect",  to: Flash::Controllers::Home::EachRedirect.new
         get "/map",            to: Flash::Controllers::Home::Map.new
         get "/each",           to: Flash::Controllers::Home::Each.new
+        get "/disabled",       to: Flash::Controllers::Home::Disabled.new
       end
 
       @middleware = Rack::Builder.new do

--- a/spec/unit/hanami/action/request_spec.rb
+++ b/spec/unit/hanami/action/request_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe Hanami::Action::Request do
 
     context "non-standard port" do
       it "gets host and port" do
-        request = described_class.new(Rack::MockRequest.env_for("http://example.com:81/foo?q=bar", {}), {})
+        request = described_class.new(
+          env: Rack::MockRequest.env_for("http://example.com:81/foo?q=bar", {}),
+          params: {}
+        )
         expect(request.host_with_port).to eq("example.com:81")
       end
     end
@@ -155,6 +158,6 @@ RSpec.describe Hanami::Action::Request do
   def build_request(attributes = {})
     url = attributes.delete("url") || "http://example.com/foo?q=bar"
     env = Rack::MockRequest.env_for(url, attributes)
-    described_class.new(env, {})
+    described_class.new(env: env, params: {})
   end
 end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Hanami::Action do
       end
     end
 
-    context "when setting res.flash method with sessions disabled" do
+    context "when setting res.flash with sessions disabled" do
       it "raises an informative exception" do
         expected = Hanami::Action::MissingSessionError
         expect { MissingResponseFlashAction.new.call({}) }.to raise_error(

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -141,17 +141,24 @@ RSpec.describe Hanami::Action do
       end
     end
 
-    context "when invoking the session method with sessions disabled" do
+    context "when setting res.session with sessions disabled" do
       it "raises an informative exception" do
         expected = Hanami::Action::MissingSessionError
-        expect { MissingSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
+        expect { MissingResponseSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
       end
     end
 
-    context "when invoking the flash method with sessions disabled" do
+    context "when setting res.flash method with sessions disabled" do
       it "raises an informative exception" do
         expected = Hanami::Action::MissingSessionError
-        expect { MissingFlashAction.new.call({}) }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+        expect { MissingResponseFlashAction.new.call({}) }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+      end
+    end
+
+    context "when accessing req.session with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingRequestSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
       end
     end
   end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -144,21 +144,30 @@ RSpec.describe Hanami::Action do
     context "when setting res.session with sessions disabled" do
       it "raises an informative exception" do
         expected = Hanami::Action::MissingSessionError
-        expect { MissingResponseSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
+        expect { MissingResponseSessionAction.new.call({}) }.to raise_error(
+          expected,
+          "To use `Hanami::Action::Response#session`, add `include Hanami::Action::Session`."
+        )
       end
     end
 
     context "when setting res.flash method with sessions disabled" do
       it "raises an informative exception" do
         expected = Hanami::Action::MissingSessionError
-        expect { MissingResponseFlashAction.new.call({}) }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+        expect { MissingResponseFlashAction.new.call({}) }.to raise_error(
+          expected,
+          "To use `Hanami::Action::Response#flash`, add `include Hanami::Action::Session`."
+        )
       end
     end
 
     context "when accessing req.session with sessions disabled" do
       it "raises an informative exception" do
         expected = Hanami::Action::MissingSessionError
-        expect { MissingRequestSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
+        expect { MissingRequestSessionAction.new.call({}) }.to raise_error(
+          expected,
+          "To use `Hanami::Action::Request#session`, add `include Hanami::Action::Session`."
+        )
       end
     end
   end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -140,6 +140,20 @@ RSpec.describe Hanami::Action do
         expect(response.body).to   eq([])
       end
     end
+
+    context "when invoking the session method with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingSessionAction.new.call({}) }.to raise_error(expected, "To use `session', add `include Hanami::Action::Session`.")
+      end
+    end
+
+    context "when invoking the flash method with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingFlashAction.new.call({}) }.to raise_error(expected, "To use `flash', add `include Hanami::Action::Session`.")
+      end
+    end
   end
 
   describe "#name" do


### PR DESCRIPTION
Somewhat unhappy with the implementation, but this introduces some tests as well on which we can rely on to refactor this. Feel free to suggest improvements, maybe we could leverage `Hanami::Action::Configuration` here. 

The configuration is already injected into the response object, we could take care to inject it into the request object as well.

Closes https://github.com/hanami/controller/issues/256