### PR TITLE
Reenable MIME specs and check both `Accept` and `Content-Type` headers checks via `accept`

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -417,7 +417,7 @@ module Hanami
     # @since 2.0.0
     # @api private
     def enforce_accepted_mime_types(request)
-      return if config.accepted_formats.none?
+      return if config.accepted_formats.empty?
 
       Mime.enforce_accept(request, config) { return halt 406 }
       Mime.enforce_content_type(request, config) { return halt 415 }

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -417,9 +417,10 @@ module Hanami
     # @since 2.0.0
     # @api private
     def enforce_accepted_mime_types(request)
-      return unless config.accepted_formats.any?
+      return if config.accepted_formats.none?
 
-      Mime.accepted_mime_type?(request, config.accepted_mime_types, config) or halt 415
+      Mime.enforce_accept(request, config) { return halt 406 }
+      Mime.enforce_content_type(request, config) { return halt 415 }
     end
 
     # @since 2.0.0

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -114,13 +114,13 @@ module Hanami
     #
     # @since 0.1.0
     # @api private
-    HTTP_ACCEPT          = "HTTP_ACCEPT"
+    HTTP_ACCEPT = "HTTP_ACCEPT"
 
     # The header key to set the mime type of the response
     #
     # @since 0.1.0
     # @api private
-    CONTENT_TYPE         = ::Rack::CONTENT_TYPE
+    CONTENT_TYPE = ::Rack::CONTENT_TYPE
 
     # The default mime type for an incoming HTTP request
     #
@@ -152,7 +152,7 @@ module Hanami
     #
     # @since 2.0.0
     # @api private
-    ETAG          = ::Rack::ETAG
+    ETAG = ::Rack::ETAG
 
     # @since 2.0.0
     # @api private
@@ -221,7 +221,7 @@ module Hanami
     #
     # @since 2.0.0
     # @api private
-    COOKIE_HASH_KEY   = ::Rack::RACK_REQUEST_COOKIE_HASH
+    COOKIE_HASH_KEY = ::Rack::RACK_REQUEST_COOKIE_HASH
 
     # The key used by Rack to set the cookies as a String in the env
     #
@@ -233,7 +233,7 @@ module Hanami
     #
     # @since 2.0.0
     # @api private
-    RACK_INPUT    = ::Rack::RACK_INPUT
+    RACK_INPUT = ::Rack::RACK_INPUT
 
     # The key that returns router params from the Rack env
     # This is a builtin integration for Hanami::Router
@@ -250,6 +250,6 @@ module Hanami
 
     # @since 2.0.0
     # @api private
-    DEFAULT_CHARSET      = "utf-8"
+    DEFAULT_CHARSET = "utf-8"
   end
 end

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -251,11 +251,5 @@ module Hanami
     # @since 2.0.0
     # @api private
     DEFAULT_CHARSET      = "utf-8"
-
-    # The key that returns content mime type from the Rack env
-    #
-    # @since 2.0.0
-    # @api private
-    HTTP_CONTENT_TYPE    = "CONTENT_TYPE"
   end
 end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -84,13 +84,13 @@ module Hanami
       #
       # @since 2.0.0
       # @api private
-      def self.content_type(configuration, request, accepted_mime_types)
+      def self.content_type(config, request, accepted_mime_types)
         if request.accept_header?
           type = best_q_match(request.accept, accepted_mime_types)
           return type if type
         end
 
-        default_response_type(configuration) || default_content_type(configuration) || Action::DEFAULT_CONTENT_TYPE
+        default_response_type(config) || default_content_type(config) || Action::DEFAULT_CONTENT_TYPE
       end
 
       # @since 2.0.0
@@ -101,22 +101,22 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      def self.default_response_type(configuration)
-        format_to_mime_type(configuration.default_response_format, configuration)
+      def self.default_response_type(config)
+        format_to_mime_type(config.default_response_format, config)
       end
 
       # @since 2.0.0
       # @api private
-      def self.default_content_type(configuration)
-        format_to_mime_type(configuration.default_request_format, configuration)
+      def self.default_content_type(config)
+        format_to_mime_type(config.default_request_format, config)
       end
 
       # @since 2.0.0
       # @api private
