### PR TITLE
Update API docs for 2.0.0

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,2 @@
---protected
--
-README.md
-LICENSE.md
-lib/**/*.rb
+--markup=markdown
+--plugin junk

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,9 @@ source "http://rubygems.org"
 gemspec
 
 unless ENV["CI"]
-  gem "byebug", require: false, platforms: :mri
-  gem "yard",   require: false
+  gem "byebug", platforms: :mri
+  gem "yard"
+  gem "yard-junk"
 end
 
 gem "hanami-utils",  github: "hanami/utils", branch: "main"

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ However, you can force this value:
 class Show < Hanami::Action
   def handle(*, res)
     # ...
-    res.format = format(:json)
+    res.format = :json
   end
 end
 
@@ -820,7 +820,7 @@ response.format                                                   # => :custom
 class Show < Hanami::Action
   def handle(*, res)
     # ...
-    res.format = format(:custom)
+    res.format = :custom
   end
 end
 
@@ -841,7 +841,7 @@ end
 
 class Csv < Hanami::Action
   def handle(*, res)
-    res.format = format(:csv)
+    res.format = :csv
     res.body = Enumerator.new do |yielder|
       yielder << csv_header
 

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -24,7 +24,7 @@ require_relative "action/mime"
 require_relative "action/rack/file"
 require_relative "action/request"
 require_relative "action/response"
-require_relative "action/error"
+require_relative "action/errors"
 
 module Hanami
   # An HTTP endpoint
@@ -270,7 +270,7 @@ module Hanami
     #
     # @param formats[Array<Symbol>] one or more symbols representing mime type(s)
     #
-    # @raise [Hanami::Controller::UnknownFormatError] if the symbol cannot
+    # @raise [Hanami::Action::UnknownFormatError] if the symbol cannot
     #   be converted into a mime type
     #
     # @since 0.1.0
@@ -600,7 +600,7 @@ module Hanami
       when String
         [Action::Mime.detect_format(value, config), value]
       else
-        raise Hanami::Controller::UnknownFormatError.new(value)
+        raise Hanami::Action::UnknownFormatError.new(value)
       end
     end
 

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -590,20 +590,6 @@ module Hanami
       res.body = Response::EMPTY_BODY
     end
 
-    # @since 2.0.0
-    # @api private
-    def format(value)
-      case value
-      when Symbol
-        format = Utils::Kernel.Symbol(value)
-        [format, Action::Mime.format_to_mime_type(format, config)]
-      when String
-        [Action::Mime.detect_format(value, config), value]
-      else
-        raise Hanami::Action::UnknownFormatError.new(value)
-      end
-    end
-
     # Finalize the response
     #
     # Prepare the data before the response will be returned to the webserver

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -126,7 +126,7 @@ module Hanami
     #
     # @raise [NoMethodError]
     #
-    # @api private
+    # @api public
     # @since 2.0.0
     def self.params(_klass = nil)
       raise NoMethodError,

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -133,64 +133,65 @@ module Hanami
             "To use `params`, please add 'hanami/validations' gem to your Gemfile"
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **before** the action is called, in the
-    # order they are added.
+    # @overload self.append_before(*callbacks, &block)
+    #   Define a callback for an Action.
+    #   The callback will be executed **before** the action is called, in the
+    #   order they are added.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
-    # @return [void]
+    #   @return [void]
     #
-    # @since 0.3.2
+    #   @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#append_after
+    #   @see Hanami::Action::Callbacks::ClassMethods#append_after
     #
-    # @example Method names (symbols)
-    #   require "hanami/controller"
+    #   @example Method names (symbols)
+    #     require "hanami/controller"
     #
-    #   class Show < Hanami::Action
-    #     before :authenticate, :set_article
+    #     class Show < Hanami::Action
+    #       before :authenticate, :set_article
     #
-    #     def handle(req, res)
+    #       def handle(req, res)
+    #       end
+    #
+    #       private
+    #       def authenticate
+    #         # ...
+    #       end
+    #
+    #       # `params` in the method signature is optional
+    #       def set_article(params)
+    #         @article = Article.find params[:id]
+    #       end
     #     end
     #
-    #     private
-    #     def authenticate
-    #       # ...
+    #     # The order of execution will be:
+    #     #
+    #     # 1. #authenticate
+    #     # 2. #set_article
+    #     # 3. #call
+    #
+    #   @example Anonymous functions (Procs)
+    #     require "hanami/controller"
+    #
+    #     class Show < Hanami::Action
+    #       before { ... } # 1 do some authentication stuff
+    #       before {|req, res| @article = Article.find params[:id] } # 2
+    #
+    #       def handle(req, res)
+    #       end
     #     end
     #
