### PR TITLE
Establish `Hanami::Action#call` as Public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ They are the endpoints that respond to incoming HTTP requests.
 
 ```ruby
 class Show < Hanami::Action
-  def handle(req, res)
+  def call(req, res)
     res[:article] = ArticleRepository.new.find(req.params[:id])
   end
 end
@@ -86,7 +86,7 @@ class Show < Hanami::Action
     super(configuration: configuration)
   end
 
-  def handle(req, res)
+  def call(req, res)
     res[:article] = repository.find(req.params[:id])
   end
 
@@ -110,7 +110,7 @@ With `Hanami::Router`:
 
 ```ruby
 class Show < Hanami::Action
-  def handle(req, *)
+  def call(req, *)
     # ...
     puts req.params # => { id: 23 } extracted from Rack env
   end
@@ -121,7 +121,7 @@ Standalone:
 
 ```ruby
 class Show < Hanami::Action
-  def handle(req, *)
+  def call(req, *)
     # ...
     puts req.params # => { :"rack.version"=>[1, 2], :"rack.input"=>#<StringIO:0x007fa563463948>, ... }
   end
@@ -132,7 +132,7 @@ Unit Testing:
 
 ```ruby
 class Show < Hanami::Action
-  def handle(req, *)
+  def call(req, *)
     # ...
     puts req.params # => { id: 23, key: "value" } passed as it is from testing
   end
@@ -164,7 +164,7 @@ class Signup < Hanami::Action
     end
   end
 
-  def handle(req, *)
+  def call(req, *)
     # Describe inheritance hierarchy
     puts req.params.class            # => Signup::Params
     puts req.params.class.superclass # => Hanami::Action::Params
@@ -205,7 +205,7 @@ class Signup < Hanami::Action
     optional(:avatar).filled(size?: 1..(MEGABYTE * 3))
   end
 
-  def handle(req, *)
+  def call(req, *)
     halt 400 unless req.params.valid?
     # ...
   end
@@ -228,7 +228,7 @@ This is the same `res` response object passed to `#handle`, where you can use it
 
 ```ruby
 class Show < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     res.status  = 201
     res.body    = "Hi!"
     res.headers.merge!("X-Custom" => "OK")
@@ -246,7 +246,7 @@ By default, an action exposes the received params.
 
 ```ruby
 class Show < Hanami::Action
-  def handle(req, res)
+  def call(req, res)
     res[:article] = ArticleRepository.new.find(req.params[:id])
   end
 end
@@ -270,7 +270,7 @@ They are useful for shared logic like authentication checks.
 class Show < Hanami::Action
   before :authenticate, :set_article
 
-  def handle(*)
+  def call(*)
   end
 
   private
@@ -293,7 +293,7 @@ class Show < Hanami::Action
   before { ... } # do some authentication stuff
   before { |req, res| res[:article] = ArticleRepository.new.find(req.params[:id]) }
 
-  def handle(*)
+  def call(*)
   end
 end
 ```
@@ -309,7 +309,7 @@ An exception handler can be a valid HTTP status code (eg. `500`, `401`), or a `S
 class Show < Hanami::Action
   handle_exception StandardError => 500
 
-  def handle(*)
+  def call(*)
     raise
   end
 end
@@ -324,7 +324,7 @@ You can map a specific raised exception to a different HTTP status.
 class Show < Hanami::Action
   handle_exception RecordNotFound => 404
 
-  def handle(*)
+  def call(*)
     raise RecordNotFound
   end
 end
@@ -363,7 +363,7 @@ configuration = Hanami::Controller::Configuration.new do |config|
 end
 
 class Show < Hanami::Action
-  def handle(*)
+  def call(*)
     raise RecordNotFound
   end
 end
@@ -382,13 +382,13 @@ module Articles
   class Index < Hanami::Action
     handle_exception MyCustomException => :handle_my_exception
 
-    def handle(*)
+    def call(*)
       raise MyCustomException
     end
 
     private
 
-    def handle_my_exception(req, res, exception)
+    def call_my_exception(req, res, exception)
       # ...
     end
   end
@@ -396,13 +396,13 @@ module Articles
   class Show < Hanami::Action
     handle_exception StandardError => :handle_standard_error
 
-    def handle(*)
+    def call(*)
       raise MyCustomException
     end
 
     private
 
-    def handle_standard_error(req, res, exception)
+    def call_standard_error(req, res, exception)
       # ...
     end
   end
@@ -421,7 +421,7 @@ When `#halt` is used with a valid HTTP code, it stops the execution and sets the
 class Show < Hanami::Action
   before :authenticate!
 
-  def handle(*)
+  def call(*)
     # ...
   end
 
@@ -440,7 +440,7 @@ Alternatively, you can specify a custom message.
 
 ```ruby
 class Show < Hanami::Action
-  def handle(req, res)
+  def call(req, res)
     res[:droid] = DroidRepository.new.find(req.params[:id]) or not_found
   end
 
@@ -469,7 +469,7 @@ require "hanami/action/cookies"
 class ReadCookiesFromRackEnv < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(req, *)
+  def call(req, *)
     # ...
     req.cookies[:foo] # => "bar"
   end
@@ -488,7 +488,7 @@ require "hanami/action/cookies"
 class SetCookies < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.cookies[:foo] = "bar"
   end
@@ -507,7 +507,7 @@ require "hanami/action/cookies"
 class RemoveCookies < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.cookies[:foo] = nil
   end
@@ -530,7 +530,7 @@ end
 class SetCookies < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.cookies[:foo] = { value: "bar", max_age: 100 }
   end
@@ -553,7 +553,7 @@ require "hanami/action/session"
 class ReadSessionFromRackEnv < Hanami::Action
   include Hanami::Action::Session
 
-  def handle(req, *)
+  def call(req, *)
     # ...
     req.session[:age] # => "35"
   end
@@ -572,7 +572,7 @@ require "hanami/action/session"
 class SetSession < Hanami::Action
   include Hanami::Action::Session
 
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.session[:age] = 31
   end
@@ -591,7 +591,7 @@ require "hanami/action/session"
 class RemoveSession < Hanami::Action
   include Hanami::Action::Session
 
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.session[:age] = nil
   end
@@ -623,7 +623,7 @@ class HttpCacheController < Hanami::Action
   include Hanami::Action::Cache
   cache_control :public, max_age: 600 # => Cache-Control: public, max-age=600
 
-  def handle(*)
+  def call(*)
     # ...
   end
 end
@@ -639,7 +639,7 @@ class HttpCacheController < Hanami::Action
   include Hanami::Action::Cache
   expires 60, :public, max_age: 600 # => Expires: Sun, 03 Aug 2014 17:47:02 GMT, Cache-Control: public, max-age=600
 
-  def handle(*)
+  def call(*)
     # ...
   end
 end
@@ -660,7 +660,7 @@ require "hanami/action/cache"
 class ConditionalGetController < Hanami::Action
   include Hanami::Action::Cache
 
-  def handle(*)
+  def call(*)
     # ...
     fresh etag: resource.cache_key
     # => halt 304 with header IfNoneMatch = resource.cache_key
@@ -679,7 +679,7 @@ require "hanami/action/cache"
 class ConditionalGetController < Hanami::Action
   include Hanami::Action::Cache
 
-  def handle(*)
+  def call(*)
     # ...
     fresh last_modified: resource.update_at
     # => halt 304 with header IfModifiedSince = resource.update_at.httpdate
@@ -695,7 +695,7 @@ If you need to redirect the client to another resource, use `res.redirect_to`:
 
 ```ruby
 class Create < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.redirect_to "http://example.com/articles/23"
   end
