### PR TITLE
Fixes for YARD docs

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -85,8 +85,8 @@ module Hanami
 
     # @!scope instance
 
-    # Override Ruby's hook for modules.
-    # It includes basic Hanami::Action modules to the given class.
+    # Overrides Ruby's hook for modules.
+    # It includes basic {Hanami::Action} modules to the given class.
     #
     # @param subclass [Class] the target action
     #
@@ -109,10 +109,10 @@ module Hanami
     # Returns the class which defines the params
     #
     # Returns the class which has been provided to define the
-    # params. By default this will be Hanami::Action::Params.
+    # params. By default this will be {Hanami::Action::Params Hanami::Action::Params}.
     #
     # @return [Class] A params class (when whitelisted) or
-    #   Hanami::Action::Params
+    #   {Hanami::Action::Params Hanami::Action::Params}
     #
     # @api private
     # @since 0.7.0
@@ -133,21 +133,23 @@ module Hanami
             "To use `params`, please add 'hanami/validations' gem to your Gemfile"
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **before** the action is called, in the
+    # Defines a callback for an Action.
+    # Callbacks defined using this method will be executed **before** the action is called, in the
     # order they are added.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
+    # @overload append_before(callbacks, blk)
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
     # @return [void]
     #
     # @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#append_after
+    # @see Hanami::Action.append_after
+    # @see Hanami::Action.prepend_before
     #
     # @example Method names (symbols)
     #   require "hanami/controller"
@@ -200,21 +202,23 @@ module Hanami
       alias_method :before, :append_before
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **after** the action is called, in the
+    # Defines a callback for an Action.
+    # Callbacks defined using this method will be executed **after** the action is called, in the
     # order they are added.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
+    # @overload append_after(callbacks, blk)
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
     # @return [void]
     #
     # @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#append_before
+    # @see Hanami::Action.append_before
+    # @see Hanami::Action.prepend_after
     def self.append_after(...)
       config.after_callbacks.append(...)
     end
@@ -224,45 +228,52 @@ module Hanami
       alias_method :after, :append_after
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **before** the action is called.
-    # It will add the callback at the beginning of the callbacks' chain.
+    # Defines a callback for an Action.
+    # Callbacks defined using this method will be executed **before** the action is called.
+    # It will add the callback at the beginning of the callbacks chain.
+    # @overload prepend_before(callbacks, blk)
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
-    #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
     # @return [void]
     #
     # @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#prepend_after
+    # @see Hanami::Action.prepend_after
+    # @see Hanami::Action.append_before
     def self.prepend_before(...)
       config.before_callbacks.prepend(...)
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **after** the action is called.
-    # It will add the callback at the beginning of the callbacks' chain.
+    # Defines a callback for an Action.
+    # Callbacks defined using this method will be executed **after** the action is called.
+    # It will add the callback at the beginning of the callbacks chain.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
+    # @overload prepend_after(callbacks, blk)
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
     # @return [void]
     #
     # @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#prepend_before
+    # @see Hanami::Action.prepend_before
+    # @see Hanami::Action.append_after
     def self.prepend_after(...)
       config.after_callbacks.prepend(...)
     end
 
-    # Restrict the access to the specified mime type symbols.
+    # Restricts the access to the specified mime type symbols. Halts processing the request
+    # and returns HTTP 406 (Not Acceptable) if the action is called without acceptable mime type.
+    #
+    # The list of acceptable values is keys of {Hanami::Action::Mime::TYPES} hash. If one of the
+    # arguments to +accept+ method is not recognized, {Hanami::Controller::UnknownFormatError} will be raised.
     #
     # @param formats[Array<Symbol>] one or more symbols representing mime type(s)
     #
@@ -349,6 +360,9 @@ module Hanami
 
     # Hook for subclasses to apply behavior as part of action invocation
     #
+    # This is a method where actuall logic of an action should be placed. It is invoked by {call}
+    # method (which is a part of the private API) after running before-hooks and before running after-hooks.
+    #
     # @param request [Hanami::Action::Request]
     # @param response [Hanami::Action::Response]
     #
@@ -357,7 +371,7 @@ module Hanami
     def handle(request, response)
     end
 
-    # Halt the action execution with the given HTTP status code and message.
+    # Halts the action execution with given HTTP status code and message.
     #
     # When used, the execution of a callback or of an action is interrupted
     # and the control returns to the framework, that decides how to handle
@@ -365,7 +379,7 @@ module Hanami
     #
     # If a message is provided, it sets the response body with the message.
     # Otherwise, it sets the response body with the default message associated