-    #     # `params` in the method signature is optional
-    #     def set_article(params)
-    #       @article = Article.find params[:id]
-    #     end
-    #   end
-    #
-    #   # The order of execution will be:
-    #   #
-    #   # 1. #authenticate
-    #   # 2. #set_article
-    #   # 3. #call
-    #
-    # @example Anonymous functions (Procs)
-    #   require "hanami/controller"
-    #
-    #   class Show < Hanami::Action
-    #     before { ... } # 1 do some authentication stuff
-    #     before {|req, res| @article = Article.find params[:id] } # 2
-    #
-    #     def handle(req, res)
-    #     end
-    #   end
-    #
-    #   # The order of execution will be:
-    #   #
-    #   # 1. authentication
-    #   # 2. set the article
-    #   # 3. `#handle`
+    #     # The order of execution will be:
+    #     #
+    #     # 1. authentication
+    #     # 2. set the article
+    #     # 3. `#handle`
     def self.append_before(...)
       config.before_callbacks.append(...)
     end
@@ -200,21 +201,22 @@ module Hanami
       alias_method :before, :append_before
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **after** the action is called, in the
-    # order they are added.
+    # @overload self.append_after(*callbacks, &block)
+    #   Define a callback for an Action.
+    #   The callback will be executed **after** the action is called, in the
+    #   order they are added.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
-    # @return [void]
+    #   @return [void]
     #
-    # @since 0.3.2
+    #   @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#append_before
+    #   @see Hanami::Action::Callbacks::ClassMethods#append_before
     def self.append_after(...)
       config.after_callbacks.append(...)
     end
@@ -224,40 +226,42 @@ module Hanami
       alias_method :after, :append_after
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **before** the action is called.
-    # It will add the callback at the beginning of the callbacks' chain.
+    # @overload self.prepend_before(*callbacks, &block)
+    #   Define a callback for an Action.
+    #   The callback will be executed **before** the action is called.
+    #   It will add the callback at the beginning of the callbacks' chain.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
-    # @return [void]
+    #   @return [void]
     #
-    # @since 0.3.2
+    #   @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#prepend_after
+    #   @see Hanami::Action::Callbacks::ClassMethods#prepend_after
     def self.prepend_before(...)
       config.before_callbacks.prepend(...)
     end
 
-    # Define a callback for an Action.
-    # The callback will be executed **after** the action is called.
-    # It will add the callback at the beginning of the callbacks' chain.
+    # @overload self.prepend_after(*callbacks, &block)
+    #   Define a callback for an Action.
+    #   The callback will be executed **after** the action is called.
+    #   It will add the callback at the beginning of the callbacks' chain.
     #
-    # @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
-    #   each of them is representing a name of a method available in the
-    #   context of the Action.
+    #   @param callbacks [Symbol, Array<Symbol>] a single or multiple symbol(s)
+    #     each of them is representing a name of a method available in the
+    #     context of the Action.
     #
-    # @param blk [Proc] an anonymous function to be executed
+    #   @param blk [Proc] an anonymous function to be executed
     #
-    # @return [void]
+    #   @return [void]
     #
-    # @since 0.3.2
+    #   @since 0.3.2
     #
-    # @see Hanami::Action::Callbacks::ClassMethods#prepend_before
+    #   @see Hanami::Action::Callbacks::ClassMethods#prepend_before
     def self.prepend_after(...)
       config.after_callbacks.prepend(...)
     end

--- a/lib/hanami/action/base_params.rb
+++ b/lib/hanami/action/base_params.rb
@@ -5,6 +5,19 @@ require "hanami/utils/hash"
 
 module Hanami
   class Action
+    # Provides access to params included in a Rack request.
+    #
+    # Offers useful access to params via methods like {#[]}, {#get} and {#to_h}.
+    #
+    # These params are available via {Request#params}.
+    #
+    # This class is used by default when {Hanami::Action::Validatable} is not included, or when no
+    # {Validatable::ClassMethods#params params} validation schema is defined.
+    #
+    # @see Hanami::Action::Request#params
+    #
+    # @api private
+    # @since 0.7.0
     class BaseParams
       # @attr_reader env [Hash] the Rack env
       #