@@ -709,7 +709,7 @@ You can also redirect with a custom status code:
 
 ```ruby
 class Create < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.redirect_to "http://example.com/articles/23", status: 301
   end
@@ -725,7 +725,7 @@ action.call({ article: { title: "Hello" }}) # => [301, {"Location" => "/articles
 
 ```ruby
 class Show < Hanami::Action
-  def handle(*)
+  def call(*)
   end
 end
 
@@ -742,7 +742,7 @@ However, you can force this value:
 
 ```ruby
 class Show < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.format = format(:json)
   end
@@ -763,7 +763,7 @@ You can restrict the accepted MIME types:
 class Show < Hanami::Action
   accept :html, :json
 
-  def handle(*)
+  def call(*)
     # ...
   end
 end
@@ -778,7 +778,7 @@ You can check if the requested MIME type is accepted by the client.
 
 ```ruby
 class Show < Hanami::Action
-  def handle(req, res)
+  def call(req, res)
     # ...
     # @_env["HTTP_ACCEPT"] # => "text/html,application/xhtml+xml,application/xml;q=0.9"
 
@@ -808,7 +808,7 @@ configuration = Hanami::Controller::Configuration.new do |config|
 end
 
 class Index < Hanami::Action
-  def handle(*)
+  def call(*)
   end
 end
 
@@ -818,7 +818,7 @@ response = action.call({ "HTTP_ACCEPT" => "application/custom" }) # => Content-T
 response.format                                                   # => :custom
 
 class Show < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     # ...
     res.format = format(:custom)
   end
@@ -840,7 +840,7 @@ configuration = Hanami::Controller::Configuration.new do |config|
 end
 
 class Csv < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     res.format = format(:csv)
     res.body = Enumerator.new do |yielder|
       yielder << csv_header
@@ -891,7 +891,7 @@ module Web
   module Controllers
     module Books
       class Show < Hanami::Action
-        def handle(*)
+        def call(*)
         end
       end
     end

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -1,23 +1,22 @@
 begin
-  require 'hanami/validations'
-  require 'hanami/action/validatable'
+  require "hanami/validations"
+  require "hanami/action/validatable"
 rescue LoadError
 end
 
-require 'hanami/utils/class_attribute'
-require 'hanami/utils/callbacks'
-require 'hanami/utils'
-require 'hanami/utils/string'
-require 'hanami/utils/kernel'
-require 'rack/utils'
+require "hanami/utils/class_attribute"
+require "hanami/utils/callbacks"
+require "hanami/utils"
+require "hanami/utils/string"
+require "hanami/utils/kernel"
+require "rack/utils"
 
-require_relative 'action/base_params'
-require_relative 'action/configuration'
-require_relative 'action/halt'
-require_relative 'action/mime'
-require_relative 'action/rack/file'
-require_relative 'action/request'
-require_relative 'action/response'
+require_relative "action/base_params"
+require_relative "action/proxy"
+require_relative "action/configuration"
+require_relative "action/halt"
+require_relative "action/mime"
+require_relative "action/rack/file"
 
 module Hanami
   # An HTTP endpoint
@@ -79,69 +78,69 @@ module Hanami
     # @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5
     # @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html
     ENTITY_HEADERS = {
-      'Allow'            => true,
-      'Content-Encoding' => true,
-      'Content-Language' => true,
-      'Content-Location' => true,
-      'Content-MD5'      => true,
-      'Content-Range'    => true,
-      'Expires'          => true,
-      'Last-Modified'    => true,
-      'extension-header' => true
+      "Allow" => true,
+      "Content-Encoding" => true,
+      "Content-Language" => true,
+      "Content-Location" => true,
+      "Content-MD5" => true,
+      "Content-Range" => true,
+      "Expires" => true,
+      "Last-Modified" => true,
+      "extension-header" => true
     }.freeze
 
     # The request method
     #
     # @since 0.3.2
     # @api private
-    REQUEST_METHOD = 'REQUEST_METHOD'.freeze
+    REQUEST_METHOD = "REQUEST_METHOD".freeze
 
     # The Content-Length HTTP header
     #
     # @since 1.0.0
     # @api private
-    CONTENT_LENGTH = 'Content-Length'.freeze
+    CONTENT_LENGTH = "Content-Length".freeze
 
     # The non-standard HTTP header to pass the control over when a resource
     # cannot be found by the current endpoint
     #
     # @since 1.0.0
     # @api private
-    X_CASCADE = 'X-Cascade'.freeze
+    X_CASCADE = "X-Cascade".freeze
 
     # HEAD request
     #
     # @since 0.3.2
     # @api private
-    HEAD = 'HEAD'.freeze
+    HEAD = "HEAD".freeze
 
     # The key that returns accepted mime types from the Rack env
     #
     # @since 0.1.0
     # @api private
-    HTTP_ACCEPT          = 'HTTP_ACCEPT'.freeze
+    HTTP_ACCEPT          = "HTTP_ACCEPT".freeze
 
     # The header key to set the mime type of the response
     #
     # @since 0.1.0
     # @api private
-    CONTENT_TYPE         = 'Content-Type'.freeze
+    CONTENT_TYPE         = "Content-Type".freeze
 
     # The default mime type for an incoming HTTP request
     #
     # @since 0.1.0
     # @api private
-    DEFAULT_ACCEPT       = '*/*'.freeze
+    DEFAULT_ACCEPT       = "*/*".freeze
 
     # The default mime type that is returned in the response
     #
     # @since 0.1.0
     # @api private
-    DEFAULT_CONTENT_TYPE = 'application/octet-stream'.freeze
+    DEFAULT_CONTENT_TYPE = "application/octet-stream".freeze
 
     # @since 0.2.0
     # @api private
-    RACK_ERRORS = 'rack.errors'.freeze
+    RACK_ERRORS = "rack.errors".freeze
 
     # This isn't part of Rack SPEC
     #
@@ -154,13 +153,13 @@ module Hanami
     # @see Hanami::Action::Throwable::RACK_ERRORS
     # @see http://www.rubydoc.info/github/rack/rack/file/SPEC#The_Error_Stream
     # @see https://github.com/hanami/controller/issues/133
