### PR TITLE
Re-add session errors (preparation for merge)

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -319,14 +319,14 @@ module Hanami
 
       halted = catch :halt do
         params   = self.class.params_class.new(env)
-        request  = build_request(env: env, params: params, sessions_enabled: sessions_enabled)
+        request  = build_request(env: env, params: params, sessions_enabled: sessions_enabled?)
         response = build_response(
           request: request,
           config: config,
           content_type: Mime.calculate_content_type_with_charset(config, request, config.accepted_mime_types),
           env: env,
           headers: config.default_headers,
-          sessions_enabled: sessions_enabled
+          sessions_enabled: sessions_enabled?
         )
 
         enforce_accepted_mime_types(request)
@@ -432,7 +432,10 @@ module Hanami
       nil
     end
 
-    def sessions_enabled
+    # @see Session#sessions_enabled?
+    # @since 2.0.0
+    # @api private
+    def sessions_enabled?
       false
     end
 

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -24,6 +24,7 @@ require_relative "action/mime"
 require_relative "action/rack/file"
 require_relative "action/request"
 require_relative "action/response"
+require_relative "action/error"
 
 module Hanami
   # An HTTP endpoint
@@ -318,13 +319,14 @@ module Hanami
 
       halted = catch :halt do
         params   = self.class.params_class.new(env)
-        request  = build_request(env, params)
+        request  = build_request(env: env, params: params, sessions_enabled: sessions_enabled)
         response = build_response(
           request: request,
           config: config,
           content_type: Mime.calculate_content_type_with_charset(config, request, config.accepted_mime_types),
           env: env,
-          headers: config.default_headers
+          headers: config.default_headers,
+          sessions_enabled: sessions_enabled
         )
 
         enforce_accepted_mime_types(request)
@@ -430,10 +432,14 @@ module Hanami
       nil
     end
 
+    def sessions_enabled
+      false
+    end
+
     # @since 2.0.0
     # @api private
-    def build_request(env, params)
-      Request.new(env, params)
+    def build_request(**options)
+      Request.new(**options)
     end
 
     # @since 2.0.0

--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -96,6 +96,7 @@ module Hanami
       # @api private
       def self.included(action)
         unless Hanami.respond_to?(:env?) && Hanami.env?(:test)
+          action.include Hanami::Action::Session
           action.class_eval do
             before :set_csrf_token, :verify_csrf_token
           end

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -19,7 +19,22 @@ module Hanami
     # @see Hanami::Action::Response#flash
     class MissingSessionError < Error
       def initialize(session_method)
-        super("To use `#{session_method}`, add `include Hanami::Action::Session`.")
+        super(<<~TEXT)
+          Sessions are not enabled. To use `#{session_method}`:
+
+          Configure sessions in your Hanami app, e.g.
+
+            module MyApp
+              class App < Hanami::App
+                # See Rack::Session::Cookie for options
+                config.sessions = :cookie, {**cookie_session_options}
+              end
+            end
+
+          Or include session support directly in your action class:
+
+            include Hanami::Action::Session
+        TEXT
       end
     end
   end

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    # @since 2.0.0
+    class Error < ::StandardError
+    end
+
+    # Missing session error
+    #
+    # This error is raised when `session` or `flash` is accessed/set on request/response objects
+    # in actions which do not include `Hanami::Action::Session`.
+    #
+    # @since 2.0.0
+    #
+    # @see Hanami::Action::Session
+    # @see Hanami::Action::Request#session
+    # @see Hanami::Action::Response#session
+    # @see Hanami::Action::Response#flash
+    class MissingSessionError < Error
+      def initialize(session_method)
+        super("To use `#{session_method}`, add `include Hanami::Action::Session`.")
+      end
+    end
+  end
+end

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -14,7 +14,7 @@ module Hanami
     #
     # @see http://www.rubydoc.info/gems/rack/Rack/Request
     class Request < ::Rack::Request
-      attr_reader :params, :sessions_enabled
+      attr_reader :params
 
       def initialize(env:, params:, sessions_enabled: false)
         super(env)
@@ -39,7 +39,7 @@ module Hanami
       end
 
       def session
-        unless sessions_enabled
+        unless @sessions_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
         end
 

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -14,11 +14,13 @@ module Hanami
     #
     # @see http://www.rubydoc.info/gems/rack/Rack/Request
     class Request < ::Rack::Request
-      attr_reader :params
+      attr_reader :params, :sessions_enabled
 
-      def initialize(env, params)
+      def initialize(env:, params:, sessions_enabled: false)
         super(env)
+
         @params = params
+        @sessions_enabled = sessions_enabled
       end
 
       def id
@@ -34,6 +36,14 @@ module Hanami
 
       def accept_header?
         accept != Action::DEFAULT_ACCEPT