@@ -18,11 +31,9 @@ module Hanami
       # @api private
       attr_reader :raw
 
-      # Initialize the params and freeze them.
+      # Returns a new frozen params object for the Rack env.
       #
       # @param env [Hash] a Rack env or an hash of params.
-      #
-      # @return [Params]
       #
       # @since 0.7.0
       # @api private
@@ -33,25 +44,26 @@ module Hanami
         freeze
       end
 
-      # Returns the object associated with the given key
+      # Returns the value for the given params key.
       #
       # @param key [Symbol] the key
       #
-      # @return [Object,nil] return the associated object, if found
+      # @return [Object,nil] the associated value, if found
       #
       # @since 0.7.0
+      # @api public
       def [](key)
         @params[key]
       end
 
-      # Get an attribute value associated with the given key.
-      # Nested attributes are reached by listing all the keys to get to the value.
+      # Returns an value associated with the given params key.
+      #
+      # You can access nested attributes by listing all the keys in the path. This uses the same key
+      # path semantics as `Hash#dig`.
       #
       # @param keys [Array<Symbol,Integer>] the key
       #
       # @return [Object,NilClass] return the associated value, if found
-      #
-      # @since 0.7.0
       #
       # @example
       #   require "hanami/controller"
@@ -73,6 +85,9 @@ module Hanami
       #       end
       #     end
       #   end
+      #
+      # @since 0.7.0
+      # @api public
       def get(*keys)
         @params.dig(*keys)
       end
@@ -83,32 +98,40 @@ module Hanami
       # @since 0.8.0
       alias_method :dig, :get
 
-      # Provide a common interface with Params
+      # Returns true at all times, providing a common interface with {Params}.
       #
       # @return [TrueClass] always returns true
       #
-      # @since 0.7.0
-      #
       # @see Hanami::Action::Params#valid?
+      #
+      # @api public
+      # @since 0.7.0
       def valid?
         true
       end
 
-      # Serialize params to Hash
+      # Returns a hash of the parsed request params.
       #
-      # @return [::Hash]
+      # @return [Hash]
       #
       # @since 0.7.0
+      # @api public
       def to_h
         @params
       end
       alias_method :to_hash, :to_h
 
-      # Iterates through params
+      # Iterates over the params.
       #
-      # @param blk [Proc]
+      # Calls the given block with each param key-value pair; returns the full hash of params.
+      #
+      # @yieldparam key [Symbol]
+      # @yieldparam value [Object]
+      #
+      # @return [to_h]
       #
       # @since 0.7.1
+      # @api public
       def each(&blk)
         to_h.each(&blk)
       end

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -5,6 +5,12 @@ require_relative "mime"
 
 module Hanami
   class Action
+    # Config for `Hanami::Action` classes.
+    #
+    # @see Hanami::Action.config
+    #
+    # @api public
+    # @since 2.0.0
     class Config < Dry::Configurable::Config
       # Default MIME type to format mapping
       #

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -157,7 +157,7 @@ module Hanami
       #
       #   The given format must be coercible to a symbol, and be a valid MIME
       #   type alias. If it isn't, at runtime the framework will raise an
-      #   `Hanami::Controller::UnknownFormatError`.
+      #   `Hanami::Action::UnknownFormatError`.
       #
       #   By default, this value is nil.
       #
@@ -174,7 +174,7 @@ module Hanami
       #
       #   The given format must be coercible to a symbol, and be a valid MIME
       #   type alias. If it isn't, at the runtime the framework will raise an
-      #   `Hanami::Controller::UnknownFormatError`.
+      #   `Hanami::Action::UnknownFormatError`.
       #
       #   By default, this value is nil.
       #

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -116,12 +116,6 @@ module Hanami
     # @api private
     HTTP_ACCEPT = "HTTP_ACCEPT"
 
-    # The header key to set the mime type of the response
-    #
-    # @since 0.1.0
-    # @api private
-    CONTENT_TYPE = ::Rack::CONTENT_TYPE
-
     # The default mime type for an incoming HTTP request
     #
     # @since 0.1.0

--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 require "hanami/utils/blank"
-require "hanami/controller/error"
 require "rack/utils"
 require "securerandom"
+require_relative "errors"
 
 module Hanami
   # @api private
   class Action
-    # Invalid CSRF Token
-    #
-    # @since 0.4.0
-    class InvalidCSRFTokenError < Controller::Error
-    end
-
     # CSRF Protection
     #
     # This security mechanism is enabled automatically if sessions are turned on.