-    RACK_EXCEPTION = 'rack.exception'.freeze
+    RACK_EXCEPTION = "rack.exception".freeze
 
     # The HTTP header for redirects
     #
     # @since 0.2.0
     # @api private
-    LOCATION = 'Location'.freeze
+    LOCATION = "Location".freeze
 
     # Override Ruby's hook for modules.
     # It includes basic Hanami::Action modules to the given class.
@@ -184,7 +183,7 @@ module Hanami
         end
       end
 
-      subclass.instance_variable_set '@configuration', configuration.dup
+      subclass.instance_variable_set "@configuration", configuration.dup
     end
 
     def self.configuration
@@ -222,7 +221,7 @@ module Hanami
     #
     # @api private
     # @since 2.0.0
-    def self.params(klass = nil, &blk)
+    def self.params(_klass = nil)
       raise NoMethodError,
             "To use `params`, please add 'hanami/validations' gem to your Gemfile"
     end
@@ -289,8 +288,8 @@ module Hanami
     #   # 1. authentication
     #   # 2. set the article
     #   # 3. #call
-    def self.append_before(*callbacks, &blk)
-      before_callbacks.append(*callbacks, &blk)
+    def self.append_before(...)
+      before_callbacks.append(...)
     end
 
     class << self
@@ -313,8 +312,8 @@ module Hanami
     # @since 0.3.2
     #
     # @see Hanami::Action::Callbacks::ClassMethods#append_before
-    def self.append_after(*callbacks, &blk)
-      after_callbacks.append(*callbacks, &blk)
+    def self.append_after(...)
+      after_callbacks.append(...)
     end
 
     class << self
@@ -337,8 +336,8 @@ module Hanami
     # @since 0.3.2
     #
     # @see Hanami::Action::Callbacks::ClassMethods#prepend_after
-    def self.prepend_before(*callbacks, &blk)
-      before_callbacks.prepend(*callbacks, &blk)
+    def self.prepend_before(...)
+      before_callbacks.prepend(...)
     end
 
     # Define a callback for an Action.
@@ -356,8 +355,8 @@ module Hanami
     # @since 0.3.2
     #
     # @see Hanami::Action::Callbacks::ClassMethods#prepend_before
-    def self.prepend_after(*callbacks, &blk)
-      after_callbacks.prepend(*callbacks, &blk)
+    def self.prepend_after(...)
+      after_callbacks.prepend(...)
     end
 
     # Restrict the access to the specified mime type symbols.
@@ -405,13 +404,15 @@ module Hanami
     #
     # @since 2.0.0
     def self.new(*args, configuration: self.configuration, **kwargs, &block)
-      allocate.tap do |obj|
+      action = allocate.tap do |obj|
         obj.instance_variable_set(:@name, Name[name])
         obj.instance_variable_set(:@configuration, configuration.dup.finalize!)
         obj.instance_variable_set(:@accepted_mime_types, Mime.restrict_mime_types(configuration, accepted_formats))
         obj.send(:initialize, *args, **kwargs, &block)
         obj.freeze
       end
+
+      Proxy.new(action)
     end
 
     module Name
@@ -426,45 +427,18 @@ module Hanami
       end
     end
 
-    attr_reader :name
+    attr_reader :name, :configuration
+
+    def initialize(**deps)
+      @_deps = deps
+    end
 
     # Implements the Rack/Hanami::Action protocol
     #
     # @since 0.1.0
     # @api private
     def call(env)
-      request  = nil
-      response = nil
-
-      halted = catch :halt do
-        begin
-          params   = self.class.params_class.new(env)
-          request  = build_request(env, params)
-          response = build_response(
-            request: request,
-            action: name,
-            configuration: configuration,
-            content_type: Mime.calculate_content_type_with_charset(configuration, request, accepted_mime_types),
-            env: env,
-            headers: configuration.default_headers
-          )
-
-          _run_before_callbacks(request, response)
-          handle(request, response)
-          _run_after_callbacks(request, response)
-        rescue => exception
-          _handle_exception(request, response, exception)
-        end
-      end
-
-      finish(request, response, halted)
     end
-
-    def initialize(**deps)
-      @_deps = deps
-    end
-
-    protected
 
     # Hook for subclasses to apply behavior as part of action invocation
     #
@@ -474,6 +448,46 @@ module Hanami
     # @since 2.0.0
     def handle(request, response)
     end
+
+    def accepted_mime_types
+      @accepted_mime_types || configuration.mime_types
+    end
+
+    # @since 0.1.0
+    # @api private
+    def _handle_exception(req, res, exception)
+      handler = exception_handler(exception)
+
+      if handler.nil?
+        _reference_in_rack_errors(req, exception)
+        raise exception
+      end
+
+      instance_exec(
+        req,
+        res,
+        exception,
+        &_exception_handler(handler)
+      )
+
+      nil
+    end
+
+    # @since 0.1.0
+    # @api private
+    def _run_before_callbacks(*args)
+      self.class.before_callbacks.run(self, *args)
+      nil
+    end
+
+    # @since 0.1.0
+    # @api private
+    def _run_after_callbacks(*args)
+      self.class.after_callbacks.run(self, *args)
+      nil
+    end
+
+    protected
 
     # Halt the action execution with the given HTTP status code and message.
     #
@@ -532,30 +546,16 @@ module Hanami
 
     private
 
-    attr_reader :configuration
-
-    def accepted_mime_types
-      @accepted_mime_types || configuration.mime_types
-    end
-
     def enforce_accepted_mime_types(req, *)
       Mime.accepted_mime_type?(req, accepted_mime_types, configuration) or halt 406
     end
 
     def exception_handler(exception)
       configuration.handled_exceptions.each do |exception_class, handler|
-        return handler if exception.kind_of?(exception_class)
+        return handler if exception.is_a?(exception_class)
       end
 
       nil
-    end
-
-    def build_request(env, params)
-      Request.new(env, params)
-    end
-
-    def build_response(**options)
-      Response.new(**options)
     end
 
     # @since 0.2.0
@@ -575,26 +575,6 @@ module Hanami
       [[exception.class, exception.message].compact.join(": "), *exception.backtrace].join("\n\t")
     end
 
-    # @since 0.1.0
-    # @api private
-    def _handle_exception(req, res, exception)
-      handler = exception_handler(exception)
-
-      if handler.nil?
-        _reference_in_rack_errors(req, exception)
-        raise exception
-      end
-
-      instance_exec(
-        req,
-        res,
-        exception,
-        &_exception_handler(handler)
-      )
-
-      nil
-    end
-
     # @since 0.3.0
     # @api private
     def _exception_handler(handler)
@@ -603,20 +583,6 @@ module Hanami
       else
         ->(*) { halt handler }
       end