+      end
+
+      def session
+        unless sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
+        end
+
+        super
       end
 
       # @since 0.1.0

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -27,7 +27,7 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      attr_reader :request, :exposures, :format, :env, :view_options, :sessions_enabled
+      attr_reader :request, :exposures, :format, :env, :view_options
 
       # @since 2.0.0
       # @api private
@@ -103,7 +103,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
-        unless sessions_enabled
+        unless @sessions_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session")
         end
 
@@ -119,7 +119,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
-        unless sessions_enabled
+        unless @sessions_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash")
         end
 

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -27,7 +27,7 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      attr_reader :request, :exposures, :format, :env, :view_options
+      attr_reader :request, :exposures, :format, :env, :view_options, :sessions_enabled
 
       # @since 2.0.0
       # @api private
@@ -45,7 +45,7 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      def initialize(request:, config:, content_type: nil, env: {}, headers: {}, view_options: nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(request:, config:, content_type: nil, env: {}, headers: {}, view_options: nil, sessions_enabled: false) # rubocop:disable Layout/LineLength, Metrics/ParameterLists
         super([], 200, headers.dup)
         set_header(Action::CONTENT_TYPE, content_type)
 
@@ -56,6 +56,7 @@ module Hanami
         @env = env
         @view_options = view_options || DEFAULT_VIEW_OPTIONS
 
+        @sessions_enabled = sessions_enabled
         @sending_file = false
       end
 
@@ -102,6 +103,10 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
+        unless sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session")
+        end
+
         env[Action::RACK_SESSION] ||= {}
       end
 
@@ -114,6 +119,10 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
+        unless sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash")
+        end
+
         @flash ||= Flash.new(session[Flash::KEY])
       end
 
@@ -179,7 +188,8 @@ module Hanami
       def request_id
         env.fetch(Action::REQUEST_ID) do
           # FIXME: raise a meaningful error, by inviting devs to include Hanami::Action::Session
-          raise "Can't find request ID"
+          # raise "Can't find request ID"
+          raise Hanami::Action::MissingSessionError.new("request_id")
         end
       end
 

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -13,6 +13,10 @@ module Hanami
       def self.included(base)
         base.class_eval do
           before { |req, _| req.id }
+
+          def sessions_enabled
+            true
+          end
         end
       end
 

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -13,14 +13,14 @@ module Hanami
       def self.included(base)
         base.class_eval do
           before { |req, _| req.id }
-
-          def sessions_enabled
-            true
-          end
         end
       end
 
       private
+
+      def sessions_enabled
+        true
+      end
 
       # Finalize the response
       #

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -18,7 +18,7 @@ module Hanami
 
       private
 
-      def sessions_enabled
+      def sessions_enabled?
         true
       end
 

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -41,4 +41,11 @@ RSpec.describe "Flash application" do
       expect(last_response.body).to match(/flash_map: \[\[:hello, "world"\]\]/)
     end
   end
+
+  context "when sessions not enabled" do
+    it "raises Hanami::Action::MissingSessionError" do
+      expected = Hanami::Action::MissingSessionError
+      expect { get "/disabled" }.to raise_error(expected, "To use `Hanami::Action::Response#flash`, add `include Hanami::Action::Session`.")
+    end
+  end
 end

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -44,8 +44,10 @@ RSpec.describe "Flash application" do
 
   context "when sessions not enabled" do
     it "raises Hanami::Action::MissingSessionError" do
-      expected = Hanami::Action::MissingSessionError
-      expect { get "/disabled" }.to raise_error(expected, "To use `Hanami::Action::Response#flash`, add `include Hanami::Action::Session`.")
+      expect { get "/disabled" }.to raise_error(
+        Hanami::Action::MissingSessionError,
+        /Hanami::Action::Response#flash/
+      )
     end
   end
 end

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "HTTP sessions" do
       get    "/",       to: Dashboard::Index.new
       post   "/login",  to: Sessions::Create.new
       delete "/logout", to: Sessions::Destroy.new
+      get    "/disabled", to: Sessions::Disabled.new
     end
   end
 
@@ -51,6 +52,13 @@ RSpec.describe "HTTP sessions" do
 
     get "/"
     expect(response.status).to be(401)
+  end
+
+  context "when sessions not enabled" do
+    it "raises Hanami::Action::MissingSessionError" do
+      expected = Hanami::Action::MissingSessionError
+      expect { get "/disabled" }.to raise_error(expected, "To use `Hanami::Action::Response#session`, add `include Hanami::Action::Session`.")
+    end
   end
 end
 

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "HTTP sessions" do
   context "when sessions not enabled" do
     it "raises Hanami::Action::MissingSessionError" do
       expected = Hanami::Action::MissingSessionError
-      expect { get "/disabled" }.to raise_error(expected, "To use `Hanami::Action::Response#session`, add `include Hanami::Action::Session`.")
+      expect { get "/disabled" }.to raise_error(expected, /Hanami::Action::Response#session/)
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -347,15 +347,21 @@ class YieldAfterBlockAction < AfterBlockAction
   end
 end
 
-class MissingSessionAction < Hanami::Action
-  def handle(*)
-    session
+class MissingRequestSessionAction < Hanami::Action
+  def handle(req, _)
+    req.session[:user_id]
   end
 end
 
-class MissingFlashAction < Hanami::Action
-  def handle(*)
-    flash
+class MissingResponseSessionAction < Hanami::Action
+  def handle(_, res)
+    res.session[:user_id] = 23
+  end
+end
+
+class MissingResponseFlashAction < Hanami::Action
+  def handle(_, res)
+    res.flash[:error] = "ouch"
   end
 end
 
@@ -852,6 +858,12 @@ module Sessions
 
     def handle(*, res)
       res.session[:user_id] = nil
+    end
+  end
+
+  class Disabled < Hanami::Action
+    def handle(*, res)
+      res.session[:user_id] = 23
     end
   end
 end
@@ -1803,6 +1815,12 @@ module Flash
           res.body = "flash_map: #{res.flash.map { |type, message| [type, message] }}"
         end
       end
+
+      class Disabled < Hanami::Action
+        def handle(_, res)
+          res.flash[:error] = "ouch"
+        end
+      end
     end
   end
 
@@ -1817,6 +1835,7 @@ module Flash
         get "/each_redirect",  to: Flash::Controllers::Home::EachRedirect.new
         get "/map",            to: Flash::Controllers::Home::Map.new
         get "/each",           to: Flash::Controllers::Home::Each.new
+        get "/disabled",       to: Flash::Controllers::Home::Disabled.new
       end
 
       @middleware = Rack::Builder.new do

--- a/spec/unit/hanami/action/request_spec.rb
+++ b/spec/unit/hanami/action/request_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe Hanami::Action::Request do
 
     context "non-standard port" do
       it "gets host and port" do
-        request = described_class.new(Rack::MockRequest.env_for("http://example.com:81/foo?q=bar", {}), {})
+        request = described_class.new(
+          env: Rack::MockRequest.env_for("http://example.com:81/foo?q=bar", {}),
+          params: {}
+        )
         expect(request.host_with_port).to eq("example.com:81")
       end
     end
@@ -155,6 +158,6 @@ RSpec.describe Hanami::Action::Request do
   def build_request(attributes = {})
     url = attributes.delete("url") || "http://example.com/foo?q=bar"
     env = Rack::MockRequest.env_for(url, attributes)
-    described_class.new(env, {})
+    described_class.new(env: env, params: {})
   end
 end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Hanami::Action do
         expected = Hanami::Action::MissingSessionError
         expect { MissingResponseSessionAction.new.call({}) }.to raise_error(
           expected,
-          "To use `Hanami::Action::Response#session`, add `include Hanami::Action::Session`."
+          /Hanami::Action::Response#session/
         )
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe Hanami::Action do
         expected = Hanami::Action::MissingSessionError
         expect { MissingResponseFlashAction.new.call({}) }.to raise_error(
           expected,
-          "To use `Hanami::Action::Response#flash`, add `include Hanami::Action::Session`."
+          /Hanami::Action::Response#flash/
         )
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe Hanami::Action do
         expected = Hanami::Action::MissingSessionError
         expect { MissingRequestSessionAction.new.call({}) }.to raise_error(
           expected,
-          "To use `Hanami::Action::Request#session`, add `include Hanami::Action::Session`."
+          /Hanami::Action::Request#session/
         )
       end
     end

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -77,6 +77,36 @@ RSpec.describe Hanami::Action do
         expect(response.body).to   eq([])
       end
     end
+
+    context "when setting res.session with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingResponseSessionAction.new.call({}) }.to raise_error(
+          expected,
+          "To use `Hanami::Action::Response#session`, add `include Hanami::Action::Session`."
+        )
+      end
+    end
+
+    context "when setting res.flash with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingResponseFlashAction.new.call({}) }.to raise_error(
+          expected,
+          "To use `Hanami::Action::Response#flash`, add `include Hanami::Action::Session`."
+        )
+      end
+    end
+
+    context "when accessing req.session with sessions disabled" do
+      it "raises an informative exception" do
+        expected = Hanami::Action::MissingSessionError
+        expect { MissingRequestSessionAction.new.call({}) }.to raise_error(
+          expected,
+          "To use `Hanami::Action::Request#session`, add `include Hanami::Action::Session`."
+        )
+      end
+    end
   end
 
   describe "request" do


### PR DESCRIPTION
I've taken @tak1n's work in #379, done another rebase, and made a few tidies in anticipation of merging this. 

I agree with @tak1n in his original PR that there might be better implementations we could find if we searched for them, but I think this gets the job done, and it does so in a way that doesn't commit us to this particular implementation either, everything done here is internal and we can always revisit this in the future.

And what's most important here is that we give helpful feedback to the user at a time when they may need it.