--- a/lib/hanami/action/error.rb
+++ b/lib/hanami/action/error.rb
@@ -2,22 +2,28 @@
 
 module Hanami
   class Action
+    # Base class for all Action errors.
+    #
+    # @api public
     # @since 2.0.0
     class Error < ::StandardError
     end
 
-    # Missing session error
+    # Error raised when session is accessed but not enabled.
     #
     # This error is raised when `session` or `flash` is accessed/set on request/response objects
     # in actions which do not include `Hanami::Action::Session`.
-    #
-    # @since 2.0.0
     #
     # @see Hanami::Action::Session
     # @see Hanami::Action::Request#session
     # @see Hanami::Action::Response#session
     # @see Hanami::Action::Response#flash
+    #
+    # @api public
+    # @since 2.0.0
     class MissingSessionError < Error
+      # @api private
+      # @since 2.0.0
       def initialize(session_method)
         super(<<~TEXT)
           Sessions are not enabled. To use `#{session_method}`:

--- a/lib/hanami/action/errors.rb
+++ b/lib/hanami/action/errors.rb
@@ -9,6 +9,22 @@ module Hanami
     class Error < ::StandardError
     end
 
+    # Unknown format error
+    #
+    # This error is raised when a action sets a format that it isn't recognized
+    # both by `Hanami::Action::Configuration` and the list of Rack mime types
+    #
+    # @since 2.0.0
+    #
+    # @see Hanami::Action::Mime#format=
+    class UnknownFormatError < Error
+      # @since 2.0.0
+      # @api private
+      def initialize(format)
+        super("Cannot find a corresponding Mime type for '#{format}'. Please configure it with Hanami::Controller::Configuration#format.") # rubocop:disable Layout/LineLength
+      end
+    end
+
     # Error raised when session is accessed but not enabled.
     #
     # This error is raised when `session` or `flash` is accessed/set on request/response objects
@@ -42,6 +58,12 @@ module Hanami
             include Hanami::Action::Session
         TEXT
       end
+    end
+
+    # Invalid CSRF Token
+    #
+    # @since 0.4.0
+    class InvalidCSRFTokenError < Error
     end
   end
 end

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
+# The Hanami::Action::Flash implementation is derived from Roda's FlashHash, also released under the
+# MIT Licence:
+#
+# Copyright (c) 2014-2020 Jeremy Evans
+# Copyright (c) 2010-2014 Michel Martens, Damian Janowski and Cyril David
+# Copyright (c) 2008-2009 Christian Neukirchen
+
 module Hanami
   class Action
-    # A container to transport data with the HTTP session, with a lifespan of
-    # just one HTTP request or redirect.
+    # A container to transport data with the HTTP session, with a lifespan of just one HTTP request
+    # or redirect.
     #
-    # Behaves like a hash, returning entries for the current request, except for
-    # {#[]=}, which updates the hash for the next request.
-    #
-    # This implementation is derived from Roda's FlashHash, also released under
-    # the MIT Licence:
-    #
-    # Copyright (c) 2014-2020 Jeremy Evans
-    # Copyright (c) 2010-2014 Michel Martens, Damian Janowski and Cyril David
-    # Copyright (c) 2008-2009 Christian Neukirchen
+    # Behaves like a hash, returning entries for the current request, except for {#[]=}, which
+    # updates the hash for the next request.
     #
     # @since 0.3.0
     # @api public
@@ -30,9 +30,9 @@ module Hanami
       # @api public
       attr_reader :next
 
-      # Initializes a new flash instance
+      # Returns a new flash object.
       #
-      # @param hash [Hash, nil] the flash hash for the current request. nil will become an empty hash.
+      # @param hash [Hash, nil] the flash hash for the current request; `nil` will become an empty hash.
       #
       # @since 0.3.0
       # @api public
@@ -41,7 +41,9 @@ module Hanami
         @next = {}
       end
 
-      # @return [Hash] The flash hash for the current request
+      # Returns the flash hash for the current request.
+      #
+      # @return [Hash] the flash hash for the current request
       #
       # @since 2.0.0
       # @api public
@@ -49,7 +51,7 @@ module Hanami
         @flash
       end
 
-      # Returns the value for the given key in the current hash
+      # Returns the value for the given key in the current hash.
       #
       # @param key [Object] the key
       #
@@ -61,7 +63,7 @@ module Hanami
         @flash[key]
       end
 