-    end
-
-    # @since 0.1.0
-    # @api private
-    def _run_before_callbacks(*args)
-      self.class.before_callbacks.run(self, *args)
-      nil
-    end
-
-    # @since 0.1.0
-    # @api private
-    def _run_after_callbacks(*args)
-      self.class.after_callbacks.run(self, *args)
-      nil
     end
 
     # According to RFC 2616, when a response MUST have an empty body, it only

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -433,20 +433,13 @@ module Hanami
       @_deps = deps
     end
 
-    # Implements the Rack/Hanami::Action protocol
-    #
-    # @since 0.1.0
-    # @api private
-    def call(env)
-    end
-
     # Hook for subclasses to apply behavior as part of action invocation
     #
     # @param request [Hanami::Action::Request]
     # @param response [Hanami::Action::Response]
     #
     # @since 2.0.0
-    def handle(request, response)
+    def call(request, response)
     end
 
     def accepted_mime_types

--- a/lib/hanami/action/proxy.rb
+++ b/lib/hanami/action/proxy.rb
@@ -19,18 +19,10 @@ module Hanami
         halted = catch :halt do
           params   = action.class.params_class.new(env)
           request  = build_request(env, params)
-          response = build_response(
-            request: request,
-            action: action.name,
-            configuration: action.configuration,
-            content_type: Mime.calculate_content_type_with_charset(action.configuration, request,
-                                                                   action.accepted_mime_types),
-            env: env,
-            headers: action.configuration.default_headers
-          )
+          response = build_response(request, action, env)
 
           action._run_before_callbacks(request, response)
-          action.handle(request, response)
+          action.call(request, response)
           action._run_after_callbacks(request, response)
         rescue StandardError => exception
           action._handle_exception(request, response, exception)
@@ -47,8 +39,16 @@ module Hanami
         Request.new(env, params)
       end
 
-      def build_response(**options)
-        Response.new(**options)
+      def build_response(request, action, env)
+        Response.new(
+          request: request,
+          action: action.name,
+          configuration: action.configuration,
+          content_type: Mime.calculate_content_type_with_charset(action.configuration, request,
+                                                                 action.accepted_mime_types),
+          env: env,
+          headers: action.configuration.default_headers
+        )
       end
     end
   end

--- a/lib/hanami/action/proxy.rb
+++ b/lib/hanami/action/proxy.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "delegate"
+require_relative "./request"
+require_relative "./response"
+
+module Hanami
+  class Action
+    class Proxy < SimpleDelegator
+      def initialize(action)
+        super(action)
+        freeze
+      end
+
+      def call(env)
+        request  = nil
+        response = nil
+
+        halted = catch :halt do
+          params   = action.class.params_class.new(env)
+          request  = build_request(env, params)
+          response = build_response(
+            request: request,
+            action: action.name,
+            configuration: action.configuration,
+            content_type: Mime.calculate_content_type_with_charset(action.configuration, request,
+                                                                   action.accepted_mime_types),
+            env: env,
+            headers: action.configuration.default_headers
+          )
+
+          action._run_before_callbacks(request, response)
+          action.handle(request, response)
+          action._run_after_callbacks(request, response)
+        rescue StandardError => exception
+          action._handle_exception(request, response, exception)
+        end
+
+        action.__send__(:finish, request, response, halted)
+      end
+
+      private
+
+      alias_method :action, :__getobj__
+
+      def build_request(env, params)
+        Request.new(env, params)
+      end
+
+      def build_response(**options)
+        Response.new(**options)
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/controller/cache_spec.rb
+++ b/spec/integration/hanami/controller/cache_spec.rb
@@ -7,7 +7,7 @@ module CacheControl
 
     cache_control :public, max_age: 600
 
-    def handle(*)
+    def call(*)
     end
   end
 
@@ -16,7 +16,7 @@ module CacheControl
 
     cache_control :public, max_age: 600
 
-    def handle(_, res)
+    def call(_, res)
       res.cache_control :private
     end
   end
@@ -24,7 +24,7 @@ module CacheControl
   class Symbol < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.cache_control :private
     end
   end
@@ -32,7 +32,7 @@ module CacheControl
   class Symbols < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.cache_control :private, :no_cache, :no_store
     end
   end
@@ -40,7 +40,7 @@ module CacheControl
   class Hash < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.cache_control :public, :no_store, max_age: 900, s_maxage: 86_400, min_fresh: 500, max_stale: 700
     end
   end
@@ -48,7 +48,7 @@ module CacheControl
   class PrivatePublic < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.cache_control :private, :public
     end
   end
@@ -80,7 +80,7 @@ module Web
   module Controllers
     module Home
       class Index < Hanami::Action
-        def handle(*)
+        def call(*)
         end
       end
     end
@@ -91,7 +91,7 @@ module Admin
   module Controllers
     module Home
       class Index < Hanami::Action
-        def handle(*)
+        def call(*)
         end
       end
     end
@@ -104,7 +104,7 @@ module Expires
 
     expires 900, :public, :no_cache
 
-    def handle(*)
+    def call(*)
     end
   end
 
@@ -113,7 +113,7 @@ module Expires
 
     expires 900, :public, :no_cache
 
-    def handle(_, res)
+    def call(_, res)
       res.expires 600, :private
     end
   end
@@ -121,7 +121,7 @@ module Expires
   class Symbol < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.expires 900, :private
     end
   end
@@ -129,7 +129,7 @@ module Expires
   class Symbols < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.expires 900, :private, :no_cache, :no_store
     end
   end
@@ -137,7 +137,7 @@ module Expires
   class Hash < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.expires 900, :public, :no_store, s_maxage: 86_400, min_fresh: 500, max_stale: 700
     end
   end
@@ -168,7 +168,7 @@ module ConditionalGet
   class Etag < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.fresh etag: 'updated'
     end
   end
@@ -176,7 +176,7 @@ module ConditionalGet
   class LastModified < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.fresh last_modified: Time.now
     end
   end
@@ -184,7 +184,7 @@ module ConditionalGet
   class EtagLastModified < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.fresh etag: 'updated', last_modified: Time.now
     end
   end
@@ -217,7 +217,7 @@ module ConditionalGet
   class LastModifiedNilValue < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.fresh last_modified: nil
     end
   end
@@ -225,7 +225,7 @@ module ConditionalGet
   class EtagNilValue < Hanami::Action
     include Hanami::Action::Cache
 
-    def handle(_, res)
+    def call(_, res)
       res.fresh etag: nil
     end
   end

--- a/spec/integration/hanami/controller/rack_errors_spec.rb
+++ b/spec/integration/hanami/controller/rack_errors_spec.rb
@@ -28,19 +28,19 @@ ConfigurationHandledExceptionSubclass = Class.new(ConfigurationHandledException)
 module Errors
   # Unhandled
   class WithoutMessage < Hanami::Action
-    def handle(*)
+    def call(*)
       raise UnhandledException
     end
   end
 
   class WithMessage < Hanami::Action
