### PR TITLE
Delegate to Request's flash and session from Response

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -319,8 +319,12 @@ module Hanami
 
       halted = catch :halt do
         params   = self.class.params_class.new(env)
-        request  = build_request(env: env, params: params, sessions_enabled: sessions_enabled?)
-        response = build_response(
+        request  = Request.new(
+          env: env,
+          params: params,
+          sessions_enabled: sessions_enabled?
+        )
+        response = Response.new(
           request: request,
           config: config,
           content_type: Mime.calculate_content_type_with_charset(config, request, config.accepted_mime_types),
@@ -438,18 +442,6 @@ module Hanami
     # @api private
     def sessions_enabled?
       false
-    end
-
-    # @since 2.0.0
-    # @api private
-    def build_request(**options)
-      Request.new(**options)
-    end
-
-    # @since 2.0.0
-    # @api private
-    def build_response(**options)
-      Response.new(**options)
     end
 
     # @since 0.2.0

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-require "rack/utils"
+require "hanami/action/flash"
 require "rack/mime"
 require "rack/request"
+require "rack/utils"
 require "securerandom"
 
 module Hanami
@@ -34,6 +35,14 @@ module Hanami
         end
 
         super
+      end
+
+      def flash
+        unless @sessions_enabled
+          raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#flash")
+        end
+
+        @flash ||= Flash.new(session[Flash::KEY])
       end
 
       def accept?(mime_type)

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -3,7 +3,6 @@
 require "rack"
 require "rack/response"
 require "hanami/utils/kernel"
-require "hanami/action/flash"
 require "hanami/action/halt"
 require "hanami/action/cookie_jar"
 require "hanami/action/cache/cache_control"
@@ -107,7 +106,7 @@ module Hanami
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session")
         end
 
-        env[Action::RACK_SESSION] ||= {}
+        request.session
       end
 
       # @since 2.0.0
@@ -123,7 +122,7 @@ module Hanami
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash")
         end
 
-        @flash ||= Flash.new(session[Flash::KEY])
+        request.flash
       end
 
       # @since 2.0.0

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -183,16 +183,6 @@ module Hanami
       end
 
       # @since 2.0.0
-      # @api private
-      def request_id
-        env.fetch(Action::REQUEST_ID) do
-          # FIXME: raise a meaningful error, by inviting devs to include Hanami::Action::Session
-          # raise "Can't find request ID"
-          raise Hanami::Action::MissingSessionError.new("request_id")
-        end
-      end
-
-      # @since 2.0.0
       # @api public
       def set_format(value) # rubocop:disable Naming/AccessorMethodName
         @format = value

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -111,18 +111,18 @@ module Hanami
 
       # @since 2.0.0
       # @api public
-      def cookies
-        @cookies ||= CookieJar.new(env.dup, headers, @config.cookies)
-      end
-
-      # @since 2.0.0
-      # @api public
       def flash
         unless @sessions_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash")
         end
 
         request.flash
+      end
+
+      # @since 2.0.0
+      # @api public
+      def cookies
+        @cookies ||= CookieJar.new(env.dup, headers, @config.cookies)
       end
 
       # @since 2.0.0

--- a/spec/unit/hanami/action/response/session_spec.rb
+++ b/spec/unit/hanami/action/response/session_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "hanami/action/response"
+require "hanami/action/request"
+
+RSpec.describe Hanami::Action::Response, "session features" do
+  subject(:response) {
+    described_class.new(
+      env: rack_env,
+      request: request,
+      config: Hanami::Action.config.dup,
+      sessions_enabled: true
+    )
+  }
+  let(:request) {
+    Hanami::Action::Request.new(env: rack_env, params: {}, sessions_enabled: true)
+  }
+  let(:rack_env) {
+    Rack::MockRequest.env_for("http://example.com/foo?q=bar")
+  }
+
+  it "uses the request's session object" do
+    expect(response.session).to eql request.session
+  end
+
+  it "uses the request's flash object" do
+    expect(response.flash).to eql request.flash
+  end
+end

--- a/spec/unit/hanami/action/response/view_rendering_spec.rb
+++ b/spec/unit/hanami/action/response/view_rendering_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Action::Response do
+RSpec.describe Hanami::Action::Response, "view rendering" do
   describe "#render" do
     subject(:response) {
       described_class.new(


### PR DESCRIPTION
This PR addresses some inconsistencies we had in how Request and Response accessed session features, namely the `session` itself, as well as `flash`:

- Until now, `session` has been accessible on both Request and Response,
- But `flash` was available on on the Response only (which was problematic, because Hanami users may want to see the previously-set flash state by interacting with the request)

Earlier I had an idea to these objects available consistently on both Request and Response, but make the Request's version of these objects read-only (see [this Trello card](https://trello.com/c/LSi57W0a/81-add-read-only-flash-and-session-objects-to-request-rationalize-request-response-overall)), which @tak1n implemented in #380. I attempted to clean this up and prepare it for merge in #398, but in doing so, I realised we'd be better served by simply ensuring the request and response operated on the _same_ objects at all times, ensuring that all changes would always be properly persisted through to the next request, regardless of from where they were made.

This PR makes this change. Now, both `session` and `flash` are canonically defined on Request (which is consistent with how `Rack::Request` is modelled — it's the owner of the `#session` method). These same methods are also defined on `Response`, but they simply delegate to the request object, which Response has access to.

This is a much simpler and easier to maintain implementation—and only a very small change from where we are now—so I'd be very confident for us to slip in right before beta4.

While I'm here, I've also removed `Response#request_id`, since we're not using it anywhere, it didn't exist previously in 1.3.x, and `Response` already has access to the `request` anyway, if really needed.

**For reviewers:** this PR has a clean commit history, with a couple of tidy-ups along the way made in separate commits.