-      # Updates the next hash with the given key and value
+      # Updates the next hash with the given key and value.
       #
       # @param key [Object] the key
       # @param value [Object] the value
@@ -72,9 +74,12 @@ module Hanami
         @next[key] = value
       end
 
-      # Calls the given block once for each element in the current hash
+      # Calls the given block once for each element in the current hash.
       #
-      # @param block [Proc]
+      # @yieldparam element [Array<(Object, Object)>] array containing the key and value from the
+      #   hash
+      #
+      # @return [now]
       #
       # @since 1.2.0
       # @api public
@@ -82,10 +87,12 @@ module Hanami
         @flash.each(&block)
       end
 
-      # Returns a new array with the results of running block once for every
-      # element in the current hash
+      # Returns an array of objects returned by the block, called once for each element in the
+      # current hash.
       #
-      # @param block [Proc]
+      # @yieldparam element [Array<(Object, Object)>] array containing the key and value from the
+      #   hash
+      #
       # @return [Array]
       #
       # @since 1.2.0
@@ -114,7 +121,7 @@ module Hanami
         @flash.key?(key)
       end
 
-      # Removes entries from the next hash
+      # Removes entries from the next hash.
       #
       # @overload discard(key)
       #   Removes the given key from the next hash

--- a/lib/hanami/action/halt.rb
+++ b/lib/hanami/action/halt.rb
@@ -4,9 +4,11 @@ require "hanami/http/status"
 
 module Hanami
   class Action
+    # @api private
+    # @since 2.0.0
     module Halt
-      # @since 2.0.0
       # @api private
+      # @since 2.0.0
       def self.call(status, body = nil)
         body ||= Http::Status.message_for(status)
         throw :halt, [status, body]

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -3,6 +3,7 @@
 require "hanami/utils"
 require "rack/utils"
 require "rack/mime"
+require_relative "errors"
 
 module Hanami
   class Action
@@ -117,7 +118,7 @@ module Hanami
         return if format.nil?
 
         config.mime_type_for(format) ||
-          TYPES.fetch(format) { raise Hanami::Controller::UnknownFormatError.new(format) }
+          TYPES.fetch(format) { raise Hanami::Action::UnknownFormatError.new(format) }
       end
 
       # Transforms MIME Types to symbol
@@ -150,7 +151,7 @@ module Hanami
       #
       # @return [Array<String>, nil]
       #
-      # @raise [Hanami::Controller::UnknownFormatError] if the format is invalid
+      # @raise [Hanami::Action::UnknownFormatError] if the format is invalid
       #
       # @since 2.0.0
       # @api private

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -145,6 +145,19 @@ module Hanami
         TYPES.key(content_type)
       end
 
+      # @since 2.0.0
+      # @api private
+      def self.detect_format_and_content_type(value, config)
+        case value
+        when Symbol
+          [value, format_to_mime_type(value, config)]
+        when String
+          [detect_format(value, config), value]
+        else
+          raise UnknownFormatError.new(value)
+        end
+      end
+
       # Transforms symbols to MIME Types
       # @example
       #   restrict_mime_types(config, [:json])  #=> ["application/json"]
@@ -223,8 +236,6 @@ module Hanami
       end
 
       # Use for setting the content_type and charset if the response
-      #
-      # @see Hanami::Action::Mime#call
       #
       # @return [String]
       #

--- a/lib/hanami/action/rack/file.rb
+++ b/lib/hanami/action/rack/file.rb
@@ -4,13 +4,17 @@ require "rack/file"
 
 module Hanami
   class Action
+    # Rack extensions for actions.
+    #
+    # @api private
+    # @since 0.4.3
     module Rack
       # File to be sent
       #
+      # @see Hanami::Action::Response#send_file
+      #
       # @since 0.4.3
       # @api private
-      #
-      # @see Hanami::Action::Rack#send_file
       class File
         # @param path [String,Pathname] file path
         #

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -9,9 +9,9 @@ require_relative "errors"
 
 module Hanami
   class Action
-    # An HTTP request based on top of `Rack::Request`.
+    # The HTTP request for an action, given to {Action#handle}.
     #
-    # This provides backwards compatibility with with Rack.
+    # Inherits from `Rack::Request`, providing compatibility with Rack functionality.
     #
     # @see http://www.rubydoc.info/gems/rack/Rack/Request
     #
@@ -54,6 +54,8 @@ module Hanami
       #
       # @raise [MissingSessionError] if sessions are not enabled
       #