-    def handle(*)
+    def call(*)
       raise UnhandledExceptionWithMessage, "boom"
     end
   end
 
   class WithCustomMessage < Hanami::Action
-    def handle(*)
+    def call(*)
       raise UnhandledExceptionWithCustomMessage, "nope"
     end
   end
@@ -49,7 +49,7 @@ module Errors
   class ActionHandled < Hanami::Action
     config.handle_exception HandledException => 400
 
-    def handle(*)
+    def call(*)
       raise HandledException
     end
   end
@@ -57,7 +57,7 @@ module Errors
   class ActionHandledSubclass < Hanami::Action
     config.handle_exception HandledException => 400
 
-    def handle(*)
+    def call(*)
       raise HandledExceptionSubclass
     end
   end
@@ -65,7 +65,7 @@ module Errors
   class ConfigurationHandled < Hanami::Action
     config.handle_exception ConfigurationHandledException => 500
 
-    def handle(*)
+    def call(*)
       raise ConfigurationHandledException
     end
   end
@@ -73,7 +73,7 @@ module Errors
   class ConfigurationHandledSubclass < Hanami::Action
     config.handle_exception ConfigurationHandledException => 500
 
-    def handle(*)
+    def call(*)
       raise ConfigurationHandledExceptionSubclass
     end
   end

--- a/spec/isolation/without_hanami_validations_spec.rb
+++ b/spec/isolation/without_hanami_validations_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Without validations' do
 
   it "has params that don't respond to .valid?" do
     action = Class.new(Hanami::Action) do
-      def handle(req, res)
+      def call(req, res)
         res.body = [req.params.respond_to?(:valid?), req.params.valid?]
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe 'Without validations' do
 
   it "has params that don't respond to .errors" do
     action = Class.new(Hanami::Action) do
-      def handle(req, res)
+      def call(req, res)
         res.body = req.params.respond_to?(:errors)
       end
     end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -84,14 +84,14 @@ end
 
 module Test
   class Index < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res[:xyz] = req.params[:name]
     end
   end
 end
 
 class CallAction < Hanami::Action
-  def handle(_req, res)
+  def call(_req, res)
     res.status = 201
     res.body   = "Hi from TestAction!"
     res.headers.merge!("X-Custom" => "OK")
@@ -99,7 +99,7 @@ class CallAction < Hanami::Action
 end
 
 class UncheckedErrorCallAction < Hanami::Action
-  def handle(_req, _res)
+  def call(_req, _res)
     raise
   end
 end
@@ -107,7 +107,7 @@ end
 class ErrorCallAction < Hanami::Action
   config.handle_exception RuntimeError => 500
 
-  def handle(_req, _res)
+  def call(_req, _res)
     raise
   end
 end
@@ -116,7 +116,7 @@ class MyCustomError < StandardError; end
 class ErrorCallFromInheritedErrorClass < Hanami::Action
   config.handle_exception StandardError => :handler
 
-  def handle(*)
+  def call(*)
     raise MyCustomError
   end
 
@@ -132,7 +132,7 @@ class ErrorCallFromInheritedErrorClassStack < Hanami::Action
   config.handle_exception StandardError => :standard_handler
   config.handle_exception MyCustomError => :handler
 
-  def handle(*)
+  def call(*)
     raise MyCustomError
   end
 
@@ -152,7 +152,7 @@ end
 class ErrorCallWithSymbolMethodNameAsHandlerAction < Hanami::Action
   config.handle_exception StandardError => :handler
 
-  def handle(*)
+  def call(*)
     raise StandardError
   end
 
@@ -167,7 +167,7 @@ end
 class ErrorCallWithStringMethodNameAsHandlerAction < Hanami::Action
   config.handle_exception StandardError => "standard_error_handler"
 
-  def handle(*)
+  def call(*)
     raise StandardError
   end
 
@@ -182,7 +182,7 @@ end
 class ErrorCallWithUnsetStatusResponse < Hanami::Action
   config.handle_exception ArgumentError => "arg_error_handler"
 
-  def handle(*)
+  def call(*)
     raise ArgumentError
   end
 
@@ -198,7 +198,7 @@ class ErrorCallWithSpecifiedStatusCodeAction < Hanami::Action
   configuration.handle_exception StandardError => 422
   puts "done"
 
-  def handle(_req, _res)
+  def call(_req, _res)
     raise StandardError
   end
 end
@@ -208,7 +208,7 @@ class BeforeMethodAction < Hanami::Action
   append_before :add_first_name_to_logger, :add_last_name_to_logger
   prepend_before :add_title_to_logger
 
-  def handle(req, res)
+  def call(req, res)
   end
 
   private
@@ -286,7 +286,7 @@ class BeforeBlockAction < Hanami::Action
   before { |_, res|   res[:article].reverse! }
   before { |req, res| res[:arguments] = [req.class.name, res.class.name] }
 
-  def handle(req, res)
+  def call(req, res)
   end
 end
 
@@ -299,7 +299,7 @@ class AfterMethodAction < Hanami::Action
   append_after :add_first_name_to_logger, :add_last_name_to_logger
   prepend_after :add_title_to_logger
 
-  def handle(*)
+  def call(*)
   end
 
   private
@@ -337,25 +337,25 @@ class AfterBlockAction < Hanami::Action
   after { |_, res| res[:egg].reverse! }
   after { |req, res| res[:arguments] = [req.class.name, res.class.name] }
 
-  def handle(*)
+  def call(*)
   end
 end
 
 class YieldAfterBlockAction < AfterBlockAction
   after { |req, res| res[:meaning_of_life_params] = req.params }
 
-  def handle(*)
+  def call(*)
   end
 end
 
 class MissingSessionAction < Hanami::Action
-  def handle(*)
+  def call(*)
     session
   end
 end
 
 class MissingFlashAction < Hanami::Action
-  def handle(*)
+  def call(*)
     flash
   end
 end
@@ -363,32 +363,32 @@ end
 class SessionAction < Hanami::Action
   include Hanami::Action::Session
 
-  def handle(req, res)
+  def call(req, res)
   end
 end
 
 class FlashAction < Hanami::Action
   include Hanami::Action::Session
 
-  def handle(*, res)
+  def call(*, res)
     res.flash[:error] = "ouch"
   end
 end
 
 class RedirectAction < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     res.redirect_to "/destination"
   end
 end
 
 class StatusRedirectAction < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     res.redirect_to "/destination", status: 301
   end
 end
 
 class SafeStringRedirectAction < Hanami::Action
-  def handle(*, res)
+  def call(*, res)
     location = Hanami::Utils::Escape::SafeString.new("/destination")
     res.redirect_to location
   end
@@ -397,7 +397,7 @@ end
 class GetCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     res.body = res.cookies[:foo]
   end
 end
@@ -405,7 +405,7 @@ end
 class ChangeCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     res.body = res.cookies[:foo]
     res.cookies[:foo] = "baz"
   end
