### PR TITLE
Fix ci slack notifications (only on main, not all branches)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run all tests
         run: script/ci
       - uses: ravsamhq/notify-slack-action@v1
-        if: always()
+        if: github.ref_name == 'main'
         with:
           status: ${{ job.status }}
           notification_title: '{workflow} has {status_message}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: ravsamhq/notify-slack-action@v1
         if: github.ref_name == 'main'
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           notification_title: '{workflow} has {status_message}'
           message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'


### PR DESCRIPTION
I haven't tested this since it's a CI thing, but I think it'll work, and will confirm after this is merged.

(The issue here is that in our private Hanami Slack, our #ci issue is reporting failed builds for all branches, which adds a lot of noise and we only want the notifications if `main` is broken.

I also realized the message says ` <|View Workflow>` but without a working link. Turns out we need to specify the token to do that. I trust that GitHub filters it out properly so it won't be public.