+      # @see Response#session
+      #
       # @since 2.0.0
       # @api public
       def session
@@ -69,6 +71,8 @@ module Hanami
       # @return [Flash]
       #
       # @raise [MissingSessionError] if sessions are not enabled
+      #
+      # @see Response#flash
       #
       # @since 2.0.0
       # @api public

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -8,15 +8,27 @@ require "securerandom"
 
 module Hanami
   class Action
-    # An HTTP request based on top of Rack::Request.
-    # This guarantees backwards compatibility with with Rack.
+    # An HTTP request based on top of `Rack::Request`.
     #
-    # @since 0.3.1
+    # This provides backwards compatibility with with Rack.
     #
     # @see http://www.rubydoc.info/gems/rack/Rack/Request
+    #
+    # @since 0.3.1
     class Request < ::Rack::Request
+      # Returns the request's params.
+      #
+      # For an action with {Validatable} included, this will be a {Params} instance, otherwise a
+      # {BaseParams}.
+      #
+      # @return [BaseParams,Params]
+      #
+      # @since 2.0.0
+      # @api public
       attr_reader :params
 
+      # @since 2.0.0
+      # @api private
       def initialize(env:, params:, sessions_enabled: false)
         super(env)
 
@@ -24,11 +36,25 @@ module Hanami
         @sessions_enabled = sessions_enabled
       end
 
+      # Returns the request's ID
+      #
+      # @return [String]
+      #
+      # @since 2.0.0
+      # @api public
       def id
         # FIXME: make this number configurable and document the probabilities of clashes
         @id ||= @env[Action::REQUEST_ID] = SecureRandom.hex(Action::DEFAULT_ID_LENGTH)
       end
 
+      # Returns the session for the request.
+      #
+      # @return [Hash] the session object
+      #
+      # @raise [MissingSessionError] if sessions are not enabled
+      #
+      # @since 2.0.0
+      # @api public
       def session
         unless @sessions_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
@@ -37,6 +63,14 @@ module Hanami
         super
       end
 
+      # Returns the flash for the request.
+      #
+      # @return [Flash]
+      #
+      # @raise [MissingSessionError] if sessions are not enabled
+      #
+      # @since 2.0.0
+      # @api public
       def flash
         unless @sessions_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#flash")
@@ -45,12 +79,16 @@ module Hanami
         @flash ||= Flash.new(session[Flash::KEY])
       end
 
+      # @since 2.0.0
+      # @api private
       def accept?(mime_type)
         !!::Rack::Utils.q_values(accept).find do |mime, _|
           ::Rack::Mime.match?(mime_type, mime)
         end
       end
 
+      # @since 2.0.0
+      # @api private
       def accept_header?
         accept != Action::DEFAULT_ACCEPT
       end

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -5,6 +5,7 @@ require "rack/mime"
 require "rack/request"
 require "rack/utils"
 require "securerandom"
+require_relative "errors"
 
 module Hanami
   class Action

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -47,7 +47,7 @@ module Hanami
       # @api private
       def initialize(request:, config:, content_type: nil, env: {}, headers: {}, view_options: nil, sessions_enabled: false) # rubocop:disable Layout/LineLength, Metrics/ParameterLists
         super([], 200, headers.dup)
-        set_header(Action::CONTENT_TYPE, content_type)
+        self.content_type = content_type if content_type
 
         @request = request
         @config = config

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -96,7 +96,7 @@ module Hanami
       # Returns the format for the response.
       #
       # Returns nil if a format has not been assigned and also cannot be determined from the
-      # response's {#content_type}.
+      # response's `#content_type`.
       #
       # @example
       #   response.format # => :json

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -8,6 +8,7 @@ require "hanami/action/cookie_jar"
 require "hanami/action/cache/cache_control"
 require "hanami/action/cache/expires"
 require "hanami/action/cache/conditional_get"
+require_relative "errors"
 
 module Hanami
   class Action

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -4,12 +4,17 @@ require "hanami/action/flash"
 
 module Hanami
   class Action
-    # Session API
+    # Session support for actions.
     #
-    # This module isn't included by default.
+    # Not included by default; you should include this module manually to enable session support.
+    # For actions within an Hanami app, this module will be included automatically if sessions are
+    # configured in the app config.
     #
+    # @api public
     # @since 0.1.0
     module Session