@@ -416,7 +416,7 @@ class GetDefaultCookiesAction < Hanami::Action
 
   config.cookies = { domain: "hanamirb.org", path: "/controller", secure: true, httponly: true }
 
-  def handle(*, res)
+  def call(*, res)
     res.body          = ""
     res.cookies[:bar] = "foo"
   end
@@ -427,7 +427,7 @@ class GetOverwrittenCookiesAction < Hanami::Action
 
   config.cookies = { domain: "hanamirb.org", path: "/controller", secure: true, httponly: true }
 
-  def handle(*, res)
+  def call(*, res)
     res.body          = ""
     res.cookies[:bar] = { value: "foo", domain: "hanamirb.com", path: "/action", secure: false, httponly: false }
   end
@@ -436,7 +436,7 @@ end
 class GetAutomaticallyExpiresCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     res.cookies[:bar] = { value: "foo", max_age: 120 }
   end
 end
@@ -444,7 +444,7 @@ end
 class SetCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     res.body          = "yo"
     res.cookies[:foo] = "yum!"
   end
@@ -457,7 +457,7 @@ class SetCookiesWithOptionsAction < Hanami::Action
     @expires = expires
   end
 
-  def handle(*, res)
+  def call(*, res)
     res.cookies[:kukki] = { value: "yum!", domain: "hanamirb.org", path: "/controller", expires: @expires, secure: true, httponly: true }
   end
 end
@@ -465,7 +465,7 @@ end
 class RemoveCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     res.cookies[:rm] = nil
   end
 end
@@ -473,7 +473,7 @@ end
 class IterateCookiesAction < Hanami::Action
   include Hanami::Action::Cookies
 
-  def handle(*, res)
+  def call(*, res)
     result = []
     res.cookies.each do |key, value|
       result << "'#{key}' has value '#{value}'"
@@ -484,13 +484,13 @@ class IterateCookiesAction < Hanami::Action
 end
 
 class ThrowCodeAction < Hanami::Action
-  def handle(req, *)
+  def call(req, *)
     halt req.params[:status].to_i, req.params[:message]
   end
 end
 
 class CatchAndThrowSymbolAction < Hanami::Action
-  def handle(_req, _res)
+  def call(_req, _res)
     catch :done do
       throw :done, 1
       raise "This code shouldn't be reachable"
@@ -502,7 +502,7 @@ class ThrowBeforeMethodAction < Hanami::Action
   before :authorize!
   before :set_body
 
-  def handle(_req, res)
+  def call(_req, res)
     res.body = "Hello!"
   end
 
@@ -521,7 +521,7 @@ class ThrowBeforeBlockAction < Hanami::Action
   before { halt 401 }
   before { res.body = "Hi!" }
 
-  def handle(_req, res)
+  def call(_req, res)
     res.body = "Hello!"
   end
 end
@@ -530,7 +530,7 @@ class ThrowAfterMethodAction < Hanami::Action
   after :raise_timeout!
   after :set_body
 
-  def handle(_req, res)
+  def call(_req, res)
     res.body = "Hello!"
   end
 
@@ -549,7 +549,7 @@ class ThrowAfterBlockAction < Hanami::Action
   after { halt 408 }
   after { res.body = "Later!" }
 
-  def handle(_req, res)
+  def call(_req, res)
     res.body = "Hello!"
   end
 end
@@ -557,7 +557,7 @@ end
 class HandledExceptionAction < Hanami::Action
   config.handle_exception RecordNotFound => 404
 
-  def handle(_req, _res)
+  def call(_req, _res)
     raise RecordNotFound.new
   end
 end
@@ -568,19 +568,19 @@ end
 class GlobalHandledExceptionAction < Hanami::Action
   config.handle_exception DomainLogicException => 400
 
-  def handle(_req, _res)
+  def call(_req, _res)
     raise DomainLogicException.new
   end
 end
 
 class UnhandledExceptionAction < Hanami::Action
-  def handle(_req, _res)
+  def call(_req, _res)
     raise RecordNotFound.new
   end
 end
 
 class ParamsAction < Hanami::Action