-    # to the code (eg 404 will set `"Not Found"`).
+    # with the code (e.g. 404 will set +"Not Found"+).
     #
     # @param status [Fixnum] a valid HTTP status code
     # @param body [String] the response body
@@ -374,8 +388,8 @@ module Hanami
     #
     # @since 0.2.0
     #
-    # @see Hanami::Action::Throwable#handle_exception
-    # @see Hanami::Http::Status:ALL
+    # @see Hanami::Action::Configuration#handle_exception
+    # @see Hanami::Http::Status::ALL
     #
     # @example Basic usage
     #   require "hanami/controller"

--- a/lib/hanami/action/base_params.rb
+++ b/lib/hanami/action/base_params.rb
@@ -18,7 +18,7 @@ module Hanami
       # @api private
       attr_reader :raw
 
-      # Initialize the params and freeze them.
+      # Initializes the params and freezes them.
       #
       # @param env [Hash] a Rack env or an hash of params.
       #
@@ -44,7 +44,7 @@ module Hanami
         @params[key]
       end
 
-      # Get an attribute value associated with the given key.
+      # Gets an attribute value associated with the given key.
       # Nested attributes are reached by listing all the keys to get to the value.
       #
       # @param keys [Array<Symbol,Integer>] the key
@@ -77,13 +77,13 @@ module Hanami
         @params.dig(*keys)
       end
 
-      # This is for compatibility with Hanami::Helpers::FormHelper::Values
+      # This is for compatibility with +Hanami::Helpers::FormHelper::Values+
       #
       # @api private
       # @since 0.8.0
       alias_method :dig, :get
 
-      # Provide a common interface with Params
+      # Provides a common interface with Params
       #
       # @return [TrueClass] always returns true
       #
@@ -94,7 +94,7 @@ module Hanami
         true
       end
 
-      # Serialize params to Hash
+      # Serializes params to a +Hash+
       #
       # @return [::Hash]
       #

--- a/lib/hanami/action/cache.rb
+++ b/lib/hanami/action/cache.rb
@@ -10,11 +10,11 @@ module Hanami
     #
     # @since 0.3.0
     #
-    # @see Hanami::Action::Cache::ClassMethods#cache_control
-    # @see Hanami::Action::Cache::ClassMethods#expires
-    # @see Hanami::Action::Cache::ClassMethods#fresh
+    # @see Hanami::Action::Cache::CacheControl::ClassMethods#cache_control
+    # @see Hanami::Action::Cache::Expires::ClassMethods#expires
+    # @see Hanami::Action::Cache::ETag#fresh?
     module Cache
-      # Override Ruby's hook for modules.
+      # Overrides Ruby's hook for modules.
       # It includes exposures logic
       #
       # @param base [Class] the target action
@@ -22,7 +22,7 @@ module Hanami
       # @since 0.3.0
       # @api private
       #
-      # @see http://www.ruby-doc.org/core/Module.html#method-i-included
+      # @see https://www.ruby-doc.org/core/Module.html#method-i-included
       def self.included(base)
         base.class_eval do
           include CacheControl, Expires

--- a/lib/hanami/action/cache/cache_control.rb
+++ b/lib/hanami/action/cache/cache_control.rb
@@ -39,7 +39,7 @@ module Hanami
           end
         end
 
-        # Finalize the response including default cache headers into the response
+        # Finalizes the response including default cache headers into the response
         #
         # @since 0.3.0
         # @api private

--- a/lib/hanami/action/cache/expires.rb
+++ b/lib/hanami/action/cache/expires.rb
@@ -39,7 +39,7 @@ module Hanami
           end
         end
 
-        # Finalize the response including default cache headers into the response
+        # Finalizes the response including default cache headers into the response
         #
         # @since 0.3.0
         # @api private

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -178,8 +178,8 @@ module Hanami
     # @since 0.5.0
     # @api private
     #
-    # @see Hanami::Action::Throwable::RACK_ERRORS
-    # @see http://www.rubydoc.info/github/rack/rack/file/SPEC#The_Error_Stream
+    # @see Hanami::Action::RACK_ERRORS
+    # @see https://www.rubydoc.info/github/rack/rack/file/SPEC.rdoc#label-The+Error+Stream
     # @see https://github.com/hanami/controller/issues/133
     RACK_EXCEPTION = "rack.exception"
 
@@ -189,7 +189,8 @@ module Hanami
     # @api private
     LOCATION = "Location"
 
-    # The key that returns Rack session params from the Rack env
+    # The key that returns Rack session params from the Rack env.
+    #
     # Please note that this is used only when an action is unit tested.
     #
     # @since 2.0.0

