### PR TITLE
Remove `hanami-utils` as a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,20 +11,20 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "hanami-utils",  "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git",  branch: "main"
-gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "main"
+gem "hanami-router", "~> 2.0.beta", require: false, git: "https://github.com/hanami/router.git", branch: "main"
 
 group :validations do
-  gem "hanami-validations", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/validations.git",
-                                            branch: "main"
+  gem "hanami-validations", "~> 2.0.beta", require: false, git: "https://github.com/hanami/validations.git",
+                                           branch: "main"
 end
 
 group :test do
-  gem "dry-files",   "~> 0.1", github: "dry-rb/dry-files", branch: "main"
+  gem "dry-files", "~> 0.1", github: "dry-rb/dry-files", branch: "main"
 
-  gem "hanami-cli",  "~> 2.0.alpha", github: "hanami/cli", branch: "main"
-  gem "hanami-view", "~> 2.0.alpha", github: "hanami/view", branch: "main"
-  gem "hanami",      "~> 2.0.alpha", github: "hanami/hanami", branch: "main"
+  gem "hanami-utils", "~> 2.0.beta",  github: "hanami/utils", branch: "main"
+  gem "hanami-cli",   "~> 2.0.alpha", github: "hanami/cli", branch: "main"
+  gem "hanami-view",  "~> 2.0.alpha", github: "hanami/view", branch: "main"
+  gem "hanami",       "~> 2.0.alpha", github: "hanami/hanami", branch: "main"
   gem "slim"
 end
 

--- a/hanami-controller.gemspec
+++ b/hanami-controller.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.required_ruby_version = ">= 3.0"
 
-  spec.add_dependency "rack",         "~> 2.0"
-  spec.add_dependency "hanami-utils", "~> 2.0.alpha"
+  spec.add_dependency "rack",             "~> 2.0"
   spec.add_dependency "dry-configurable", "~> 0.13", ">= 0.13.0"
 
   spec.add_development_dependency "bundler",   ">= 1.6", "< 3"

--- a/lib/hanami/action/blank.rb
+++ b/lib/hanami/action/blank.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    # Checks for blank
+    #
+    # @since 2.0.0
+    # @api private
+    class Blank
+      # Matcher for blank strings
+      #
+      # @since 2.0.0
+      # @api private
+      STRING_MATCHER = /\A[[:space:]]*\z/
+
+      # Checks if object is blank
+      #
+      # @example Basic Usage
+      #   require "hanami/action/blank"
+      #
+      #   Hanami::Action::Blank.blank?("")   # => true
+      #   Hanami::Action::Blank.blank?("  ") # => true
+      #   Hanami::Action::Blank.blank?(nil)  # => true
+      #   Hanami::Action::Blank.blank?(true) # => false
+      #   Hanami::Action::Blank.blank?(1)    # => false
+      #
+      # @param object the argument
+      #
+      # @return [TrueClass,FalseClass] info, whether object is blank
+      #
+      # @since 2.0.0
+      # @api private
+      def self.blank?(object)
+        case object
+        when ::String
+          STRING_MATCHER === object
+        when ::Hash, ::Array
+          object.empty?
+        when TrueClass, Numeric
+          false
+        when FalseClass, NilClass
+          true
+        else
+          object.respond_to?(:empty?) ? object.empty? : !self
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/utils/blank"
+require "hanami/action/blank"
 
 module Hanami
   class Action
@@ -71,8 +71,8 @@ module Hanami
         # @since 0.3.0
         # @api private
         def fresh?
-          return false if Hanami::Utils::Blank.blank?(modified_since)
-          return false if Hanami::Utils::Blank.blank?(@value)
+          return false if Hanami::Action::Blank.blank?(modified_since)
+          return false if Hanami::Action::Blank.blank?(@value)
 
           Time.httpdate(modified_since).to_i >= @value.to_time.to_i
         end

--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/utils/blank"
+require "hanami/action/blank"
 require "rack/utils"
 require "securerandom"
 
@@ -146,7 +146,7 @@ module Hanami
       #
       # @api private
       def missing_csrf_token?(req, _res)
-        Hanami::Utils::Blank.blank?(req.params[CSRF_TOKEN])
+        Hanami::Action::Blank.blank?(req.params[CSRF_TOKEN])
       end
 
       # Generates a random CSRF Token


### PR DESCRIPTION
We look to decommission `hanami-utils` in the long run.