-  def handle(req, res)
+  def call(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -602,7 +602,7 @@ class WhitelistedParamsAction < Hanami::Action
 
   params Params
 
-  def handle(req, res)
+  def call(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -612,7 +612,7 @@ class WhitelistedDslAction < Hanami::Action
     required(:username).filled
   end
 
-  def handle(req, res)
+  def call(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -627,7 +627,7 @@ class WhitelistedUploadDslAction < Hanami::Action
     required(:upload).filled
   end
 
-  def handle(req, res)
+  def call(req, res)
     res.body = req.params.to_h.inspect
   end
 end
@@ -637,7 +637,7 @@ class ParamsValidationAction < Hanami::Action
     required(:email).filled(:str?)
   end
 
-  def handle(req, *)
+  def call(req, *)
     halt 400 unless req.params.valid?
   end
 end
@@ -689,7 +689,7 @@ class NestedParams < Hanami::Action::Params
 end
 
 class Root < Hanami::Action
-  def handle(req, res)
+  def call(req, res)
     res.body = req.params.to_h.inspect
     res.headers.merge!("X-Test" => "test")
   end
@@ -697,14 +697,14 @@ end
 
 module About
   class Team < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
       res.headers.merge!("X-Test" => "test")
     end
   end
 
   class Contacts < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -712,37 +712,37 @@ end
 
 module Identity
   class Show < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class New < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Create < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Edit < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Update < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Destroy < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -750,43 +750,43 @@ end
 
 module Flowers
   class Index < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Show < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class New < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Create < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Edit < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Update < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
 
   class Destroy < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -808,7 +808,7 @@ module Painters
       end
     end
 
-    def handle(req, res)
+    def call(req, res)
       res.body = req.params.to_h.inspect
     end
   end
@@ -819,7 +819,7 @@ module Dashboard
     include Hanami::Action::Session
     before :authenticate!
 
-    def handle(*, res)
+    def call(*, res)
       res.body = "User ID from session: #{res.session[:user_id]}"
     end
 
@@ -839,7 +839,7 @@ module Sessions
   class Create < Hanami::Action
     include Hanami::Action::Session
 
-    def handle(*, res)
+    def call(*, res)
       res.session[:user_id] = 23
       res.redirect_to "/"
     end
@@ -848,7 +848,7 @@ module Sessions
   class Destroy < Hanami::Action
     include Hanami::Action::Session
 
-    def handle(*, res)
+    def call(*, res)
       res.session[:user_id] = nil
     end
   end
@@ -857,7 +857,7 @@ end
 class StandaloneSession < Hanami::Action
   include Hanami::Action::Session
 
-  def handle(*, res)
+  def call(*, res)
     res.session[:age] = Time.now.year - 1982
   end
 end
@@ -866,7 +866,7 @@ module Glued
   class SendFile < Hanami::Action
     include Hanami::Action::Glue
 
-    def handle(_req, _res)
+    def call(_req, _res)
       send_file "test.txt"
     end
   end
@@ -882,7 +882,7 @@ module App
   class StandaloneAction < Hanami::Action
     config.handle_exception App::CustomError => 400
 
-    def handle(_req, _res)
+    def call(_req, _res)
       raise App::CustomError
     end
   end
@@ -896,7 +896,7 @@ module App2
     class Index < Hanami::Action
       config.handle_exception App2::CustomError => 400
 
-      def handle(_req, _res)
+      def call(_req, _res)
         raise App2::CustomError
       end
     end
@@ -927,7 +927,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def handle(_req, res)
+        def call(_req, res)
           res.body = "Muzic!"
           res.headers["X-Frame-Options"] = "ALLOW FROM https://example.org"
         end
@@ -938,7 +938,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def handle(_req, _res)
+        def call(_req, _res)
           raise ArgumentError
         end
       end
@@ -950,7 +950,7 @@ module MusicPlayer
         include Hanami::Action::Session
         include MusicPlayer::Controllers::Authentication
 
-        def handle(_req, res)
+        def call(_req, res)
           res.body = current_user
         end
       end
@@ -962,7 +962,7 @@ module MusicPlayer
 
         config.handle_exception ArtistNotFound => 404
 
-        def handle(_req, _res)
+        def call(_req, _res)
           raise ArtistNotFound
         end
       end
@@ -974,7 +974,7 @@ module MusicPlayer
     include Hanami::Action::Session
     include MusicPlayer::Controllers::Authentication
 
-    def handle(_req, _res)
+    def call(_req, _res)
       raise ArgumentError
     end
   end
@@ -995,7 +995,7 @@ class VisibilityAction < Hanami::Action
   include Hanami::Action::Cookies
   include Hanami::Action::Session
 
-  def handle(*, res)
+  def call(*, res)
     res.body   = "x"
     res.status = 201
     res.format = :json
@@ -1008,7 +1008,7 @@ end
 module SendFileTest
   module Files
     class Show < Hanami::Action
-      def handle(req, res)
+      def call(req, res)
         id = req.params[:id]
 
         # This if statement is only for testing purpose
@@ -1055,44 +1055,44 @@ module SendFileTest
     end
 
     class UnsafeLocal < Hanami::Action
-      def handle(*, res)
+      def call(*, res)
         res.unsafe_send_file "Gemfile"
       end
     end
 
     class UnsafePublic < Hanami::Action
-      def handle(*, res)
+      def call(*, res)
         res.unsafe_send_file "spec/support/fixtures/test.txt"
       end
     end
 
     class UnsafeAbsolute < Hanami::Action
-      def handle(*, res)
+      def call(*, res)
         res.unsafe_send_file Pathname.new("Gemfile").realpath
       end
     end
 
     class UnsafeMissingLocal < Hanami::Action
-      def handle(*, res)
+      def call(*, res)
         res.unsafe_send_file "missing"
       end
     end
 
     class UnsafeMissingAbsolute < Hanami::Action
-      def handle(_req, res)
+      def call(_req, res)
         res.unsafe_send_file Pathname.new(".").join("missing")
       end
     end
 
     class Flow < Hanami::Action
-      def handle(*, res)
+      def call(*, res)
         res.send_file Pathname.new("test.txt")
         res.redirect_to "/"
       end
     end
 
     class Glob < Hanami::Action
-      def handle(*)
+      def call(*)
         halt 202
       end
     end
@@ -1100,7 +1100,7 @@ module SendFileTest
     class BeforeCallback < Hanami::Action
       before :before_callback
 
-      def handle(*, res)
+      def call(*, res)
         res.send_file Pathname.new("test.txt")
       end
 
@@ -1114,7 +1114,7 @@ module SendFileTest
     class AfterCallback < Hanami::Action
       after :after_callback
 
-      def handle(*, res)
+      def call(*, res)
         res.send_file Pathname.new("test.txt")
       end
 
@@ -1163,7 +1163,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def handle(_req, res)
+      def call(_req, res)
         res.body = "index"
       end
     end
@@ -1173,7 +1173,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def handle(req, res)
+      def call(req, res)
         content = "code"
 
         res.headers.merge!(
@@ -1196,7 +1196,7 @@ module HeadTest
       include Hanami::Action::Glue
       include Hanami::Action::Session
 
-      def handle(_req, res)
+      def call(_req, res)
         res.headers.merge!(
           "Last-Modified" => "Fri, 27 Nov 2015 13:32:36 GMT",
           "X-Rate-Limit"  => "4000",
@@ -1248,7 +1248,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(*, res)
+        def call(*, res)
           res[:greeting] = "Hello"
         end
       end
@@ -1258,7 +1258,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(*, res)
+        def call(*, res)
           res.body = "foo"
         end
       end
@@ -1270,7 +1270,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(*)
+        def call(*)
         end
       end
 
@@ -1283,7 +1283,7 @@ module FullStack
           required(:title).filled(:str?)
         end
 
-        def handle(req, res)
+        def call(req, res)
           req.params.valid?
 
           res.redirect_to "/books"
@@ -1311,7 +1311,7 @@ module FullStack
           end
         end
 
-        def handle(req, res)
+        def call(req, res)
           valid = req.params.valid?
 
           res.status = 201
@@ -1330,7 +1330,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(*)
+        def call(*)
         end
       end
 
@@ -1339,7 +1339,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(*, res)
+        def call(*, res)
           res.flash[:message] = "Saved!"
           res.redirect_to "/settings"
         end
@@ -1352,7 +1352,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(*, res)
+        def call(*, res)
           res.redirect_to "/poll/1"
         end
       end
@@ -1362,7 +1362,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(req, res)
+        def call(req, res)
           if req.env["REQUEST_METHOD"] == "GET"
             res.flash[:notice] = "Start the poll"
           else
@@ -1377,7 +1377,7 @@ module FullStack
         include Hanami::Action::Session
         include Inspector
 
-        def handle(req, res)
+        def call(req, res)
           if req.env["REQUEST_METHOD"] == "POST"
             res.flash[:notice] = "Poll completed"
             res.redirect_to "/"
@@ -1395,7 +1395,7 @@ module FullStack
         before :redirect_to_root
         after :set_body
 
-        def handle(*, res)
+        def call(*, res)
           res.body = "call method shouldn't be called"
         end
 
@@ -1450,7 +1450,7 @@ module FullStack
 end
 
 class MethodInspectionAction < Hanami::Action
-  def handle(req, res)
+  def call(req, res)
     res.body = req.request_method
   end
 end
@@ -1459,7 +1459,7 @@ class RackExceptionAction < Hanami::Action
   class TestException < ::StandardError
   end
 
-  def handle(_req, _res)
+  def call(_req, _res)
     raise TestException.new
   end
 end
@@ -1470,7 +1470,7 @@ class HandledRackExceptionAction < Hanami::Action
 
   config.handle_exception TestException => 500
 
-  def handle(_req, _res)
+  def call(_req, _res)
     raise TestException.new
   end
 end
@@ -1484,7 +1484,7 @@ class HandledRackExceptionSubclassAction < Hanami::Action
 
   config.handle_exception TestException => 500
 
-  def handle(_req, _res)
+  def call(_req, _res)
     raise TestSubclassException.new
   end
 end
@@ -1497,7 +1497,7 @@ module SessionWithCookies
         include Hanami::Action::Session
         include Hanami::Action::Cookies
 
-        def handle(req, res)
+        def call(req, res)
         end
       end
     end
@@ -1532,7 +1532,7 @@ module SessionsWithoutCookies
         include Hanami::Action::Session
         include Inspector
 
-        def handle(*)
+        def call(*)
         end
       end
     end
@@ -1559,20 +1559,20 @@ end
 
 module Mimes
   class Default < Hanami::Action
-    def handle(_req, res)
+    def call(_req, res)
       res.body, = *format(res.content_type)
     end
   end
 
   class Custom < Hanami::Action
-    def handle(_req, res)
+    def call(_req, res)
       res.format = format(:xml)
       res.body   = res.format
     end
   end
 
   class Latin < Hanami::Action
-    def handle(_req, res)
+    def call(_req, res)
       res.charset = "latin1"
       res.format  = format(:html)
       res.body    = res.format
@@ -1580,7 +1580,7 @@ module Mimes
   end
 
   class Accept < Hanami::Action
-    def handle(req, res)
+    def call(req, res)
       res.headers["X-AcceptDefault"] = req.accept?("application/octet-stream").to_s
       res.headers["X-AcceptHtml"]    = req.accept?("text/html").to_s
       res.headers["X-AcceptXml"]     = req.accept?("application/xml").to_s
@@ -1593,7 +1593,7 @@ module Mimes
   class CustomFromAccept < Hanami::Action
     accept :json, :custom
 
-    def handle(*, res)
+    def call(*, res)
       res.body, = *format(res.content_type)
     end
   end
@@ -1601,19 +1601,19 @@ module Mimes
   class Restricted < Hanami::Action
     accept :html, :json, :custom
 
-    def handle(_req, res)
+    def call(_req, res)
       res.body, = *format(res.content_type)
     end
   end
 
   class NoContent < Hanami::Action
-    def handle(_req, res)
+    def call(_req, res)
       res.status = 204
     end
   end
 
   class OverrideDefaultResponse < Hanami::Action
-    def handle(*, res)
+    def call(*, res)
       res.format = format(:xml)
     end
 
@@ -1627,7 +1627,7 @@ module Mimes
   class Strict < Hanami::Action
     accept :json
 
-    def handle(_req, res)
+    def call(_req, res)
       res.body, = *format(res.content_type)
     end
   end
@@ -1661,7 +1661,7 @@ module MimesWithDefault
   class Default < Hanami::Action
     accept :json
 
-    def handle(*, res)
+    def call(*, res)
       res.body, = *format(res.content_type)
     end
   end
@@ -1760,7 +1760,7 @@ module Flash
       class Index < Hanami::Action
         include Hanami::Action::Session
 
-        def handle(req, res)
+        def call(req, res)
           res.flash[:hello] = "world"
 
           if req.env["REQUEST_METHOD"] == "GET"
@@ -1774,7 +1774,7 @@ module Flash
       class Books < Hanami::Action
         include Hanami::Action::Session
 
-        def handle(_, res)
+        def call(_, res)
           res.body = "flash_empty: #{res.flash.empty?} flash: #{res.flash.inspect}"
         end
       end
@@ -1782,7 +1782,7 @@ module Flash
       class Print < Hanami::Action
         include Hanami::Action::Session
 
-        def handle(_, res)
+        def call(_, res)
           res.body = res.flash[:hello]
         end
       end
@@ -1790,7 +1790,7 @@ module Flash
       class EachRedirect < Hanami::Action
         include Hanami::Action::Session
 
-        def handle(_, res)
+        def call(_, res)
           res.flash[:hello] = "world"
           res.redirect_to "/each"
         end
@@ -1799,7 +1799,7 @@ module Flash
       class Each < Hanami::Action
         include Hanami::Action::Session
 
-        def handle(_, res)
+        def call(_, res)
           each_result = []
           res.flash.each { |type, message| each_result << [type, message] }
           res.body = "flash_each: #{each_result}"
@@ -1809,7 +1809,7 @@ module Flash
       class MapRedirect < Hanami::Action
         include Hanami::Action::Session
 
-        def handle(_, res)
+        def call(_, res)
           res.flash[:hello] = "world"
           res.redirect_to "/map"
         end
@@ -1818,7 +1818,7 @@ module Flash
       class Map < Hanami::Action
         include Hanami::Action::Session
 
-        def handle(_, res)
+        def call(_, res)
           res.body = "flash_map: #{res.flash.map { |type, message| [type, message] }}"
         end
       end
@@ -1890,13 +1890,13 @@ module Inheritance
       end
 
       class Show < RestfulAction
-        def handle(*, res)
+        def call(*, res)
           res[:found] = true
         end
       end
 
       class Destroy < Show
-        def handle(*, res)
+        def call(*, res)
           super
           res[:destroyed] = true
         end

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Hanami::Action do
   class FormatController
     class Lookup < Hanami::Action
-      def handle(*)
+      def call(*)
       end
     end
 
     class Custom < Hanami::Action
-      def handle(req, res)
+      def call(req, res)
         input = req.params[:format]
         input = input.to_sym unless input.nil?
 
@@ -17,7 +17,7 @@ RSpec.describe Hanami::Action do
     class Configuration < Hanami::Action
       config.default_response_format = :jpg
 
-      def handle(*, res)
+      def call(*, res)
         res.body = res.format
       end
     end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Hanami::Action do
   describe "request" do
     it "gets a Rack-like request object" do
       action_class = Class.new(Hanami::Action) do
-        def handle(req, res)
+        def call(req, res)
           res[:request] = req
         end
       end


### PR DESCRIPTION
# Enhancement

Re-establish `Hanami::Action#call` as Public API for Hanami 2.0 actions.

During the Hanami 2.0 rewriting, we had to gave up to a _Hanami signature_ method `#call` for actions in favor of `#handle`. This was to reduce the internal complexity (meta-programming) of `Hanami::Action`.

# Implementation details

Introduce `Hanami::Action::Proxy`, a wrapper around `Hanami::Action` that acts as an adapter with Rack.
It's responsible to prepare the execution (instantiate request, response, run callbacks) and finally invokes `Hanami::Action#call`.

This wrapper eliminates the need of meta-programming to keep `Hanami::Action#call` as Public API.

For each incoming Rack request

```
[rack server] --> [router] --> *[action proxy] --> [action]

* new addition of this PR.
```