+      # @api private
+      # @since 0.1.0
       def self.included(base)
         base.class_eval do
           before { |req, _| req.id }

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -4,6 +4,12 @@ require "hanami/action/params"
 
 module Hanami
   class Action
+    # Support for validating params when calling actions.
+    #
+    # Included only when hanami-validations (and its dependencies) are bundled.
+    #
+    # @api private
+    # @since 0.1.0
     module Validatable
       # Defines the class name for anonymous params
       #
@@ -34,12 +40,9 @@ module Hanami
         # Once whitelisted, the params are available as an Hash with symbols
         # as keys.
         #
-        #
-        #
         # It accepts an anonymous block where all the params can be listed.
         # It internally creates an inner class which inherits from
         # Hanami::Action::Params.
-        #
         #
         # Alternatively, it accepts an concrete class that should inherit from
         # Hanami::Action::Params.
@@ -48,8 +51,6 @@ module Hanami
         # @param blk [Proc] a block which defines the whitelisted params
         #
         # @return void
-        #
-        # @since 0.3.0
         #
         # @see Hanami::Action::Params
         # @see https://guides.hanamirb.org//validations/overview
@@ -93,6 +94,9 @@ module Hanami
         #       req.params[:admin]               # => nil
         #     end
         #   end
+        #
+        # @since 0.3.0
+        # @api public
         def params(klass = nil, &blk)
           if klass.nil?
             klass = const_set(PARAMS_CLASS_NAME, Class.new(Params))

--- a/lib/hanami/controller.rb
+++ b/lib/hanami/controller.rb
@@ -2,7 +2,6 @@
 
 require "hanami/action"
 require "hanami/controller/version"
-require "hanami/controller/error"
 
 # Hanami
 #
@@ -27,20 +26,5 @@ module Hanami
   #     end
   #   end
   module Controller
-    # Unknown format error
-    #
-    # This error is raised when a action sets a format that it isn't recognized
-    # both by `Hanami::Action::Configuration` and the list of Rack mime types
-    #
-    # @since 0.2.0
-    #
-    # @see Hanami::Action::Mime#format=
-    class UnknownFormatError < Hanami::Controller::Error
-      # @since 0.2.0
-      # @api private
-      def initialize(format)
-        super("Cannot find a corresponding Mime type for '#{format}'. Please configure it with Hanami::Controller::Configuration#format.") # rubocop:disable Layout/LineLength
-      end
-    end
   end
 end

--- a/lib/hanami/controller/error.rb
+++ b/lib/hanami/controller/error.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Hanami
-  module Controller
-    # @since 0.5.0
-    class Error < ::StandardError
-    end
-  end
-end

--- a/lib/hanami/http/status.rb
+++ b/lib/hanami/http/status.rb
@@ -3,6 +3,8 @@
 require "rack/utils"
 
 module Hanami
+  # @since 0.1.0
+  # @api private
   module Http
     # An HTTP status
     #

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1047,9 +1047,9 @@ module SendFileTest
             # we should have also checked #accept? but w/e
             res.body = ::File.read(Pathname.new("spec/support/fixtures/#{resource.asset_path}.html"))
             res.status = 200
-            res.format = format(:html)
+            res.format = :html
           when "json", nil
-            res.format = format(:json)
+            res.format = :json
             res.send_file Pathname.new("#{resource.asset_path}.json")
           else
             halt 406
@@ -1558,13 +1558,13 @@ end
 module Mimes
   class Default < Hanami::Action
     def handle(_req, res)
-      res.body, = *format(res.content_type)
+      res.body = res.format
     end
   end
 
   class Custom < Hanami::Action
     def handle(_req, res)
-      res.format = format(:xml)
+      res.format = :xml
       res.body   = res.format
     end
   end
@@ -1572,7 +1572,7 @@ module Mimes
   class Latin < Hanami::Action
     def handle(_req, res)
       res.charset = "latin1"
-      res.format  = format(:html)
+      res.format  = :html
       res.body    = res.format
     end
   end
@@ -1584,7 +1584,7 @@ module Mimes
       res.headers["X-AcceptXml"]     = req.accept?("application/xml").to_s
       res.headers["X-AcceptJson"]    = req.accept?("text/json").to_s
 
-      res.body, = *format(res.content_type)
+      res.body = res.format
     end
   end
 
@@ -1594,7 +1594,7 @@ module Mimes
     accept :json, :custom
 
     def handle(*, res)
-      res.body, = *format(res.content_type)
+      res.body = res.format
     end
   end
 