--- a/lib/hanami/action/cookie_jar.rb
+++ b/lib/hanami/action/cookie_jar.rb
@@ -10,14 +10,12 @@ module Hanami
     # It acts as an Hash
     #
     # @since 0.1.0
-    #
-    # @see Hanami::Action::Cookies#cookies
     class CookieJar
       # @since 0.4.5
       # @api private
       COOKIE_SEPARATOR = ";,"
 
-      # Initialize the CookieJar
+      # Initializes the CookieJar
       #
       # @param env [Hash] a raw Rack env
       # @param headers [Hash] the response headers
@@ -31,7 +29,7 @@ module Hanami
         @default_options = default_options
       end
 
-      # Finalize itself, by setting the proper headers to add and remove
+      # Finalizes itself, by setting the proper headers to add and remove
       # cookies, before the response is returned to the webserver.
       #
       # @return [void]
@@ -61,7 +59,7 @@ module Hanami
         @cookies[key]
       end
 
-      # Associate the given value with the given key and store them
+      # Associates the given value with the given key and store them
       #
       # @param key [Symbol] the key
       # @param value [#to_s,Hash] value that can be serialized as a string or

--- a/lib/hanami/action/cookies.rb
+++ b/lib/hanami/action/cookies.rb
@@ -7,12 +7,10 @@ module Hanami
     # This module isn't included by default.
     #
     # @since 0.1.0
-    #
-    # @see Hanami::Action::Cookies#cookies
     module Cookies
       private
 
-      # Finalize the response by flushing cookies into the response
+      # Finalizes the response by flushing cookies into the response
       #
       # @since 0.1.0
       # @api private

--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -14,17 +14,16 @@ module Hanami
     class InvalidCSRFTokenError < Controller::Error
     end
 
-    # CSRF Protection
-    #
+    # Module providing CSRF Protection for actions.
     # This security mechanism is enabled automatically if sessions are turned on.
     #
-    # It stores a "challenge" token in session. For each "state changing request"
+    # It stores a "challenge" token in the session. For each "state changing request"
     # (eg. <tt>POST</tt>, <tt>PATCH</tt> etc..), we should send a special param:
     # <tt>_csrf_token</tt>.
     #
     # If the param matches with the challenge token, the flow can continue.
-    # Otherwise the application detects an attack attempt, it reset the session
-    # and <tt>Hanami::Action::InvalidCSRFTokenError</tt> is raised.
+    # Otherwise the application detects an attack attempt, resets the session
+    # and {Hanami::Action::InvalidCSRFTokenError} is raised.
     #
     # We can specify a custom handling strategy, by overriding <tt>#handle_invalid_csrf_token</tt>.
     #
@@ -36,8 +35,8 @@ module Hanami
     #
     # @since 0.4.0
     #
-    # @see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29
-    # @see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
+    # @see https://owasp.org/www-community/attacks/csrf
+    # @see https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
     #
     # @example Custom Handling
     #   module Web::Controllers::Books

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -41,7 +41,7 @@ module Hanami
         @next = {}
       end
 
-      # @return [Hash] The flash hash for the current request
+      # @return [Hash] the flash hash for the current request
       #
       # @since 2.0.0
       # @api public
@@ -94,7 +94,7 @@ module Hanami
         @flash.map(&block)
       end
 
-      # Returns `true` if the current hash contains no elements.
+      # Returns +true+ if the current hash contains no elements.
       #
       # @return [Boolean]
       #
@@ -104,7 +104,7 @@ module Hanami
         @flash.empty?
       end
 
-      # Returns `true` if the given key is present in the current hash.
+      # Returns +true+ if the given key is present in the current hash.
       #
       # @return [Boolean]
       #

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -6,8 +6,11 @@ require "rack/mime"
 
 module Hanami
   class Action
+    # Module containing logic related to MIME types
+    #
+    # @api private
     module Mime # rubocop:disable Metrics/ModuleLength
-      # Most commom MIME Types used for responses
+      # Most common MIME Types used for responses
       #
       # @since 1.0.0
       # @api private

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -10,9 +10,9 @@ module Hanami
     # It's able to extract the relevant params from a Rack env of from an Hash.
     #
     # There are three scenarios:
-    #   * When used with Hanami::Router: it contains only the params from the request
-    #   * When used standalone: it contains all the Rack env
-    #   * Default: it returns the given hash as it is. It's useful for testing purposes.
+    # * When used with Hanami::Router: it contains only the params from the request
+    # * When used standalone: it contains all the Rack env
+    # * Default: it returns the given hash as it is. It's useful for testing purposes.
     #
     # @since 0.1.0
     class Params < BaseParams
@@ -28,7 +28,7 @@ module Hanami
           super(errors.dup)
         end
 