-      def self.format_to_mime_type(format, configuration)
+      def self.format_to_mime_type(format, config)
         return if format.nil?
 
-        configuration.mime_type_for(format) ||
+        config.mime_type_for(format) ||
           TYPES.fetch(format) { raise Hanami::Controller::UnknownFormatError.new(format) }
       end
 
@@ -125,7 +125,7 @@ module Hanami
       #
       # @see Hanami::Action::Mime#finish
       # @example
-      #   detect_format("text/html; charset=utf-8", configuration)  #=> :html
+      #   detect_format("text/html; charset=utf-8", config)  #=> :html
       #
       # @return [Symbol, nil]
       #
@@ -232,9 +232,9 @@ module Hanami
       #
       # @since 2.0.0
       # @api private
-      def self.calculate_content_type_with_charset(configuration, request, accepted_mime_types)
-        charset      = self.charset(configuration.default_charset)
-        content_type = self.content_type(configuration, request, accepted_mime_types)
+      def self.calculate_content_type_with_charset(config, request, accepted_mime_types)
+        charset      = self.charset(config.default_charset)
+        content_type = self.content_type(config, request, accepted_mime_types)
         content_type_with_charset(content_type, charset)
       end
 

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -179,6 +179,7 @@ module Hanami
       # @api private
       def self.accepted_mime_type?(request, accepted_mime_types, configuration)
         mime_type = request.content_type ||
+                    (request.accept if request.accept_header?) ||
                     default_content_type(configuration) ||
                     Action::DEFAULT_CONTENT_TYPE
 

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -230,7 +230,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def self.calculate_content_type_with_charset(config, request, accepted_mime_types)
-        charset      = self.charset(config.default_charset)
+        charset = self.charset(config.default_charset)
         content_type = self.content_type(config, request, accepted_mime_types)
         content_type_with_charset(content_type, charset)
       end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -184,11 +184,8 @@ module Hanami
       def self.enforce_accept(request, config)
         return unless request.accept_header?
 
-        accept_mime_types = ::Rack::Utils.q_values(request.accept).map(&:first)
-
-        accept_mime_types.each do |mime_type|
-          return if accepted_mime_type?(mime_type, config) # rubocop:disable Lint/NonLocalExitFromIterator
-        end
+        accept_types = ::Rack::Utils.q_values(request.accept).map(&:first)
+        return if accept_types.any? { |mime_type| accepted_mime_type?(mime_type, config) }
 
         yield
       end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -178,7 +178,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def self.accepted_mime_type?(request, accepted_mime_types, configuration)
-        mime_type = request.env[Action::HTTP_CONTENT_TYPE] ||
+        mime_type = request.content_type ||
                     default_content_type(configuration) ||
                     Action::DEFAULT_CONTENT_TYPE
 

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -182,7 +182,7 @@ module Hanami
                     default_content_type(configuration) ||
                     Action::DEFAULT_CONTENT_TYPE
 
-        !accepted_mime_types.find { |mt| ::Rack::Mime.match?(mt, mime_type) }.nil?
+        accepted_mime_types.any? { |mt| ::Rack::Mime.match?(mt, mime_type) }
       end
 
       # Use for setting the content_type and charset if the response

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -28,6 +28,14 @@ module Hanami
         @id ||= @env[Action::REQUEST_ID] = SecureRandom.hex(Action::DEFAULT_ID_LENGTH)
       end
 
+      def session
+        unless @sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
+        end
+
+        super
+      end
+
       def accept?(mime_type)
         !!::Rack::Utils.q_values(accept).find do |mime, _|
           ::Rack::Mime.match?(mime_type, mime)
@@ -36,14 +44,6 @@ module Hanami
 
       def accept_header?
         accept != Action::DEFAULT_ACCEPT