@@ -1604,7 +1604,7 @@ module Mimes
     accept :html, :json, :custom
 
     def handle(_req, res)
-      res.body, = *format(res.content_type)
+      res.body = res.format
     end
   end
 
@@ -1616,7 +1616,7 @@ module Mimes
 
   class OverrideDefaultResponse < Hanami::Action
     def handle(*, res)
-      res.format = format(:xml)
+      res.format = :xml
     end
 
     private
@@ -1630,7 +1630,7 @@ module Mimes
     accept :json
 
     def handle(_req, res)
-      res.body, = *format(res.content_type)
+      res.body = res.format
     end
   end
 
@@ -1662,7 +1662,7 @@ module MimesWithDefault
     accept :json
 
     def handle(*, res)
-      res.body, = *format(res.content_type)
+      res.body = res.format
     end
   end
 

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hanami::Action do
         input = req.params[:format]
         input = input.to_sym unless input.nil?
 
-        res.format = format(input)
+        res.format = input
       end
     end
 

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -96,17 +96,17 @@ RSpec.describe Hanami::Action do
     end
 
     it "sets nil and raises an error" do
-      expect { action.call(format: nil) }.to raise_error(Hanami::Controller::UnknownFormatError, "Cannot find a corresponding Mime type for ''. Please configure it with Hanami::Controller::Configuration#format.")
+      expect { action.call(format: nil) }.to raise_error(Hanami::Action::UnknownFormatError, "Cannot find a corresponding Mime type for ''. Please configure it with Hanami::Controller::Configuration#format.")
     end
 
     it "sets '' and raises an error" do
-      expect { action.call(format: "") }.to raise_error(Hanami::Controller::UnknownFormatError, "Cannot find a corresponding Mime type for ''. Please configure it with Hanami::Controller::Configuration#format.")
+      expect { action.call(format: "") }.to raise_error(Hanami::Action::UnknownFormatError, "Cannot find a corresponding Mime type for ''. Please configure it with Hanami::Controller::Configuration#format.")
     end
 
     it "sets an unknown format and raises an error" do
       action.call(format: :unknown)
     rescue StandardError => exception
-      expect(exception).to         be_kind_of(Hanami::Controller::UnknownFormatError)
+      expect(exception).to         be_kind_of(Hanami::Action::UnknownFormatError)
       expect(exception.message).to eq("Cannot find a corresponding Mime type for 'unknown'. Please configure it with Hanami::Controller::Configuration#format.")
     end
 

--- a/spec/unit/hanami/controller/error_spec.rb
+++ b/spec/unit/hanami/controller/error_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe Hanami::Controller::Error do
-  it "inherits from ::StandardError" do
-    expect(described_class.superclass).to eq(StandardError)
-  end
-end

--- a/spec/unit/hanami/controller/unknown_format_error_spec.rb
+++ b/spec/unit/hanami/controller/unknown_format_error_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe Hanami::Controller::UnknownFormatError do
-  it "inheriths from Hanami::Controller::Error" do
-    expect(Hanami::Controller::UnknownFormatError.superclass).to eq(Hanami::Controller::Error)
-  end
-end


### PR DESCRIPTION
Ensure we have 100% coverage for API docs in hanami-controller (and that methods have been checked for appropriate `@api` public or private tags).

This PR does include a couple of small code changes:

In [eea8ef5](https://github.com/hanami/controller/pull/401/commits/eea8ef59ebc1c82c1b20f1f7e4921edd630b3efd), it rearranges the errors into `hanami/action/errors.rb`. `Hanami::Controller::UnknownFormatError` becomes `Hanami::Action::UnknownFormatError` (other error names remain unchanged).

In [6686ec2](https://github.com/hanami/controller/pull/401/commits/6686ec26c8d7d40709bcd2b98b2d8c0680b84006), we remove a CONTENT_TYPE constant that we don't really need internally, because we can use Rack's own `#content_type` method instead of manually referring to the header.

In [ca3761c](https://github.com/hanami/controller/pull/401/commits/ca3761cb54cfb1bbca6589ee8ff9efc45dc40921), it changes the way we assign the response format via `Response#format.

Previously this felt a bit disjointed. You had to use an `Action#format` helper inside your `#handle` method and pass its values to the response:

```ruby
response.format = format(:json)
```

This is a detail that I expect many people will overlook. It's also mostly about associating a format to a content type, which we already have enough information to do inside the response. So now you can just do this:

```ruby
response.format = :json
```