-        # Add an error to the param validations
+        # Adds an error to the param validations
         #
         # This has a semantic similar to `Hash#dig` where you use a set of keys
         # to get a nested value, here you use a set of keys to set a nested
@@ -149,7 +149,7 @@ module Hanami
         validations(&blk || -> {})
       end
 
-      # Initialize the params and freeze them.
+      # Initializes the params and freeze them.
       #
       # @param env [Hash] a Rack env or an hash of params.
       #
@@ -235,7 +235,7 @@ module Hanami
         errors.empty?
       end
 
-      # Serialize validated params to Hash
+      # Serializes validated params to Hash
       #
       # @return [::Hash]
       #

--- a/lib/hanami/action/rack/file.rb
+++ b/lib/hanami/action/rack/file.rb
@@ -10,7 +10,7 @@ module Hanami
       # @since 0.4.3
       # @api private
       #
-      # @see Hanami::Action::Rack#send_file
+      # @see Hanami::Action::Response#send_file
       class File
         # @param path [String,Pathname] file path
         #

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -22,7 +22,7 @@ module Hanami
       # @since 0.1.0
       # @api private
       module ClassMethods
-        # Whitelist valid parameters to be passed to Hanami::Action#call.
+        # Whitelists valid parameters to be passed to {Hanami::Action#handle}.
         #
         # This feature isn't mandatory, but higly recommended for security
         # reasons.
@@ -38,11 +38,11 @@ module Hanami
         #
         # It accepts an anonymous block where all the params can be listed.
         # It internally creates an inner class which inherits from
-        # Hanami::Action::Params.
+        # {Hanami::Action::Params}.
         #
         #
         # Alternatively, it accepts an concrete class that should inherit from
-        # Hanami::Action::Params.
+        # +Hanami::Action::Params+.
         #
         # @param klass [Class,nil] a Hanami::Action::Params subclass
         # @param blk [Proc] a block which defines the whitelisted params
@@ -52,7 +52,6 @@ module Hanami
         # @since 0.3.0
         #
         # @see Hanami::Action::Params
-        # @see https://guides.hanamirb.org//validations/overview
         #
         # @example Anonymous Block
         #   require "hanami/controller"

--- a/lib/hanami/controller.rb
+++ b/lib/hanami/controller.rb
@@ -13,19 +13,6 @@ module Hanami
   # @since 0.1.0
   #
   # @see Hanami::Action
-  #
-  # @example
-  #   require "hanami/controller"
-  #
-  #   module Articles
-  #     class Index < Hanami::Action
-  #       # ...
-  #     end
-  #
-  #     class Show < Hanami::Action
-  #       # ...
-  #     end
-  #   end
   module Controller
     # Unknown format error
     #

--- a/lib/hanami/http/status.rb
+++ b/lib/hanami/http/status.rb
@@ -42,7 +42,7 @@ module Hanami
       # @api private
       #
       # @example
-      #   require 'hanami/http/status'
+      #   require "hanami/http/status"
       #
       #   Hanami::Http::Status.message_for(409) # => "Conflict"
       def self.message_for(code)

--- a/lib/hanami/http/status.rb
+++ b/lib/hanami/http/status.rb
@@ -15,7 +15,7 @@ module Hanami
       # @api private
       ALL = ::Rack::Utils::HTTP_STATUS_CODES
 
-      # Return a status for the given code
+      # Returns a status for the given code
       #
       # @param code [Integer] a valid HTTP code
       #
@@ -27,12 +27,12 @@ module Hanami
       # @example
       #   require 'hanami/http/status'
       #
-      #   Hanami::Http::Status.for_code(418) # => [418, "I'm a teapot"]
+      #   Hanami::Http::Status.for_code(409) # => [409, "Conflict"]
       def self.for_code(code)
         ALL.assoc(code)
       end
 
-      # Return a message for the given status code
+      # Returns a message for the given status code
       #
       # @param code [Integer] a valid HTTP code
       #
@@ -40,6 +40,11 @@ module Hanami
       #
       # @since 0.3.2
       # @api private
+      #
+      # @example
+      #   require 'hanami/http/status'
+      #
+      #   Hanami::Http::Status.message_for(409) # => "Conflict"
       def self.message_for(code)
         for_code(code)[1]
       end


### PR DESCRIPTION
This fixes some things in YARD docs. More of a housekeeping than storytelling - I focused on minor things like:
* Making sure links in @see work
* Transforming all descriptions to use 3rd person (finalize -> finalizes etc.)
* Fixing wording in few places
* Deleting some outdated examples and links
* Fixing formatting in few cases