-      end
-
-      def session
-        unless @sessions_enabled
-          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
-        end
-
-        super
       end
 
       # @since 0.1.0

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -64,19 +64,19 @@ RSpec.describe "MIME Type" do
 
     context "when ACCEPT and Content-Type are sent and we use the accept macro" do
       it 'sets "Content-Type" header according to exact value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom", "CONTENT_TYPE" => "application/custom")
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom")
         expect(response.headers["Content-Type"]).to eq("application/custom; charset=utf-8")
         expect(response.body).to                    eq("custom")
       end
 
       it 'sets "Content-Type" header according to weighted value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.9,application/json;q=0.5", "CONTENT_TYPE" => "application/custom")
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.9,application/json;q=0.5")
         expect(response.headers["Content-Type"]).to eq("application/custom; charset=utf-8")
         expect(response.body).to                    eq("custom")
       end
 
       it 'sets "Content-Type" header according to weighted, unordered value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.1, application/json;q=0.5", "CONTENT_TYPE" => "application/json")
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.1, application/json;q=0.5")
         expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
         expect(response.body).to                    eq("json")
       end
@@ -84,13 +84,13 @@ RSpec.describe "MIME Type" do
 
     context "when ACCEPT and Content-Type are send and there are no restriction using accept macro" do
       it 'sets "Content-Type" header according to exact and weighted value' do
