### PR TITLE
Provide consistent class-level interface for config-like methods

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -287,6 +287,14 @@ module Hanami
       config.accepted_formats = formats
     end
 
+    # @see Config#handle_exception
+    #
+    # @since 2.0.0
+    # @api public
+    def self.handle_exception(...)
+      config.handle_exception(...)
+    end
+
     # Returns a new action
     #
     # @since 2.0.0

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -266,7 +266,7 @@ module Hanami
     #
     # @since 0.1.0
     #
-    # @see Hanami::Action::Configuration#format
+    # @see Config#format
     #
     # @example
     #   require "hanami/controller"

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -99,6 +99,10 @@ module Hanami
           include Validatable if defined?(Validatable)
         end
       end
+
+      if instance_variable_defined?(:@params_class)
+        subclass.instance_variable_set(:@params_class, @params_class)
+      end
     end
 
     # Returns the class which defines the params
@@ -112,7 +116,7 @@ module Hanami
     # @api private
     # @since 0.7.0
     def self.params_class
-      @params_class ||= BaseParams
+      @params_class || BaseParams
     end
 
     # Placeholder implementation for params class method

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -284,7 +284,7 @@ module Hanami
     #   # When called with "application/json" => 200
     #   # When called with "application/xml"  => 415
     def self.accept(*formats)
-      config.accepted_formats = *formats
+      config.accepted_formats = formats
     end
 
     # Returns a new action

--- a/spec/integration/hanami/controller/rack_errors_spec.rb
+++ b/spec/integration/hanami/controller/rack_errors_spec.rb
@@ -49,7 +49,7 @@ module Errors
 
   # Handled
   class ActionHandled < Hanami::Action
-    config.handle_exception HandledException => 400
+    handle_exception HandledException => 400
 
     def handle(*)
       raise HandledException
@@ -57,7 +57,7 @@ module Errors
   end
 
   class ActionHandledSubclass < Hanami::Action
-    config.handle_exception HandledException => 400
+    handle_exception HandledException => 400
 
     def handle(*)
       raise HandledExceptionSubclass
@@ -65,7 +65,7 @@ module Errors
   end
 
   class ConfigurationHandled < Hanami::Action
-    config.handle_exception ConfigurationHandledException => 500
+    handle_exception ConfigurationHandledException => 500
 
     def handle(*)
       raise ConfigurationHandledException
@@ -73,7 +73,7 @@ module Errors
   end
 
   class ConfigurationHandledSubclass < Hanami::Action
-    config.handle_exception ConfigurationHandledException => 500
+    handle_exception ConfigurationHandledException => 500
 
     def handle(*)
       raise ConfigurationHandledExceptionSubclass
@@ -137,12 +137,12 @@ RSpec.describe 'Reference exception in "rack.errors"' do
       expect(response.errors).to be_empty
     end
 
-    xit "doesn't dump exception in rack.errors if it's handled by the configuration" do
+    it "doesn't dump exception in rack.errors if it's handled by the configuration" do
       response = app.get("/configuration_handled")
       expect(response.errors).to be_empty
     end
 
-    xit "doesn't dump exception in rack.errors if its superclass is handled by the configuration" do
+    it "doesn't dump exception in rack.errors if its superclass is handled by the configuration" do
       response = app.get("/configuration_handled_subclass")
       expect(response.errors).to be_empty
     end

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -499,7 +499,7 @@ RSpec.describe Hanami::Action::Params do
     end
   end
 
-  describe "inhertiance" do
+  describe "inheritance" do
     let(:action) { Class.new(WhitelistedParamsAction).new }
 
     it "uses the params defined in the parent class" do

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -498,4 +498,13 @@ RSpec.describe Hanami::Action::Params do
       expect { params.errors.add(:book, :code, "is invalid") }.to raise_error(ArgumentError, %(Can't add :book, :code, "is invalid" to {:book=>["is missing"]}))
     end
   end
+
+  describe "inhertiance" do
+    let(:action) { Class.new(WhitelistedParamsAction).new }
+
+    it "uses the params defined in the parent class" do
+      response = action.call(id: 23, unknown: 4, article: {foo: "bar", tags: [:cool]})
+      expect(response.body).to eq([%({:id=>23, :article=>{:tags=>[:cool]}})])
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses the issues I raised in #389, which was a survey of the class-level interface for `Hanami::Action` and its intersection with `config`.

In #389 I recommended we do the following:

> - Restore a `handle_exception` class method that delegates to `configuration`
> - Move `accept` to `configuration` and rename it `accepted_formats`, then add `accept` back as a class method delegating to `configuration`. This keeps all config together in the same object, and ensures the `accept` values are inheritable, which is not currently the case.
> - Leave `params` as a class method (this is key behaviour, and doesn't feel like "config" at all), but update it to be inheritable, so a params defined on a parent class is copied to its children

Let's look at each of these now:

> - Restore a `handle_exception` class method that delegates to `configuration`

I've done this here in 88277305fb67d6e3a308b47648cd2d42d4f4d56b.

> - Move `accept` to `configuration` and rename it `accepted_formats`, then add `accept` back as a class method delegating to `configuration`. This keeps all config together in the same object, and ensures the `accept` values are inheritable, which is not currently the case.

This was done in #392.

> - Leave `params` as a class method (this is key behaviour, and doesn't feel like "config" at all), but update it to be inheritable, so a params defined on a parent class is copied to its children

I've done this here in 42ea7c8a3c61bd6578dfadcf51d2dd1397f6f440.

With all of these completed, we now have:

- Class methods for all the most frequently used config-like directives (`accept`, `handle_exceptions`) and other behavioural concerns (`params`)
- As well as consistent inheritance for all of these: they will all be copied into any subclasses

This should sort out any awkwardness people have felt in setting up their action classes!

Resolves #389.