-        response = app.get("/", "HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "CONTENT_TYPE" => "application/xml")
+        response = app.get("/", "HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
         expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
         expect(response.body).to                    eq("html")
       end
 
       it 'sets "Content-Type" header according to quality scale value' do
-        response = app.get("/", "HTTP_ACCEPT" => "application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8", "CONTENT_TYPE" => "application/xml")
+        response = app.get("/", "HTTP_ACCEPT" => "application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8")
         expect(response.headers["Content-Type"]).to eq("application/xml; charset=utf-8")
         expect(response.body).to                    eq("xml")
       end

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe "MIME Type" do
     end
 
     context "when no ACCEPT or Content-Type are sent but there is a restriction using the accept macro" do
-      it "sets the status to 415" do
+      it "accepts the request and sets the status to 200" do
         response = app.get("/custom_from_accept")
-        expect(response.status).to eq 415 # FIXME: This should either be a 200 or a 406
+        expect(response.status).to eq 200
       end
     end
 
@@ -118,7 +118,7 @@ RSpec.describe "MIME Type" do
 
       it "does not accept an unmatched format" do
         response = app.get("/strict", "HTTP_ACCEPT" => "application/xml")
-        expect(response.status).to be(415)
+        expect(response.status).to be(406)
       end
     end
   end

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -4,38 +4,38 @@ RSpec.describe "MIME Type" do
   describe "Content type" do
     let(:app) { Rack::MockRequest.new(Mimes::Application.new) }
 
-    xit 'fallbacks to the default "Content-Type" header when the request is lacking of this information' do
+    it 'fallbacks to the default "Content-Type" header when the request is lacking of this information' do
       response = app.get("/")
       expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
       expect(response.body).to                    eq("all")
     end
 
-    xit 'returns the specified "Content-Type" header' do
+    it 'returns the specified "Content-Type" header' do
       response = app.get("/custom")
       expect(response.headers["Content-Type"]).to eq("application/xml; charset=utf-8")
       expect(response.body).to                    eq("xml")
     end
 
-    xit "returns the custom charser header" do
+    it "returns the custom charser header" do
       response = app.get("/latin")
       expect(response.headers["Content-Type"]).to eq("text/html; charset=latin1")
       expect(response.body).to                    eq("html")
     end
 
-    xit "allows to override default_response_format" do
+    it "allows to override default_response_format" do
       response = app.get("/overwritten_format")
       expect(response.headers["Content-Type"]).to eq("application/xml; charset=utf-8")
     end
 
     # FIXME: Review if this test must be in place
-    xit 'does not produce a "Content-Type" header when the request has a 204 No Content status' do
+    it 'does not produce a "Content-Type" header when the request has a 204 No Content status' do
       response = app.get("/nocontent")
       expect(response.headers).to_not have_key("Content-Type")
       expect(response.body).to        eq("")
     end
 
     context "when ACCEPT header is set and no accept macro is use" do
-      xit 'sets "Content-Type" header according to wildcard value' do
+      it 'sets "Content-Type" header according to wildcard value' do
         response = app.get("/", "HTTP_ACCEPT" => "*/*")
         expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
         expect(response.body).to                    eq("all")
@@ -43,54 +43,54 @@ RSpec.describe "MIME Type" do
     end
 
     context "when no ACCEPT or Content-Type are sent but there is a restriction using the accept macro" do
-      xit "sets the status to 406" do
+      it "sets the status to 415" do
         response = app.get("/custom_from_accept")
-        expect(response.status).to eq 406
+        expect(response.status).to eq 415 # FIXME: This should either be a 200 or a 406
       end
     end
 
     context "when Content-Type are sent and there is a restriction using the accept macro" do
-      xit 'sets "Content-Type" to fallback' do
-        response = app.get("/custom_from_accept", "Content-Type" => "application/custom")
+      it 'sets "Content-Type" to fallback' do
+        response = app.get("/custom_from_accept", "CONTENT_TYPE" => "application/custom")
         expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
-        expect(response.body).to                    eq("all")
+        expect(response.body).to eq("all")
       end
 
-      xit "sets status to 406 if Content-Type do not match" do
-        response = app.get("/custom_from_accept", "Content-Type" => "application/xml")
-        expect(response.status).to eq(406)
+      it "sets status to 415 if Content-Type do not match" do
+        response = app.get("/custom_from_accept", "CONTENT_TYPE" => "application/xml")
+        expect(response.status).to eq(415)
       end
     end
 
     context "when ACCEPT and Content-Type are sent and we use the accept macro" do
-      xit 'sets "Content-Type" header according to exact value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom", "Content-Type" => "application/custom")
+      it 'sets "Content-Type" header according to exact value' do
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom", "CONTENT_TYPE" => "application/custom")
         expect(response.headers["Content-Type"]).to eq("application/custom; charset=utf-8")
         expect(response.body).to                    eq("custom")
       end
 
-      xit 'sets "Content-Type" header according to weighted value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.9,application/json;q=0.5", "Content-Type" => "application/custom")
+      it 'sets "Content-Type" header according to weighted value' do
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.9,application/json;q=0.5", "CONTENT_TYPE" => "application/custom")
         expect(response.headers["Content-Type"]).to eq("application/custom; charset=utf-8")
         expect(response.body).to                    eq("custom")
       end
 
-      xit 'sets "Content-Type" header according to weighted, unordered value' do
-        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.1, application/json;q=0.5", "Content-Type" => "application/json")
+      it 'sets "Content-Type" header according to weighted, unordered value' do
+        response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom;q=0.1, application/json;q=0.5", "CONTENT_TYPE" => "application/json")
         expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
         expect(response.body).to                    eq("json")
       end
     end
 
     context "when ACCEPT and Content-Type are send and there are no restriction using accept macro" do
-      xit 'sets "Content-Type" header according to exact and weighted value' do
-        response = app.get("/", "HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "Content-Type" => "application/xml")
+      it 'sets "Content-Type" header according to exact and weighted value' do
+        response = app.get("/", "HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "CONTENT_TYPE" => "application/xml")
         expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
         expect(response.body).to                    eq("html")
       end
 
-      xit 'sets "Content-Type" header according to quality scale value' do
-        response = app.get("/", "HTTP_ACCEPT" => "application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8", "Content-Type" => "application/xml")
+      it 'sets "Content-Type" header according to quality scale value' do
+        response = app.get("/", "HTTP_ACCEPT" => "application/json;q=0.6,application/xml;q=0.9,*/*;q=0.8", "CONTENT_TYPE" => "application/xml")
         expect(response.headers["Content-Type"]).to eq("application/xml; charset=utf-8")
         expect(response.body).to                    eq("xml")
       end
@@ -100,9 +100,9 @@ RSpec.describe "MIME Type" do
     context "with an accepted format and default response format" do
       let(:app) { Rack::MockRequest.new(MimesWithDefault::Application.new) }
       let(:content_type) { "application/json" }
-      let(:response) { app.get("/default_and_accept", "Content-Type" => content_type) }
+      let(:response) { app.get("/default_and_accept", "CONTENT_TYPE" => content_type) }
 
-      xit "defaults to the accepted format" do
+      it "defaults to the accepted format" do
         expect(response.status).to be(200)
         expect(response.body).to eq("html")
       end
@@ -110,14 +110,14 @@ RSpec.describe "MIME Type" do
 
     context "with an accepted format" do
       it "accepts the matching format" do
-        response = app.get("/strict", "HTTP_ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json")
-        expect(response.status).to be(200)
+        response = app.get("/strict", "HTTP_ACCEPT" => "application/json")
+        expect(response.status).to eq(200)
         expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
         expect(response.body).to eq("json")
       end
 
       it "does not accept an unmatched format" do
-        response = app.get("/strict", "HTTP_ACCEPT" => "application/xml", "CONTENT_TYPE" => "application/xml")
+        response = app.get("/strict", "HTTP_ACCEPT" => "application/xml")
         expect(response.status).to be(415)
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe "MIME Type" do
     context "when Accept is missing" do
       let(:accept) { nil }
 
-      xit "accepts all" do
+      it "accepts all" do
         expect(response.headers["X-AcceptDefault"]).to eq("true")
         expect(response.headers["X-AcceptHtml"]).to    eq("true")
         expect(response.headers["X-AcceptXml"]).to     eq("true")
@@ -143,7 +143,7 @@ RSpec.describe "MIME Type" do
       context 'when "*/*"' do
         let(:accept) { "*/*" }
 
-        xit "accepts all" do
+        it "accepts all" do
           expect(response.headers["X-AcceptDefault"]).to eq("true")
           expect(response.headers["X-AcceptHtml"]).to    eq("true")
           expect(response.headers["X-AcceptXml"]).to     eq("true")
@@ -155,7 +155,7 @@ RSpec.describe "MIME Type" do
       context 'when "text/html"' do
         let(:accept) { "text/html" }
 
-        xit "accepts selected mime types" do
+        it "accepts selected mime types" do
           expect(response.headers["X-AcceptDefault"]).to eq("false")
           expect(response.headers["X-AcceptHtml"]).to    eq("true")
           expect(response.headers["X-AcceptXml"]).to     eq("false")
@@ -167,7 +167,7 @@ RSpec.describe "MIME Type" do
       context "when weighted" do
         let(:accept) { "text/html,application/xhtml+xml,application/xml;q=0.9" }
 
-        xit "accepts selected mime types" do
+        it "accepts selected mime types" do
           expect(response.headers["X-AcceptDefault"]).to eq("false")
           expect(response.headers["X-AcceptHtml"]).to    eq("true")
           expect(response.headers["X-AcceptXml"]).to     eq("true")
@@ -179,7 +179,7 @@ RSpec.describe "MIME Type" do
       context "applies the weighting mechanism for media ranges" do
         let(:accept) { "text/*,application/json,text/html,*/*" }
 
-        xit "accepts selected mime types" do
+        it "accepts selected mime types" do
           expect(response.headers["X-AcceptDefault"]).to eq("true")
           expect(response.headers["X-AcceptHtml"]).to    eq("true")
           expect(response.headers["X-AcceptXml"]).to     eq("true")

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1589,6 +1589,8 @@ module Mimes
   end
 
   class CustomFromAccept < Hanami::Action
+    config.format custom: "application/custom"
+
     accept :json, :custom
 
     def handle(*, res)
@@ -1597,6 +1599,8 @@ module Mimes
   end
 
   class Restricted < Hanami::Action
+    config.format custom: "application/custom"
+
     accept :html, :json, :custom
 
     def handle(_req, res)
@@ -1632,19 +1636,15 @@ module Mimes
 
   class Application
     def initialize
-      # configuration = Hanami::Action::Configuration.new do |config|
-      #   config.format custom: "application/custom"
-      # end
-
       @router = Hanami::Router.new do
         get "/",                   to: Mimes::Default.new
-        # get "/custom",             to: Mimes::Custom.new
+        get "/custom",             to: Mimes::Custom.new
         get "/accept",             to: Mimes::Accept.new
-        # get "/restricted",         to: Mimes::Restricted.new
+        get "/restricted",         to: Mimes::Restricted.new
         get "/latin",              to: Mimes::Latin.new
         get "/nocontent",          to: Mimes::NoContent.new
         get "/overwritten_format", to: Mimes::OverrideDefaultResponse.new
-        # get "/custom_from_accept", to: Mimes::CustomFromAccept.new
+        get "/custom_from_accept", to: Mimes::CustomFromAccept.new
         get "/strict",             to: Mimes::Strict.new
       end
     end
@@ -1657,6 +1657,8 @@ end
 
 module MimesWithDefault
   class Default < Hanami::Action
+    config.default_response_format = :html
+
     accept :json
 
     def handle(*, res)
@@ -1666,10 +1668,6 @@ module MimesWithDefault
 
   class Application
     def initialize
-      # configuration = Hanami::Action::Configuration.new do |config|
-      #   config.default_response_format = :html
-      # end
-
       @router = Hanami::Router.new do
         get "/default_and_accept", to: MimesWithDefault::Default.new
       end


### PR DESCRIPTION
## Background

The way our `accept` macro has worked has taken over time has taken a few different shapes.

- In 1.3.x it worked on the `Accept` header only ([see here for code](https://github.com/hanami/controller/blob/2496ac797237d7320b96048a3c9e3fbebb00532c/lib/hanami/action/mime.rb#L168-L172)) and returned a 406 response for non-matching types.
- However, 1.3.x _also_ had a `content_type` macro that operated on the `Content-Type` header ([see code](https://github.com/hanami/controller/blob/2496ac797237d7320b96048a3c9e3fbebb00532c/lib/hanami/action/mime.rb#L198-L204)) and returned a 415 response for non-matching types.
- In the very earliest phase of 2.0 development, when @jodosha was completely overhauling the shape of hanami-controller, we removed the `content_type` macro and left the `accept` macro only (in [this commit](https://github.com/hanami/controller/commit/85e927a694998e5ebfcbad216d7bdec4109b6806), which is rather large). The `accept` macro and its behaviour were left largely unchanged at this point.
- Then not too long after, we changed the `accept` macro to no longer operate on the `Accept` header and instead look at `Content-Type` only, and return a 415 response for all non-matching types (see [this PR](https://github.com/hanami/controller/pull/265), addressing [this issue](https://github.com/hanami/controller/issues/257))

## Shortcomings 

I ran into some trouble with this early 2.0-phase implementation, because it meant that if you put `accept :json` into a base action class (e.g. for every action class within an API service to inherit from), then it would reject _any_ request without a `Content-Type: application/json` header.

Requiring a `Content-Type` header like this would make sense for POST, PUT, PATCH requests, that is, any kind of request that contains a request body and needs to describe its content type.

However, `GET` and other requests without bodies are likely _not_ to have `Content-Type` headers. These requests would more likely have an `Accept` header only.

## Changes

I believe that when an action contains `accept :json`, then it should be able to successfully handle a request with only an `Accept: application/json` header, and no `Content-Type`. It should also handle weighted `Accept` headers too, like `text/html, application/xhtml+xml, application/xml;q=0.9`.

This PR changes the way we enforce the accepted formats configured with `accept`. It:

- Checks the `Accept` header first. If it is present, it will check if any any of the header's MIME types are acceptable per the configured `accepted_formats`. If none are acceptable, then the request will be a 406 error.
- If the `Accept` is not present, it then checks `Content-Type`. If this header is present, but checks to see if the Content-Type MIME type is accepted able per the configured `accepted_formats`. If it is not acceptable, then the request will be a 415 error.
  - If the `Content-Type` header is not present, then it will substitute this with the MIME type for the `default_request_format`, if configured.
- Lastly, if there is no `Accept`, no `Content-Type`, no `default_request_format`, then the request is accepted regardless, with the idea here being that the client has no care or opinion about the format they want, and our Action class can return whatever content it likes in its response.

I believe this strikes a balance that should satisfy the spread of real-world requests. It captures the spirit of _both_ the original `accept` and `content_type` macros while ensuring we still keep the slimmer API surface area of the `accept` macro only.

Certainly if this were implemented earlier, I could have avoided hacking in a workaround inside the app in which I discovered this issue.

## Implementation

This PR has a few key commits that are worth reviewing:

- 17ee819 restores all of our mime_spec.rb examples, most of which were previously disabled. I made no changes to these specs apart from changing their expected response code from 406 to 415 (which shows how they must have been targeting the 1.3.x behaviour still). Interestingly, I also to had to our code to check the `Accept` header too, for all specs to pass.
- d74b4fa implements the new algorithm I described above, and updates the specs to match this behaviour.

Other commits here are mostly about tidying up what has felt like a bit of an unloved area from our 2.0 development phase.