### PR TITLE
Add single `formats` setting to replace `accepted_formats`, `default_request_format`, `default_response_format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,12 +928,6 @@ configuration = Hanami::Controller::Configuration.new do |config|
   #
   config.format custom: "application/custom"
 
-  # Define a fallback format to detect in case of HTTP request with `Accept: */*`
-  # If not defined here, it will return Rack's default: `application/octet-stream`
-  # Argument: symbol, it should be already known. defaults to `nil`
-  #
-  config.default_request_format = :html
-
   # Define a default format to set as `Content-Type` header for response,
   # unless otherwise specified.
   # If not defined here, it will return Rack's default: `application/octet-stream`

--- a/hanami-controller.gemspec
+++ b/hanami-controller.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", "~> 2.0"
   spec.add_dependency "hanami-utils", "~> 2.0.0.rc1"
   spec.add_dependency "dry-configurable", "~> 1.0", "< 2"
+  spec.add_dependency "dry-core", "~> 1.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "bundler",   ">= 1.6", "< 3"

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -58,7 +58,7 @@ module Hanami
 
     # See {Config} for individual setting accessor API docs
     setting :handled_exceptions, default: {}
-    setting :formats, default: Config::Formats.new, cloneable: true
+    setting :formats, default: Config::Formats.new, mutable: true
     setting :default_charset
     setting :default_headers, default: {}, constructor: -> (headers) { headers.compact }
     setting :cookies, default: {}, constructor: -> (cookie_options) {
@@ -70,8 +70,8 @@ module Hanami
       Pathname(File.expand_path(dir || Dir.pwd)).realpath
     }
     setting :public_directory, default: Config::DEFAULT_PUBLIC_DIRECTORY
-    setting :before_callbacks, default: Utils::Callbacks::Chain.new, cloneable: true
-    setting :after_callbacks, default: Utils::Callbacks::Chain.new, cloneable: true
+    setting :before_callbacks, default: Utils::Callbacks::Chain.new, mutable: true
+    setting :after_callbacks, default: Utils::Callbacks::Chain.new, mutable: true
 
     # @!scope class
 

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -311,7 +311,7 @@ module Hanami
         response = build_response(
           request: request,
           config: config,
-          content_type: Mime.calculate_content_type_with_charset(config, request, config.formats.accepted_mime_types),
+          content_type: Mime.response_content_type_with_charset(request, config),
           env: env,
           headers: config.default_headers,
           sessions_enabled: sessions_enabled?

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -311,7 +311,7 @@ module Hanami
         response = build_response(
           request: request,
           config: config,
-          content_type: Mime.calculate_content_type_with_charset(config, request, config.accepted_mime_types),
+          content_type: Mime.calculate_content_type_with_charset(config, request, config.formats.accepted_mime_types),
           env: env,
           headers: config.default_headers,
           sessions_enabled: sessions_enabled?

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -59,9 +59,6 @@ module Hanami
     # See {Config} for individual setting accessor API docs
     setting :handled_exceptions, default: {}
     setting :format_mappings, default: Config::DEFAULT_FORMAT_MAPPINGS
-    setting :default_request_format, constructor: -> (format) {
-      Utils::Kernel.Symbol(format) unless format.nil?
-    }
     setting :default_response_format, constructor: -> (format) {
       Utils::Kernel.Symbol(format) unless format.nil?
     }

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -278,6 +278,14 @@ module Hanami
       config.after_callbacks.prepend(...)
     end
 
+    # TODO: document
+    def self.format(...)
+      config.format(...)
+    end
+    # class << self
+    #   alias_method :accept, :format
+    # end
+
     # Restrict the access to the specified mime type symbols.
     #
     # @param formats[Array<Symbol>] one or more symbols representing mime type(s)

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -60,7 +60,6 @@ module Hanami
     setting :handled_exceptions, default: {}
     setting :format_mappings, default: Config::DEFAULT_FORMAT_MAPPINGS
     setting :formats, default: []
-    setting :accepted_formats, default: []
     setting :default_charset
     setting :default_headers, default: {}, constructor: -> (headers) { headers.compact }
     setting :cookies, default: {}, constructor: -> (cookie_options) {
@@ -277,39 +276,6 @@ module Hanami
     def self.format(...)
       config.format(...)
     end
-    # class << self
-    #   alias_method :accept, :format
-    # end
-
-    # Restrict the access to the specified mime type symbols.
-    #
-    # @param formats[Array<Symbol>] one or more symbols representing mime type(s)
-    #
-    # @raise [Hanami::Action::UnknownFormatError] if the symbol cannot
-    #   be converted into a mime type
-    #
-    # @since 0.1.0
-    #
-    # @see Config#format
-    #
-    # @example
-    #   require "hanami/controller"
-    #
-    #   class Show < Hanami::Action
-    #     accept :html, :json
-    #
-    #     def handle(req, res)
-    #       # ...
-    #     end
-    #   end
-    #
-    #   # When called with "*/*"              => 200
-    #   # When called with "text/html"        => 200
-    #   # When called with "application/json" => 200
-    #   # When called with "application/xml"  => 415
-    def self.accept(*formats)
-      config.accepted_formats = formats
-    end
 
     # @see Config#handle_exception
     #
@@ -440,7 +406,7 @@ module Hanami
     # @since 2.0.0
     # @api private
     def enforce_accepted_mime_types(request)
-      return if config.accepted_formats.empty?
+      return if config.formats.empty?
 
       Mime.enforce_accept(request, config) { return halt 406 }
       Mime.enforce_content_type(request, config) { return halt 415 }

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -58,7 +58,7 @@ module Hanami
 
     # See {Config} for individual setting accessor API docs
     setting :handled_exceptions, default: {}
-    setting :formats, default: Config::DEFAULT_FORMATS
+    setting :format_mappings, default: Config::DEFAULT_FORMAT_MAPPINGS
     setting :default_request_format, constructor: -> (format) {
       Utils::Kernel.Symbol(format) unless format.nil?
     }

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -59,9 +59,7 @@ module Hanami
     # See {Config} for individual setting accessor API docs
     setting :handled_exceptions, default: {}
     setting :format_mappings, default: Config::DEFAULT_FORMAT_MAPPINGS
-    setting :default_response_format, constructor: -> (format) {
-      Utils::Kernel.Symbol(format) unless format.nil?
-    }
+    setting :formats, default: []
     setting :accepted_formats, default: []
     setting :default_charset
     setting :default_headers, default: {}, constructor: -> (headers) { headers.compact }
@@ -84,7 +82,7 @@ module Hanami
     #
     #   @example Access inside class body
     #     class Show < Hanami::Action
-    #       config.default_response_format = :json
+    #       config.format :json
     #     end
     #
     #   @return [Config]

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -271,7 +271,10 @@ module Hanami
       config.after_callbacks.prepend(...)
     end
 
-    # TODO: document
+    # @see Config#format
+    #
+    # @since 2.0.0
+    # @api public
     def self.format(...)
       config.format(...)
     end

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -58,8 +58,7 @@ module Hanami
 
     # See {Config} for individual setting accessor API docs
     setting :handled_exceptions, default: {}
-    setting :format_mappings, default: Config::DEFAULT_FORMAT_MAPPINGS
-    setting :formats, default: []
+    setting :formats, default: Config::Formats.new, cloneable: true
     setting :default_charset
     setting :default_headers, default: {}, constructor: -> (headers) { headers.compact }
     setting :cookies, default: {}, constructor: -> (cookie_options) {

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -63,10 +63,6 @@ module Hanami
         self.formats.values = formats
       end
 
-      def default_format
-        formats.default
-      end
-
       # @!attribute [rw] default_charset
       #
       #   Sets a charset (character set) as default fallback for all the requests

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -143,6 +143,15 @@ module Hanami
         formats.key(format)
       end
 
+      # TODO: document
+      def use_formats(*formats)
+        default_format = formats.first
+
+        self.accepted_formats = formats
+        self.default_request_format = default_format
+        self.default_response_format = default_format
+      end
+
       # @since 2.0.0
       # @api private
       def accepted_mime_types

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -82,7 +82,11 @@ module Hanami
       # @since 2.0.0
       # @api public
       def format(*formats)
-        self.formats.values = formats
+        if formats.empty?
+          self.formats.values
+        else
+          self.formats.values = formats
+        end
       end
 
       # @!attribute [rw] default_charset

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -145,10 +145,14 @@ module Hanami
 
       # TODO: document
       def format(*formats)
-        default_format = formats.first
+        self.formats = formats
 
+        # TODO: update this
         self.accepted_formats = formats
-        self.default_response_format = default_format
+      end
+
+      def default_format
+        formats.first
       end
 
       # @since 2.0.0
@@ -156,23 +160,6 @@ module Hanami
       def accepted_mime_types
         accepted_formats.any? ? Mime.restrict_mime_types(self) : mime_types
       end
-
-      # @!attribute [rw] default_response_format
-      #
-      #   Sets a format to be used for all responses regardless of the request
-      #   type.
-      #
-      #   The given format must be coercible to a symbol, and be a valid MIME
-      #   type alias. If it isn't, at the runtime the framework will raise an
-      #   `Hanami::Action::UnknownFormatError`.
-      #
-      #   By default, this value is nil.
-      #
-      #   @return [Symbol]
-      #
-      #   @see Hanami::Action::Mime
-      #
-      #   @since 0.5.0
 
       # @!attribute [rw] default_charset
       #

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -58,19 +58,6 @@ module Hanami
           .to_h
       end
 
-      # Returns the configured format's MIME types
-      #
-      # @return [Array<String>] the format's MIME types
-      #
-      # @see Hanami::Action::Config::Formats
-      #
-      # @since 0.8.0
-      #
-      # @api private
-      def mime_types
-        formats.mime_types
-      end
-
       # Returns a MIME type for the given format
       #
       # @param format [#to_sym] a format
@@ -95,7 +82,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def accepted_mime_types
-        formats.any? ? Mime.restrict_mime_types(self) : mime_types
+        formats.any? ? Mime.restrict_mime_types(self) : formats.mime_types
       end
 
       # @!attribute [rw] default_charset

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -15,7 +15,7 @@ module Hanami
       #
       # @since 0.2.0
       # @api private
-      DEFAULT_FORMATS = {
+      DEFAULT_FORMAT_MAPPINGS = {
         "application/octet-stream" => :all,
         "*/*" => :all,
         "text/html" => :html
@@ -68,17 +68,17 @@ module Hanami
           .to_h
       end
 
-      # @!attribute [rw] formats
+      # @!attribute [rw] format_mappings
       #
-      #   Specifies the MIME type to format mapping
+      #   Specifies the MIME type to format mapping for the action.
       #
       #   @return [Hash{String=>Symbol}] MIME type strings as keys and format symbols as values
       #
-      #   @see format
+      #   @see #add_format
       #   @see Hanami::Action::Mime
       #
       #   @example
-      #     config.formats = {"text/html" => :html}
+      #     config.format_mappings = {"text/html" => :html}
       #
       #   @since 0.2.0
 
@@ -89,16 +89,16 @@ module Hanami
       #
       # @return [void]
       #
-      # @see formats
+      # @see #format_mappings
       # @see Hanami::Action::Mime
       #
       # @example
       #   config.format html: "text/html"
       #
       # @since 0.2.0
-      def format(hash)
+      def add_format(hash)
         symbol, mime_type = *Utils::Kernel.Array(hash)
-        formats[Utils::Kernel.String(mime_type)] = Utils::Kernel.Symbol(symbol)
+        format_mappings[Utils::Kernel.String(mime_type)] = Utils::Kernel.Symbol(symbol)
       end
 
       # Returns the configured format for the given MIME type
@@ -107,27 +107,27 @@ module Hanami
       #
       # @return [Symbol,nil] the corresponding format, nil if not found
       #
-      # @see format
+      # @see #add_format
       #
       # @since 0.2.0
       # @api private
       def format_for(mime_type)
-        formats[mime_type]
+        format_mappings[mime_type]
       end
 
       # Returns the configured format's MIME types
       #
       # @return [Array<String>] the format's MIME types
       #
-      # @see formats=
-      # @see format
+      # @see #format_mappings=
+      # @see #format
       #
       # @since 0.8.0
       #
       # @api private
       def mime_types
         # FIXME: this isn't efficient. speed it up!
-        ((formats.keys - DEFAULT_FORMATS.keys) +
+        ((format_mappings.keys - DEFAULT_FORMAT_MAPPINGS.keys) +
           Hanami::Action::Mime::TYPES.values).freeze
       end
 
@@ -140,7 +140,7 @@ module Hanami
       # @since 0.2.0
       # @api private
       def mime_type_for(format)
-        formats.key(format)
+        format_mappings.key(format)
       end
 
       # TODO: document

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -148,7 +148,6 @@ module Hanami
         default_format = formats.first
 
         self.accepted_formats = formats
-        self.default_request_format = default_format
         self.default_response_format = default_format
       end
 
@@ -157,23 +156,6 @@ module Hanami
       def accepted_mime_types
         accepted_formats.any? ? Mime.restrict_mime_types(self) : mime_types
       end
-
-      # @!attribute [rw] default_request_format
-      #
-      #   Sets a format as default fallback for all the requests without a strict
-      #   requirement for the MIME type.
-      #
-      #   The given format must be coercible to a symbol, and be a valid MIME
-      #   type alias. If it isn't, at runtime the framework will raise an
-      #   `Hanami::Action::UnknownFormatError`.
-      #
-      #   By default, this value is nil.
-      #
-      #   @return [Symbol]
-      #
-      #   @see Hanami::Action::Mime
-      #
-      #   @since 0.5.0
 
       # @!attribute [rw] default_response_format
       #

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -58,20 +58,6 @@ module Hanami
           .to_h
       end
 
-      # Returns the configured format for the given MIME type
-      #
-      # @param mime_type [#to_s,#to_str] A mime type
-      #
-      # @return [Symbol,nil] the corresponding format, nil if not found
-      #
-      # @see Hanami::Action::Config::Formats#add
-      #
-      # @since 0.2.0
-      # @api private
-      def format_for(mime_type)
-        formats.format_for(mime_type)
-      end
-
       # Returns the configured format's MIME types
       #
       # @return [Array<String>] the format's MIME types

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -144,7 +144,7 @@ module Hanami
       end
 
       # TODO: document
-      def use_formats(*formats)
+      def format(*formats)
         default_format = formats.first
 
         self.accepted_formats = formats

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -58,7 +58,29 @@ module Hanami
           .to_h
       end
 
-      # TODO: document
+      # @!attribute [r] formats
+      #   Returns the format config for the action.
+      #
+      #   @return [Config::Formats]
+      #
+      #   @since 2.0.0
+      #   @api public
+
+      # Sets the format (or formats) for the action.
+      #
+      # To configure custom formats and MIME type mappings, call {Formats#add formats.add} first.
+      #
+      # @example
+      #   config.format :html, :json
+      #
+      # @param formats [Array<Symbol>] the format names
+      #
+      # @return [Array<Symbol>] the given format names
+      #
+      # @see #formats
+      #
+      # @since 2.0.0
+      # @api public
       def format(*formats)
         self.formats.values = formats
       end

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -79,12 +79,6 @@ module Hanami
         formats.default
       end
 
-      # @since 2.0.0
-      # @api private
-      def accepted_mime_types
-        formats.any? ? Mime.restrict_mime_types(self) : formats.mime_types
-      end
-
       # @!attribute [rw] default_charset
       #
       #   Sets a charset (character set) as default fallback for all the requests

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -11,16 +11,6 @@ module Hanami
     # @api public
     # @since 2.0.0
     class Config < Dry::Configurable::Config
-      # Default MIME type to format mapping
-      #
-      # @since 0.2.0
-      # @api private
-      DEFAULT_FORMAT_MAPPINGS = {
-        "application/octet-stream" => :all,
-        "*/*" => :all,
-        "text/html" => :html
-      }.freeze
-
       # Default public directory
       #
       # This serves as the root directory for file downloads
@@ -68,67 +58,31 @@ module Hanami
           .to_h
       end
 
-      # @!attribute [rw] format_mappings
-      #
-      #   Specifies the MIME type to format mapping for the action.
-      #
-      #   @return [Hash{String=>Symbol}] MIME type strings as keys and format symbols as values
-      #
-      #   @see #add_format
-      #   @see Hanami::Action::Mime
-      #
-      #   @example
-      #     config.format_mappings = {"text/html" => :html}
-      #
-      #   @since 0.2.0
-
-      # Registers a MIME type to format mapping
-      #
-      # @param hash [Hash{Symbol=>String}] format symbols as keys and the MIME
-      #   type strings must as values
-      #
-      # @return [void]
-      #
-      # @see #format_mappings
-      # @see Hanami::Action::Mime
-      #
-      # @example
-      #   config.format html: "text/html"
-      #
-      # @since 0.2.0
-      def add_format(hash)
-        symbol, mime_type = *Utils::Kernel.Array(hash)
-        format_mappings[Utils::Kernel.String(mime_type)] = Utils::Kernel.Symbol(symbol)
-      end
-
       # Returns the configured format for the given MIME type
       #
       # @param mime_type [#to_s,#to_str] A mime type
       #
       # @return [Symbol,nil] the corresponding format, nil if not found
       #
-      # @see #add_format
+      # @see Hanami::Action::Config::Formats#add
       #
       # @since 0.2.0
       # @api private
       def format_for(mime_type)
-        format_mappings[mime_type]
+        formats.format_for(mime_type)
       end
 
       # Returns the configured format's MIME types
       #
       # @return [Array<String>] the format's MIME types
       #
-      # @see #format_mappings=
-      # @see #format
+      # @see Hanami::Action::Config::Formats
       #
       # @since 0.8.0
       #
       # @api private
       def mime_types
-        # FIXME: this isn't efficient. speed it up!
-        ((format_mappings.keys - DEFAULT_FORMAT_MAPPINGS.keys) +
-          Hanami::Action::Mime::TYPES.values).freeze
+        formats.mime_types
       end
 
       # Returns a MIME type for the given format
@@ -140,16 +94,16 @@ module Hanami
       # @since 0.2.0
       # @api private
       def mime_type_for(format)
-        format_mappings.key(format)
+        formats.mime_type_for(format)
       end
 
       # TODO: document
       def format(*formats)
-        self.formats = formats
+        self.formats.values = formats
       end
 
       def default_format
-        formats.first
+        formats.default
       end
 
       # @since 2.0.0

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -146,9 +146,6 @@ module Hanami
       # TODO: document
       def format(*formats)
         self.formats = formats
-
-        # TODO: update this
-        self.accepted_formats = formats
       end
 
       def default_format
@@ -158,7 +155,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def accepted_mime_types
-        accepted_formats.any? ? Mime.restrict_mime_types(self) : mime_types
+        formats.any? ? Mime.restrict_mime_types(self) : mime_types
       end
 
       # @!attribute [rw] default_charset

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -58,18 +58,6 @@ module Hanami
           .to_h
       end
 
-      # Returns a MIME type for the given format
-      #
-      # @param format [#to_sym] a format
-      #
-      # @return [String,nil] the corresponding MIME type, if present
-      #
-      # @since 0.2.0
-      # @api private
-      def mime_type_for(format)
-        formats.mime_type_for(format)
-      end
-
       # TODO: document
       def format(*formats)
         self.formats.values = formats

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -15,7 +15,11 @@ module Hanami
 
         # @since 2.0.0
         # @api private
-        attr_reader :values, :mapping
+        attr_reader :mapping
+
+        # @since 2.0.0
+        # @api private
+        attr_accessor :values
 
         # @since 2.0.0
         # @api private
@@ -40,12 +44,6 @@ module Hanami
           mappings.each do |symbol, mime_type|
             add(symbol => mime_type)
           end
-        end
-
-        # @since 2.0.0
-        # @api private
-        def values=(*formats)
-          @values = Utils::Kernel.Array(formats)
         end
 
         # Add a custom format

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -114,27 +114,6 @@ module Hanami
           @mapping.key(format)
         end
 
-        # Retrieve the supported MIME Types
-        #
-        # @return [Array<String>] the supported MIME Types
-        #
-        # @example
-        #   @config.formats.mime_types # => ["text/html", "application/json"]
-        #
-        # @since 2.0.0
-        # @api public
-        def mime_types
-          # FIXME: this isn't efficient. speed it up!
-          ((@mapping.keys - DEFAULT_MAPPING.keys) +
-            Hanami::Action::Mime::TYPES.values).freeze
-        end
-
-        # @since 2.0.0
-        # @api private
-        def accepted_mime_types
-          any? ? Mime.restrict_mime_types(self) : mime_types
-        end
-
         # Returns the default format name
         #
         # @return [Symbol,NilClass] the default format name, if any

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -5,6 +5,10 @@ require "hanami/utils/kernel"
 module Hanami
   class Action
     class Config
+      # Action format configuration.
+      #
+      # @since 2.0.0
+      # @api private
       class Formats
         # Default MIME type to format mapping
         #
@@ -124,10 +128,10 @@ module Hanami
         # @example
         #   @config.formats.format_for("application/json") # => :json
         #
+        # @see #mime_type_for
+        #
         # @since 2.0.0
         # @api public
-        #
-        # @see #mime_type_for
         def format_for(mime_type)
           @mapping[mime_type]
         end
@@ -136,22 +140,22 @@ module Hanami
         #
         # @param format [Symbol] the format name
         #
-        # @return [String,NilClass] the associated MIME Type, if any
+        # @return [String, nil] the associated MIME Type, if any
         #
         # @example
         #   @config.formats.mime_type_for(:json) # => "application/json"
         #
+        # @see #format_for
+        #
         # @since 2.0.0
         # @api public
-        #
-        # @see #format_for
         def mime_type_for(format)
           @mapping.key(format)
         end
 
         # Returns the default format name
         #
-        # @return [Symbol,NilClass] the default format name, if any
+        # @return [Symbol, nil] the default format name, if any
         #
         # @example
         #   @config.formats.default # => :json

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -47,8 +47,10 @@ module Hanami
         def mapping=(mappings)
           @mapping = {}
 
-          mappings.each do |format_name, mime_type|
-            add(format_name, mime_type)
+          mappings.each do |format_name, mime_types|
+            Array(mime_types).each do |mime_type|
+              add(format_name, mime_type)
+            end
           end
         end
 
@@ -136,11 +138,11 @@ module Hanami
           @mapping[mime_type]
         end
 
-        # Retrieve the MIME Type associated with the given format name
+        # Returns the primary MIME type associated with the given format.
         #
         # @param format [Symbol] the format name
         #
-        # @return [String, nil] the associated MIME Type, if any
+        # @return [String, nil] the associated MIME type, if any
         #
         # @example
         #   @config.formats.mime_type_for(:json) # => "application/json"
@@ -151,6 +153,20 @@ module Hanami
         # @api public
         def mime_type_for(format)
           @mapping.key(format)
+        end
+
+        # Returns an array of all MIME types associated with the given format.
+        #
+        # Returns an empty array if no such format is configured.
+        #
+        # @param format [Symbol] the format name
+        #
+        # @return [Array<String>] the associated MIME types
+        #
+        # @since 2.0.0
+        # @api public
+        def mime_types_for(format)
+          @mapping.each_with_object([]) { |(mime_type, f), arr| arr << mime_type if format == f }
         end
 
         # Returns the default format name

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -48,22 +48,37 @@ module Hanami
           end
         end
 
-        # Add a custom format to MIME type mapping and enables the format
+        # Add a custom format to MIME type mapping and enables the format.
         #
-        # @param format [Symbol]
-        # @param mime_type [String]
+        # @overload add(format, mime_type)
+        #   Adds a format mapping to a single MIME type.
         #
-        # @example
-        #   config.formats.add(:json, "application/scim+json")
+        #   @param format [Symbol]
+        #   @param mime_type [String]
+        #
+        #   @example
+        #     config.formats.add(:json, "application/json")
+        #
+        # @overload add(format, mime_types)
+        #   Adds a format mapping to multiple MIME types.
+        #
+        #   @param format [Symbol]
+        #   @param mime_types [Array<String>]
+        #
+        #   @example
+        #     config.formats.add(:json, ["application/json+scim", "application/json"])
         #
         # @return [self]
         #
         # @since 2.0.0
         # @api public
-        def add(format, mime_type)
+        def add(format, mime_types)
           format = Utils::Kernel.Symbol(format)
 
-          @mapping[Utils::Kernel.String(mime_type)] = format
+          Array(mime_types).each do |mime_type|
+            @mapping[Utils::Kernel.String(mime_type)] = format
+          end
+
           @values << format unless @values.include?(format)
 
           self

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -27,7 +27,7 @@ module Hanami
 
         # @since 2.0.0
         # @api private
-        def initialize_copy(original)
+        private def initialize_copy(original) # rubocop:disable Style/AccessModifierDeclarations
           super
           @values = original.values.dup
           @mapping = original.mapping.dup

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -10,8 +10,7 @@ module Hanami
         # @api private
         DEFAULT_MAPPING = {
           "application/octet-stream" => :all,
-          "*/*" => :all,
-          "text/html" => :html
+          "*/*" => :all
         }.freeze
 
         # @since 2.0.0

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    class Config
+      class Formats
+        # Default MIME type to format mapping
+        #
+        # @since 2.0.0
+        # @api private
+        DEFAULT_MAPPING = {
+          "application/octet-stream" => :all,
+          "*/*" => :all,
+          "text/html" => :html
+        }.freeze
+
+        # @since 2.0.0
+        # @api private
+        attr_reader :values, :mapping
+
+        # @since 2.0.0
+        # @api private
+        def initialize(values: [], mapping: DEFAULT_MAPPING.dup)
+          @values = values
+          @mapping = mapping
+        end
+
+        # @since 2.0.0
+        # @api private
+        def initialize_copy(original)
+          super
+          @values = original.values.dup
+          @mapping = original.mapping.dup
+        end
+
+        # @since 2.0.0
+        # @api private
+        def mapping=(mappings)
+          @mapping = {}
+
+          mappings.each do |symbol, mime_type|
+            add(symbol => mime_type)
+          end
+        end
+
+        # @since 2.0.0
+        # @api private
+        def values=(*formats)
+          @values = Utils::Kernel.Array(formats)
+        end
+
+        # @since 2.0.0
+        # @api private
+        def empty?
+          @values.empty?
+        end
+
+        # @since 2.0.0
+        # @api private
+        def any?
+          @values.any?
+        end
+
+        # @since 2.0.0
+        # @api private
+        def map(&blk)
+          @values.map(&blk)
+        end
+
+        # Add a custom format
+        #
+        # @param mapping [Hash]
+        #
+        # @example
+        #   config.formats.add(json: "application/scim+json")
+        #
+        # @since 2.0.0
+        # @api public
+        def add(mapping)
+          symbol, mime_type = *Utils::Kernel.Array(mapping)
+          @mapping[Utils::Kernel.String(mime_type)] = Utils::Kernel.Symbol(symbol)
+        end
+
+        # Retrieve the format name associated with the given MIME Type
+        #
+        # @param mime_type [String] the MIME Type
+        #
+        # @return [Symbol,NilClass] the associated format name, if any
+        #
+        # @example
+        #   @config.formats.format_for("application/json") # => :json
+        #
+        # @since 2.0.0
+        # @api public
+        #
+        # @see #mime_type_for
+        def format_for(mime_type)
+          @mapping[mime_type]
+        end
+
+        # Retrieve the MIME Type associated with the given format name
+        #
+        # @param format [Symbol] the format name
+        #
+        # @return [String,NilClass] the associated MIME Type, if any
+        #
+        # @example
+        #   @config.formats.mime_type_for(:json) # => "application/json"
+        #
+        # @since 2.0.0
+        # @api public
+        #
+        # @see #format_for
+        def mime_type_for(format)
+          @mapping.key(format)
+        end
+
+        # Retrieve the supported MIME Types
+        #
+        # @return [Array<String>] the supported MIME Types
+        #
+        # @example
+        #   @config.formats.mime_types # => ["text/html", "application/json"]
+        #
+        # @since 2.0.0
+        # @api public
+        def mime_types
+          # FIXME: this isn't efficient. speed it up!
+          ((@mapping.keys - DEFAULT_MAPPING.keys) +
+            Hanami::Action::Mime::TYPES.values).freeze
+        end
+
+        # Returns the default format name
+        #
+        # @return [Symbol,NilClass] the default format name, if any
+        #
+        # @example
+        #   @config.formats.default # => :json
+        #
+        # @since 2.0.0
+        # @api public
+        def default
+          @values.first
+        end
+
+        # @since 2.0.0
+        # @api private
+        def keys
+          @mapping.keys
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -45,18 +45,6 @@ module Hanami
           @mapping = original.mapping.dup
         end
 
-        # @since 2.0.0
-        # @api private
-        def mapping=(mappings)
-          @mapping = {}
-
-          mappings.each do |format_name, mime_types|
-            Array(mime_types).each do |mime_type|
-              add(format_name, mime_type)
-            end
-          end
-        end
-
         # Add a custom format to MIME type mapping and enables the format.
         #
         # @overload add(format, mime_type)
@@ -109,6 +97,18 @@ module Hanami
         # @api private
         def map(&blk)
           @values.map(&blk)
+        end
+
+        # @since 2.0.0
+        # @api private
+        def mapping=(mappings)
+          @mapping = {}
+
+          mappings.each do |format_name, mime_types|
+            Array(mime_types).each do |mime_type|
+              add(format_name, mime_type)
+            end
+          end
         end
 
         # Clears any previously added mappings and format values.

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hanami/utils/kernel"
+
 module Hanami
   class Action
     class Config
@@ -41,23 +43,30 @@ module Hanami
         def mapping=(mappings)
           @mapping = {}
 
-          mappings.each do |symbol, mime_type|
-            add(symbol => mime_type)
+          mappings.each do |format_name, mime_type|
+            add(format_name, mime_type)
           end
         end
 
-        # Add a custom format
+        # Add a custom format to MIME type mapping and enables the format
         #
-        # @param mapping [Hash]
+        # @param format [Symbol]
+        # @param mime_type [String]
         #
         # @example
-        #   config.formats.add(json: "application/scim+json")
+        #   config.formats.add(:json, "application/scim+json")
+        #
+        # @return [self]
         #
         # @since 2.0.0
         # @api public
-        def add(mapping)
-          symbol, mime_type = *Utils::Kernel.Array(mapping)
-          @mapping[Utils::Kernel.String(mime_type)] = Utils::Kernel.Symbol(symbol)
+        def add(format, mime_type)
+          format = Utils::Kernel.Symbol(format)
+
+          @mapping[Utils::Kernel.String(mime_type)] = format
+          @values << format unless @values.include?(format)
+
+          self
         end
 
         # @since 2.0.0

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -48,6 +48,20 @@ module Hanami
           @values = Utils::Kernel.Array(formats)
         end
 
+        # Add a custom format
+        #
+        # @param mapping [Hash]
+        #
+        # @example
+        #   config.formats.add(json: "application/scim+json")
+        #
+        # @since 2.0.0
+        # @api public
+        def add(mapping)
+          symbol, mime_type = *Utils::Kernel.Array(mapping)
+          @mapping[Utils::Kernel.String(mime_type)] = Utils::Kernel.Symbol(symbol)
+        end
+
         # @since 2.0.0
         # @api private
         def empty?
@@ -64,20 +78,6 @@ module Hanami
         # @api private
         def map(&blk)
           @values.map(&blk)
-        end
-
-        # Add a custom format
-        #
-        # @param mapping [Hash]
-        #
-        # @example
-        #   config.formats.add(json: "application/scim+json")
-        #
-        # @since 2.0.0
-        # @api public
-        def add(mapping)
-          symbol, mime_type = *Utils::Kernel.Array(mapping)
-          @mapping[Utils::Kernel.String(mime_type)] = Utils::Kernel.Symbol(symbol)
         end
 
         # Retrieve the format name associated with the given MIME Type

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "hanami/utils/kernel"
+require "dry/core"
 
 module Hanami
   class Action
@@ -10,6 +11,8 @@ module Hanami
       # @since 2.0.0
       # @api private
       class Formats
+        include Dry.Equalizer(:values, :mapping)
+
         # Default MIME type to format mapping
         #
         # @since 2.0.0

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -78,6 +78,19 @@ module Hanami
           @values.map(&blk)
         end
 
+        # Clears any previously added mappings and format values.
+        #
+        # @return [self]
+        #
+        # @since 2.0.0
+        # @api public
+        def clear
+          @mapping = DEFAULT_MAPPING.dup
+          @values = []
+
+          self
+        end
+
         # Retrieve the format name associated with the given MIME Type
         #
         # @param mime_type [String] the MIME Type

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -130,6 +130,12 @@ module Hanami
             Hanami::Action::Mime::TYPES.values).freeze
         end
 
+        # @since 2.0.0
+        # @api private
+        def accepted_mime_types
+          any? ? Mime.restrict_mime_types(self) : mime_types
+        end
+
         # Returns the default format name
         #
         # @return [Symbol,NilClass] the default format name, if any

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -45,9 +45,16 @@ module Hanami
           @mapping = original.mapping.dup
         end
 
-        # Add a custom format to MIME type mapping and enables the format.
+        # @overload add(format)
+        #   Adds and enables a format.
+        #
+        #   @param format [Symbol]
+        #
+        #   @example
+        #     config.formats.add(:json)
         #
         # @overload add(format, mime_type)
+        #   Adds a custom format to MIME type mapping and enables the format.
         #   Adds a format mapping to a single MIME type.
         #
         #   @param format [Symbol]
@@ -69,7 +76,7 @@ module Hanami
         #
         # @since 2.0.0
         # @api public
-        def add(format, mime_types)
+        def add(format, mime_types = [])
           format = Utils::Kernel.Symbol(format)
 
           Array(mime_types).each do |mime_type|

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -26,9 +26,15 @@ module Hanami
         # @api private
         attr_reader :mapping
 
+        # The array of enabled formats.
+        #
+        # @example
+        #   config.formats.values = [:html, :json]
+        #   config.formats.values # => [:html, :json]
+        #
         # @since 2.0.0
-        # @api private
-        attr_accessor :values
+        # @api public
+        attr_reader :values
 
         # @since 2.0.0
         # @api private
@@ -43,6 +49,13 @@ module Hanami
           super
           @values = original.values.dup
           @mapping = original.mapping.dup
+        end
+
+        # !@attribute [w] values
+        #   @since 2.0.0
+        #   @api public
+        def values=(formats)
+          @values = formats.map { |f| Utils::Kernel.Symbol(f) }
         end
 
         # @overload add(format)

--- a/lib/hanami/action/errors.rb
+++ b/lib/hanami/action/errors.rb
@@ -21,7 +21,14 @@ module Hanami
       # @since 2.0.0
       # @api private
       def initialize(format)
-        super("Cannot find a corresponding Mime type for '#{format}'. Please configure it with Hanami::Controller::Configuration#format.") # rubocop:disable Layout/LineLength
+        msg =
+          if format.to_s != "" # rubocop:disable Style/NegatedIfElseCondition
+            "Cannot find a corresponding MIME type for format #{format.inspect}. Configure one via `config.formats.add(#{format}: \"MIME_TYPE_HERE\")`." # rubocop:disable Layout/LineLength
+          else
+            "Cannot find a corresponding MIME type for `nil` format."
+          end
+
+        super(msg)
       end
     end
 

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -103,15 +103,16 @@ module Hanami
       # @since 2.0.0
       # @api private
       def self.default_response_type(config)
-        format_to_mime_type(config.default_format, config)
+        # FIXME: I don't think we have test coverage of this code path
+        format_to_mime_type(config.default_format, config.formats)
       end
 
       # @since 2.0.0
       # @api private
-      def self.format_to_mime_type(format, config)
+      def self.format_to_mime_type(format, formats_config)
         return if format.nil?
 
-        config.mime_type_for(format) ||
+        formats_config.mime_type_for(format) ||
           TYPES.fetch(format) { raise Hanami::Action::UnknownFormatError.new(format) }
       end
 
@@ -144,7 +145,8 @@ module Hanami
       def self.detect_format_and_content_type(value, config)
         case value
         when Symbol
-          [value, format_to_mime_type(value, config)]
+          # FIXME: I don't think we have test coverage of this code path
+          [value, format_to_mime_type(value, config.formats)]
         when String
           [detect_format(value, config), value]
         else
@@ -154,7 +156,7 @@ module Hanami
 
       # Transforms symbols to MIME Types
       # @example
-      #   restrict_mime_types(config, [:json])  #=> ["application/json"]
+      #   restrict_mime_types(config.formats, [:json])  #=> ["application/json"]
       #
       # @return [Array<String>, nil]
       #
@@ -162,14 +164,14 @@ module Hanami
       #
       # @since 2.0.0
       # @api private
-      def self.restrict_mime_types(config)
-        return if config.formats.empty?
+      def self.restrict_mime_types(formats_config)
+        return if formats_config.empty?
 
-        mime_types = config.formats.map do |format|
-          format_to_mime_type(format, config)
+        mime_types = formats_config.map do |format|
+          format_to_mime_type(format, formats_config)
         end
 
-        accepted_mime_types = mime_types & config.formats.mime_types
+        accepted_mime_types = mime_types & formats_config.mime_types
 
         return if accepted_mime_types.empty?
 
@@ -222,7 +224,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def self.accepted_mime_type?(mime_type, config)
-        config.accepted_mime_types.any? { |accepted_mime_type|
+        config.formats.accepted_mime_types.any? { |accepted_mime_type|
           ::Rack::Mime.match?(accepted_mime_type, mime_type)
         }
       end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -130,7 +130,7 @@ module Hanami
         return if content_type.nil?
 
         ct = content_type.split(";").first
-        config.format_for(ct) || format_for(ct)
+        config.formats.format_for(ct) || format_for(ct)
       end
 
       # @since 2.0.0

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -169,7 +169,7 @@ module Hanami
           format_to_mime_type(format, config)
         end
 
-        accepted_mime_types = mime_types & config.mime_types
+        accepted_mime_types = mime_types & config.formats.mime_types
 
         return if accepted_mime_types.empty?
 

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -163,9 +163,9 @@ module Hanami
       # @since 2.0.0
       # @api private
       def self.restrict_mime_types(config)
-        return if config.accepted_formats.empty?
+        return if config.formats.empty?
 
-        mime_types = config.accepted_formats.map do |format|
+        mime_types = config.formats.map do |format|
           format_to_mime_type(format, config)
         end
 
@@ -176,16 +176,15 @@ module Hanami
         accepted_mime_types
       end
 
-      # Yields if an action is configured with `accepted_formats`, the request has an `Accept`
-      # header, and none of the Accept types matches the accepted formats. The given block is
-      # expected to halt the request handling.
+      # Yields if an action is configured with `formats`, the request has an `Accept` header, an
+      # none of the Accept types matches the accepted formats. The given block is expected to halt
+      # the request handling.
       #
       # If any of these conditions are not met, then the request is acceptable and the method
       # returns without yielding.
       #
       # @see Action#enforce_accepted_mime_types
-      # @see Action.accept
-      # @see Config#accepted_formats
+      # @see Config#formats
       #
       # @since 2.0.0
       # @api private
@@ -198,16 +197,15 @@ module Hanami
         yield
       end
 
-      # Yields if an action is configured with `accepted_formats`, the request has a `Content-Type`
-      # header (or a `default_requst_format` is configured), and the content type does not match the
+      # Yields if an action is configured with `formats`, the request has a `Content-Type` header
+      # (or a `default_requst_format` is configured), and the content type does not match the
       # accepted formats. The given block is expected to halt the request handling.
       #
       # If any of these conditions are not met, then the request is acceptable and the method
       # returns without yielding.
       #
       # @see Action#enforce_accepted_mime_types
-      # @see Action.accept
-      # @see Config#accepted_formats
+      # @see Config#formats
       #
       # @since 2.0.0
       # @api private

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -91,7 +91,7 @@ module Hanami
           return type if type
         end
 
-        default_response_type(config) || default_content_type(config) || Action::DEFAULT_CONTENT_TYPE
+        default_response_type(config) || Action::DEFAULT_CONTENT_TYPE
       end
 
       # @since 2.0.0
@@ -104,12 +104,6 @@ module Hanami
       # @api private
       def self.default_response_type(config)
         format_to_mime_type(config.default_response_format, config)
-      end
-
-      # @since 2.0.0
-      # @api private
-      def self.default_content_type(config)
-        format_to_mime_type(config.default_request_format, config)
       end
 
       # @since 2.0.0
@@ -218,7 +212,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def self.enforce_content_type(request, config)
-        content_type = request.content_type || default_content_type(config)
+        content_type = request.content_type
 
         return if content_type.nil?
 

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -235,10 +235,10 @@ module Hanami
       #
       # @since 2.0.0
       # @api private
-      def self.calculate_content_type_with_charset(config, request, accepted_mime_types)
-        charset = self.charset(config.default_charset)
-        content_type = self.content_type(config, request, accepted_mime_types)
-        content_type_with_charset(content_type, charset)
+      def self.response_content_type_with_charset(request, config)
+        content_type = self.content_type(config, request, config.formats.accepted_mime_types)
+
+        content_type_with_charset(content_type, charset(config.default_charset))
       end
 
       # Patched version of <tt>Rack::Utils.best_q_match</tt>.

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -68,6 +68,8 @@ module Hanami
         zip: "application/zip"
       }.freeze
 
+      ANY_TYPE = "*/*"
+
       class << self
         # Returns a format name for the given content type.
         #
@@ -242,7 +244,7 @@ module Hanami
         # @since 2.0.0
         # @api private
         def accepted_mime_types(config)
-          return ["*/*"] if config.formats.empty?
+          return [ANY_TYPE] if config.formats.empty?
 
           config.formats.map { |format| format_to_mime_types(format, config) }.flatten(1)
         end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -104,7 +104,7 @@ module Hanami
       # @api private
       def self.default_response_type(config)
         # FIXME: I don't think we have test coverage of this code path
-        format_to_mime_type(config.default_format, config.formats)
+        format_to_mime_type(config.formats.default, config.formats)
       end
 
       # @since 2.0.0

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -103,7 +103,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def self.default_response_type(config)
-        format_to_mime_type(config.default_response_format, config)
+        format_to_mime_type(config.default_format, config)
       end
 
       # @since 2.0.0

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -68,254 +68,207 @@ module Hanami
         zip: "application/zip"
       }.freeze
 
-      # @since 2.0.0
-      # @api private
-      def self.content_type_with_charset(content_type, charset)
-        "#{content_type}; charset=#{charset}"
-      end
-
-      # Use for setting Content-Type
-      # If the request has the ACCEPT header it will try to return the best Content-Type based
-      # on the content of the ACCEPT header taking in consideration the weights
-      #
-      # If no ACCEPT header it will check the default response_format, then the default request format and
-      # lastly it will fallback to DEFAULT_CONTENT_TYPE
-      #
-      # @return [String]
-      #
-      # @since 2.0.0
-      # @api private
-      def self.content_type(config, request, accepted_mime_types)
-        if request.accept_header?
-          type = best_q_match(request.accept, accepted_mime_types)
-          return type if type
-        end
-
-        default_response_type(config) || Action::DEFAULT_CONTENT_TYPE
-      end
-
-      # @since 2.0.0
-      # @api private
-      def self.charset(default_charset)
-        default_charset || Action::DEFAULT_CHARSET
-      end
-
-      # @since 2.0.0
-      # @api private
-      def self.default_response_type(config)
-        # FIXME: I don't think we have test coverage of this code path
-        format_to_mime_type(config.formats.default, config.formats)
-      end
-
-      # @since 2.0.0
-      # @api private
-      def self.format_to_mime_type(format, formats_config)
-        return if format.nil?
-
-        formats_config.mime_type_for(format) ||
-          TYPES.fetch(format) { raise Hanami::Action::UnknownFormatError.new(format) }
-      end
-
-      # Transforms MIME Types to symbol
-      # Used for setting the format of the response
-      #
-      # @see Hanami::Action::Mime#finish
-      # @example
-      #   detect_format("text/html; charset=utf-8", config)  #=> :html
-      #
-      # @return [Symbol, nil]
-      #
-      # @since 2.0.0
-      # @api private
-      def self.detect_format(content_type, config)
-        return if content_type.nil?
-
-        ct = content_type.split(";").first
-        config.formats.format_for(ct) || format_for(ct)
-      end
-
-      # @since 2.0.0
-      # @api private
-      def self.format_for(content_type)
-        TYPES.key(content_type)
-      end
-
-      # @since 2.0.0
-      # @api private
-      def self.detect_format_and_content_type(value, config)
-        case value
-        when Symbol
-          # FIXME: I don't think we have test coverage of this code path
-          [value, format_to_mime_type(value, config.formats)]
-        when String
-          [detect_format(value, config), value]
-        else
-          raise UnknownFormatError.new(value)
-        end
-      end
-
-      # Transforms symbols to MIME Types
-      # @example
-      #   restrict_mime_types(config.formats, [:json])  #=> ["application/json"]
-      #
-      # @return [Array<String>, nil]
-      #
-      # @raise [Hanami::Action::UnknownFormatError] if the format is invalid
-      #
-      # @since 2.0.0
-      # @api private
-      def self.restrict_mime_types(formats_config)
-        return if formats_config.empty?
-
-        mime_types = formats_config.map do |format|
-          format_to_mime_type(format, formats_config)
-        end
-
-        accepted_mime_types = mime_types & formats_config.mime_types
-
-        return if accepted_mime_types.empty?
-
-        accepted_mime_types
-      end
-
-      # Yields if an action is configured with `formats`, the request has an `Accept` header, an
-      # none of the Accept types matches the accepted formats. The given block is expected to halt
-      # the request handling.
-      #
-      # If any of these conditions are not met, then the request is acceptable and the method
-      # returns without yielding.
-      #
-      # @see Action#enforce_accepted_mime_types
-      # @see Config#formats
-      #
-      # @since 2.0.0
-      # @api private
-      def self.enforce_accept(request, config)
-        return unless request.accept_header?
-
-        accept_types = ::Rack::Utils.q_values(request.accept).map(&:first)
-        return if accept_types.any? { |mime_type| accepted_mime_type?(mime_type, config) }
-
-        yield
-      end
-
-      # Yields if an action is configured with `formats`, the request has a `Content-Type` header
-      # (or a `default_requst_format` is configured), and the content type does not match the
-      # accepted formats. The given block is expected to halt the request handling.
-      #
-      # If any of these conditions are not met, then the request is acceptable and the method
-      # returns without yielding.
-      #
-      # @see Action#enforce_accepted_mime_types
-      # @see Config#formats
-      #
-      # @since 2.0.0
-      # @api private
-      def self.enforce_content_type(request, config)
-        content_type = request.content_type
-
-        return if content_type.nil?
-
-        return if accepted_mime_type?(content_type, config)
-
-        yield
-      end
-
-      # @since 2.0.0
-      # @api private
-      def self.accepted_mime_type?(mime_type, config)
-        config.formats.accepted_mime_types.any? { |accepted_mime_type|
-          ::Rack::Mime.match?(accepted_mime_type, mime_type)
-        }
-      end
-
-      # Use for setting the content_type and charset if the response
-      #
-      # @return [String]
-      #
-      # @since 2.0.0
-      # @api private
-      def self.response_content_type_with_charset(request, config)
-        content_type = self.content_type(config, request, config.formats.accepted_mime_types)
-
-        content_type_with_charset(content_type, charset(config.default_charset))
-      end
-
-      # Patched version of <tt>Rack::Utils.best_q_match</tt>.
-      #
-      # @since 2.0.0
-      # @api private
-      #
-      # @see http://www.rubydoc.info/gems/rack/Rack/Utils#best_q_match-class_method
-      # @see https://github.com/rack/rack/pull/659
-      # @see https://github.com/hanami/controller/issues/59
-      # @see https://github.com/hanami/controller/issues/104
-      # @see https://github.com/hanami/controller/issues/275
-      def self.best_q_match(q_value_header, available_mimes = TYPES.values)
-        ::Rack::Utils.q_values(q_value_header).each_with_index.map do |(req_mime, quality), index|
-          match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
-          next unless match
-
-          RequestMimeWeight.new(req_mime, quality, index, match)
-        end.compact.max&.format
-      end
-
-      # @since 1.0.1
-      # @api private
-      class RequestMimeWeight
+      class << self
+        # Returns a format name for the given content type.
+        #
+        # The format name will come from the configured formats, if such a format is configured
+        # there, or instead from the default list of formats in `Mime::TYPES`.
+        #
+        # Returns nil if no matching format can be found.
+        #
+        # This is used to return the format name a {Response}.
+        #
+        # @example
+        #   detect_format("application/jsonl charset=utf-8", config) # => :json
+        #
+        # @return [Symbol, nil]
+        #
+        # @see Response#format
+        # @see Action#finish
+        #
         # @since 2.0.0
         # @api private
-        MIME_SEPARATOR = "/"
-        private_constant :MIME_SEPARATOR
+        def detect_format(content_type, config)
+          return if content_type.nil?
 
-        # @since 2.0.0
-        # @api private
-        MIME_WILDCARD = "*"
-        private_constant :MIME_WILDCARD
-
-        include Comparable
-
-        # @since 1.0.1
-        # @api private
-        attr_reader :quality
-
-        # @since 1.0.1
-        # @api private
-        attr_reader :index
-
-        # @since 1.0.1
-        # @api private
-        attr_reader :mime
-
-        # @since 1.0.1
-        # @api private
-        attr_reader :format
-
-        # @since 1.0.1
-        # @api private
-        attr_reader :priority
-
-        # @since 1.0.1
-        # @api private
-        def initialize(mime, quality, index, format = mime)
-          @quality, @index, @format = quality, index, format
-          calculate_priority(mime)
+          ct = content_type.split(";").first
+          config.formats.format_for(ct) || TYPES.key(ct)
         end
 
-        # @since 1.0.1
+        # Returns a format name and content type pair for a given format name or content type
+        # string.
+        #
+        # @example
+        #   detect_format_and_content_type(:json, config)
+        #   # => [:json, "application/json"]
+        #
+        #   detect_format_and_content_type("application/json", config)
+        #   # => [:json, "application/json"]
+        #
+        # @example Unknown format name
+        #   detect_format_and_content_type(:unknown, config)
+        #   # raises Hanami::Action::UnknownFormatError
+        #
+        # @example Unknown content type
+        #   detect_format_and_content_type("application/unknown", config)
+        #   # => [nil, "application/unknown"]
+        #
+        # @return [Array<(Symbol, String)>]
+        #
+        # @raise [Hanami::Action::UnknownFormatError] if an unknown format name is given
+        #
+        # @since 2.0.0
         # @api private
-        def <=>(other)
-          return priority <=> other.priority unless priority == other.priority
+        def detect_format_and_content_type(value, config)
+          case value
+          when Symbol
+            [value, format_to_mime_type(value, config)]
+          when String
+            [detect_format(value, config), value]
+          else
+            raise UnknownFormatError.new(value)
+          end
+        end
 
-          other.index <=> index
+        # Returns a string combining the given content type and charset, intended for setting as a
+        # `Content-Type` header.
+        #
+        # @example
+        #   Mime.content_type_with_charset("application/json", "utf-8")
+        #   # => "application/json; charset=utf-8"
+        #
+        # @param content_type [String]
+        # @param charset [String]
+        #
+        # @return [String]
+        #
+        # @since 2.0.0
+        # @api private
+        def content_type_with_charset(content_type, charset)
+          "#{content_type}; charset=#{charset}"
+        end
+
+        # Returns a string combining a MIME type and charset, intended for setting as the
+        # `Content-Type` header for the response to the given request.
+        #
+        # This uses the request's `Accept` header (if present) along with the configured formats to
+        # determine the best content type to return.
+        #
+        # @return [String]
+        #
+        # @see Action#call
+        #
+        # @since 2.0.0
+        # @api private
+        def response_content_type_with_charset(request, config)
+          content_type_with_charset(
+            response_content_type(request, config),
+            config.default_charset || Action::DEFAULT_CHARSET
+          )
+        end
+
+        # Patched version of <tt>Rack::Utils.best_q_match</tt>.
+        #
+        # @since 2.0.0
+        # @api private
+        #
+        # @see http://www.rubydoc.info/gems/rack/Rack/Utils#best_q_match-class_method
+        # @see https://github.com/rack/rack/pull/659
+        # @see https://github.com/hanami/controller/issues/59
+        # @see https://github.com/hanami/controller/issues/104
+        # @see https://github.com/hanami/controller/issues/275
+        def best_q_match(q_value_header, available_mimes = TYPES.values)
+          ::Rack::Utils.q_values(q_value_header).each_with_index.map { |(req_mime, quality), index|
+            match = available_mimes.find { |am| ::Rack::Mime.match?(am, req_mime) }
+            next unless match
+
+            RequestMimeWeight.new(req_mime, quality, index, match)
+          }.compact.max&.format
+        end
+
+        # Yields if an action is configured with `formats`, the request has an `Accept` header, an
+        # none of the Accept types matches the accepted formats. The given block is expected to halt
+        # the request handling.
+        #
+        # If any of these conditions are not met, then the request is acceptable and the method
+        # returns without yielding.
+        #
+        # @see Action#enforce_accepted_mime_types
+        # @see Config#formats
+        #
+        # @since 2.0.0
+        # @api private
+        def enforce_accept(request, config)
+          return unless request.accept_header?
+
+          accept_types = ::Rack::Utils.q_values(request.accept).map(&:first)
+          return if accept_types.any? { |mime_type| accepted_mime_type?(mime_type, config) }
+
+          yield
+        end
+
+        # Yields if an action is configured with `formats`, the request has a `Content-Type` header
+        # (or a `default_requst_format` is configured), and the content type does not match the
+        # accepted formats. The given block is expected to halt the request handling.
+        #
+        # If any of these conditions are not met, then the request is acceptable and the method
+        # returns without yielding.
+        #
+        # @see Action#enforce_accepted_mime_types
+        # @see Config#formats
+        #
+        # @since 2.0.0
+        # @api private
+        def enforce_content_type(request, config)
+          content_type = request.content_type
+
+          return if content_type.nil?
+
+          return if accepted_mime_type?(content_type, config)
+
+          yield
         end
 
         private
 
-        # @since 1.0.1
+        # @since 2.0.0
         # @api private
-        def calculate_priority(mime)
-          @priority ||= (mime.split(MIME_SEPARATOR, 2).count(MIME_WILDCARD) * -10) + quality
+        def accepted_mime_type?(mime_type, config)
+          accepted_mime_types(config).any? { |accepted_mime_type|
+            ::Rack::Mime.match?(accepted_mime_type, mime_type)
+          }
+        end
+
+        # @since 2.0.0
+        # @api private
+        def accepted_mime_types(config)
+          return ["*/*"] if config.formats.empty?
+
+          config.formats.map { |format| format_to_mime_type(format, config) }
+        end
+
+        # @since 2.0.0
+        # @api private
+        def response_content_type(request, config)
+          if request.accept_header?
+            all_mime_types = TYPES.values + config.formats.mapping.keys
+            content_type = best_q_match(request.accept, all_mime_types)
+
+            return content_type if content_type
+          end
+
+          if config.formats.default
+            return format_to_mime_type(config.formats.default, config)
+          end
+
+          Action::DEFAULT_CONTENT_TYPE
+        end
+
+        # @since 2.0.0
+        # @api private
+        def format_to_mime_type(format, config)
+          config.formats.mime_type_for(format) ||
+            TYPES.fetch(format) { raise Hanami::Action::UnknownFormatError.new(format) }
         end
       end
     end

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -244,7 +244,7 @@ module Hanami
         def accepted_mime_types(config)
           return ["*/*"] if config.formats.empty?
 
-          config.formats.map { |format| format_to_mime_type(format, config) }
+          config.formats.map { |format| format_to_mime_types(format, config) }.flatten(1)
         end
 
         # @since 2.0.0
@@ -269,6 +269,14 @@ module Hanami
         def format_to_mime_type(format, config)
           config.formats.mime_type_for(format) ||
             TYPES.fetch(format) { raise Hanami::Action::UnknownFormatError.new(format) }
+        end
+
+        # @since 2.0.0
+        # @api private
+        def format_to_mime_types(format, config)
+          config.formats.mime_types_for(format).tap { |types|
+            types << TYPES[format] if TYPES.key?(format)
+          }
         end
       end
     end

--- a/lib/hanami/action/mime/request_mime_weight.rb
+++ b/lib/hanami/action/mime/request_mime_weight.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    module Mime
+      # @since 1.0.1
+      # @api private
+      class RequestMimeWeight
+        # @since 2.0.0
+        # @api private
+        MIME_SEPARATOR = "/"
+        private_constant :MIME_SEPARATOR
+
+        # @since 2.0.0
+        # @api private
+        MIME_WILDCARD = "*"
+        private_constant :MIME_WILDCARD
+
+        include Comparable
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :quality
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :index
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :mime
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :format
+
+        # @since 1.0.1
+        # @api private
+        attr_reader :priority
+
+        # @since 1.0.1
+        # @api private
+        def initialize(mime, quality, index, format = mime)
+          @quality, @index, @format = quality, index, format
+          calculate_priority(mime)
+        end
+
+        # @since 1.0.1
+        # @api private
+        def <=>(other)
+          return priority <=> other.priority unless priority == other.priority
+
+          other.index <=> index
+        end
+
+        private
+
+        # @since 1.0.1
+        # @api private
+        def calculate_priority(mime)
+          @priority ||= (mime.split(MIME_SEPARATOR, 2).count(MIME_WILDCARD) * -10) + quality
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "MIME Type" do
       expect(response.body).to        eq("")
     end
 
-    context "when ACCEPT header is set and no accept macro is use" do
+    context "when ACCEPT header is set and no format is configured" do
       it 'sets "Content-Type" header according to wildcard value' do
         response = app.get("/", "HTTP_ACCEPT" => "*/*")
         expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
@@ -37,27 +37,28 @@ RSpec.describe "MIME Type" do
       end
     end
 
-    context "when no ACCEPT or Content-Type are sent but there is a restriction using the accept macro" do
+    context "when no ACCEPT or Content-Type are sent but there is a format configured" do
       it "accepts the request and sets the status to 200" do
         response = app.get("/custom_from_accept")
         expect(response.status).to eq 200
       end
     end
 
-    context "when Content-Type are sent and there is a restriction using the accept macro" do
-      it 'sets "Content-Type" to fallback' do
+    context "when Content-Type are sent and there is a format configured" do
+      it 'accepts the request and sets the response "Content-Type" to the default format' do
         response = app.get("/custom_from_accept", "CONTENT_TYPE" => "application/custom")
-        expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
-        expect(response.body).to eq("all")
+        expect(response.status).to eq 200
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+        expect(response.body).to eq("json")
       end
 
-      it "sets status to 415 if Content-Type do not match" do
+      it "sets status to 415 if Content-Type does not match" do
         response = app.get("/custom_from_accept", "CONTENT_TYPE" => "application/xml")
         expect(response.status).to eq(415)
       end
     end
 
-    context "when ACCEPT and Content-Type are sent and we use the accept macro" do
+    context "when ACCEPT and Content-Type are sent and a format is configured" do
       it 'sets "Content-Type" header according to exact value' do
         response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom")
         expect(response.headers["Content-Type"]).to eq("application/custom; charset=utf-8")
@@ -77,7 +78,7 @@ RSpec.describe "MIME Type" do
       end
     end
 
-    context "when ACCEPT and Content-Type are send and there are no restriction using accept macro" do
+    context "when ACCEPT and Content-Type are send and there is no format configured" do
       it 'sets "Content-Type" header according to exact and weighted value' do
         response = app.get("/", "HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
         expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
@@ -94,8 +95,7 @@ RSpec.describe "MIME Type" do
     # See https://github.com/hanami/controller/issues/225
     context "with an accepted format and default response format" do
       let(:app) { Rack::MockRequest.new(MimesWithDefault::Application.new) }
-      let(:content_type) { "application/json" }
-      let(:response) { app.get("/default_and_accept", "CONTENT_TYPE" => content_type) }
+      let(:response) { app.get("/default_and_accept", "CONTENT_TYPE" => "application/json") }
 
       it "defaults to the accepted format" do
         expect(response.status).to be(200)

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -22,11 +22,6 @@ RSpec.describe "MIME Type" do
       expect(response.body).to                    eq("html")
     end
 
-    it "allows to override default_response_format" do
-      response = app.get("/overwritten_format")
-      expect(response.headers["Content-Type"]).to eq("application/xml; charset=utf-8")
-    end
-
     # FIXME: Review if this test must be in place
     it 'does not produce a "Content-Type" header when the request has a 204 No Content status' do
       response = app.get("/nocontent")

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1585,7 +1585,7 @@ module Mimes
   end
 
   class CustomFromAccept < Hanami::Action
-    config.format custom: "application/custom"
+    config.add_format custom: "application/custom"
 
     accept :json, :custom
 
@@ -1595,7 +1595,7 @@ module Mimes
   end
 
   class Restricted < Hanami::Action
-    config.format custom: "application/custom"
+    config.add_format custom: "application/custom"
 
     accept :html, :json, :custom
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1585,7 +1585,7 @@ module Mimes
   end
 
   class CustomFromAccept < Hanami::Action
-    config.formats.add custom: "application/custom"
+    config.formats.add :custom, "application/custom"
 
     format :json, :custom
 
@@ -1595,7 +1595,7 @@ module Mimes
   end
 
   class Restricted < Hanami::Action
-    config.formats.add custom: "application/custom"
+    config.formats.add :custom, "application/custom"
 
     format :html, :json, :custom
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1585,7 +1585,7 @@ module Mimes
   end
 
   class CustomFromAccept < Hanami::Action
-    config.add_format custom: "application/custom"
+    config.formats.add custom: "application/custom"
 
     format :json, :custom
 
@@ -1595,7 +1595,7 @@ module Mimes
   end
 
   class Restricted < Hanami::Action
-    config.add_format custom: "application/custom"
+    config.formats.add custom: "application/custom"
 
     format :html, :json, :custom
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1610,18 +1610,6 @@ module Mimes
     end
   end
 
-  class OverrideDefaultResponse < Hanami::Action
-    def handle(*, res)
-      res.format = :xml
-    end
-
-    private
-
-    def default_response_format
-      :json
-    end
-  end
-
   class Strict < Hanami::Action
     accept :json
 
@@ -1639,7 +1627,6 @@ module Mimes
         get "/restricted",         to: Mimes::Restricted.new
         get "/latin",              to: Mimes::Latin.new
         get "/nocontent",          to: Mimes::NoContent.new
-        get "/overwritten_format", to: Mimes::OverrideDefaultResponse.new
         get "/custom_from_accept", to: Mimes::CustomFromAccept.new
         get "/strict",             to: Mimes::Strict.new
       end
@@ -1653,7 +1640,7 @@ end
 
 module MimesWithDefault
   class Default < Hanami::Action
-    config.default_response_format = :html
+    config.format :html
 
     accept :json
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1587,7 +1587,7 @@ module Mimes
   class CustomFromAccept < Hanami::Action
     config.add_format custom: "application/custom"
 
-    accept :json, :custom
+    format :json, :custom
 
     def handle(*, res)
       res.body = res.format
@@ -1597,7 +1597,7 @@ module Mimes
   class Restricted < Hanami::Action
     config.add_format custom: "application/custom"
 
-    accept :html, :json, :custom
+    format :html, :json, :custom
 
     def handle(_req, res)
       res.body = res.format
@@ -1611,7 +1611,7 @@ module Mimes
   end
 
   class Strict < Hanami::Action
-    accept :json
+    format :json
 
     def handle(_req, res)
       res.body = res.format
@@ -1640,9 +1640,7 @@ end
 
 module MimesWithDefault
   class Default < Hanami::Action
-    config.format :html
-
-    accept :json
+    config.format :html, :json
 
     def handle(*, res)
       res.body = res.format

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Hanami::Action::Config::Formats do
     end
   end
 
+  describe "#add" do
+    it "adds a new mapping" do
+      expect { formats.add(custom: "application/custom") }
+        .to change { formats.mapping }
+        .to include("application/custom" => :custom)
+    end
+  end
+
   describe "#format_for" do
     before do
       formats.mapping = {html: "text/html"}

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe Hanami::Action::Config::Formats do
     end
   end
 
+  describe "#clear" do
+    it "clears any previously assigned mappings and values" do
+      formats.add(custom: "application/custom")
+      formats.values = [:custom]
+
+      formats.clear
+
+      expect(formats.mapping.keys).not_to include "application/custom"
+      expect(formats.values).to eq []
+    end
+  end
+
   describe "#format_for" do
     before do
       formats.mapping = {html: "text/html"}

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe Hanami::Action::Config::Formats do
         .to include("application/custom" => :custom)
     end
 
+    it "can add a mapping to multiple content types" do
+      expect { formats.add(:json, ["application/json", "application/json+scim"]) }
+        .to change { formats.mapping }
+        .to include("application/json" => :json, "application/json+scim" => :json)
+    end
+
     it "replaces the a previously set mapping for a given MIME type" do
       formats.mapping = {html: "text/html"}
       formats.add :custom, "text/html"

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -23,14 +23,6 @@ RSpec.describe Hanami::Action::Config::Formats do
     end
   end
 
-  describe "#mime_types" do
-    it "returns the MIME types from the configured formats (as well as the default MIME types)" do
-      formats.mapping = {custom: "custom/type"}
-
-      expect(formats.mime_types).to eq(["custom/type"] + Hanami::Action::Mime::TYPES.values)
-    end
-  end
-
   describe "#mime_type_for" do
     before do
       formats.mapping = {html: "text/html"}

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Hanami::Action::Config::Formats do
     end
   end
 
+  describe "#values" do
+    it "returns an empty array by default" do
+      expect(formats.values).to eq []
+    end
+
+    it "can have a list of format names assigned" do
+      expect { formats.values = [:json, :html] }
+        .to change { formats.values }
+        .to [:json, :html]
+    end
+  end
+
   describe "#format_for" do
     before do
       formats.mapping = {html: "text/html"}

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe Hanami::Action::Config::Formats do
       expect(formats.format_for("*/*")).to be nil
     end
   end
+
+  describe "#mime_types" do
+    it "returns the MIME types from the configured formats (as well as the default MIME types)" do
+      formats.mapping = {custom: "custom/type"}
+
+      expect(formats.mime_types).to eq(["custom/type"] + Hanami::Action::Mime::TYPES.values)
+    end
+  end
 end

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -110,15 +110,29 @@ RSpec.describe Hanami::Action::Config::Formats do
 
   describe "#mime_type_for" do
     before do
-      formats.mapping = {html: "text/html"}
+      formats.mapping = {html: ["text/html", "text/htm"]}
     end
 
-    it "returns the configured MIME type for the given format" do
+    it "returns the first configured MIME type for the given format" do
       expect(formats.mime_type_for(:html)).to eq "text/html"
     end
 
     it "returns nil if no matching MIME type is found" do
       expect(formats.mime_type_for(:missing)).to be nil
+    end
+  end
+
+  describe "#mime_types_for" do
+    before do
+      formats.mapping = {html: ["text/html", "text/htm"]}
+    end
+
+    it "returns all configured MIME types for the given format" do
+      expect(formats.mime_types_for(:html)).to eq ["text/html", "text/htm"]
+    end
+
+    it "returns an empty array if no matching MIME type is found" do
+      expect(formats.mime_types_for(:missing)).to eq []
     end
   end
 end

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Action::Config::Formats do
+  subject(:formats) { described_class.new }
+
+  describe "#format_for" do
+    before do
+      formats.mapping = {html: "text/html"}
+    end
+
+    it "returns the configured format for the given MIME type" do
+      expect(formats.format_for("text/html")).to eq :html
+    end
+
+    it "returns the most recently configured format for a given MIME type" do
+      formats.add htm: "text/html"
+
+      expect(formats.format_for("text/html")).to eq(:htm)
+    end
+
+    it "returns nil if no matching format is found" do
+      expect(formats.format_for("*/*")).to be nil
+    end
+  end
+end

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Hanami::Action::Config::Formats do
         .to include("application/custom" => :custom)
     end
 
+    it "replaces the a previously set mapping for a given MIME type" do
+      formats.mapping = {html: "text/html"}
+      formats.add :custom, "text/html"
+
+      expect(formats.mapping).to eq("text/html" => :custom)
+    end
+
     it "appends the format to the list of enabled formats" do
       formats.values = [:json]
 
@@ -34,6 +41,20 @@ RSpec.describe Hanami::Action::Config::Formats do
       }
         .to change { formats.values }
         .to [:json, :custom]
+    end
+
+    it "raises an error if the given format cannot be coerced into symbol" do
+      expect { formats.add(23, "boom") }.to raise_error(TypeError)
+    end
+
+    it "raises an error if the given mime type cannot be coerced into string" do
+      obj = Class.new(BasicObject) do
+        def hash
+          23
+        end
+      end.new
+
+      expect { formats.add(:boom, obj) }.to raise_error(TypeError)
     end
   end
 

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -3,6 +3,21 @@
 RSpec.describe Hanami::Action::Config::Formats do
   subject(:formats) { described_class.new }
 
+  describe "#mapping" do
+    it "is a basic mapping of mime types to `:all` formats by default" do
+      expect(formats.mapping).to eq(
+        "application/octet-stream" => :all,
+        "*/*" => :all
+      )
+    end
+
+    it "can be replaced a mapping" do
+      expect { formats.mapping = {all: "*/*"} }
+        .to change { formats.mapping }
+        .to("*/*" => :all)
+    end
+  end
+
   describe "#format_for" do
     before do
       formats.mapping = {html: "text/html"}

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -20,9 +20,20 @@ RSpec.describe Hanami::Action::Config::Formats do
 
   describe "#add" do
     it "adds a new mapping" do
-      expect { formats.add(custom: "application/custom") }
+      expect { formats.add(:custom, "application/custom") }
         .to change { formats.mapping }
         .to include("application/custom" => :custom)
+    end
+
+    it "appends the format to the list of enabled formats" do
+      formats.values = [:json]
+
+      expect {
+        formats.add(:custom, "application/custom")
+        formats.add(:custom, "application/custom+more")
+      }
+        .to change { formats.values }
+        .to [:json, :custom]
     end
   end
 
@@ -40,7 +51,7 @@ RSpec.describe Hanami::Action::Config::Formats do
 
   describe "#clear" do
     it "clears any previously assigned mappings and values" do
-      formats.add(custom: "application/custom")
+      formats.add(:custom, "application/custom")
       formats.values = [:custom]
 
       formats.clear
@@ -60,7 +71,7 @@ RSpec.describe Hanami::Action::Config::Formats do
     end
 
     it "returns the most recently configured format for a given MIME type" do
-      formats.add htm: "text/html"
+      formats.add :htm, "text/html"
 
       expect(formats.format_for("text/html")).to eq(:htm)
     end

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe Hanami::Action::Config::Formats do
       expect(formats.mime_types).to eq(["custom/type"] + Hanami::Action::Mime::TYPES.values)
     end
   end
+
+  describe "#mime_type_for" do
+    before do
+      formats.mapping = {html: "text/html"}
+    end
+
+    it "returns the configured MIME type for the given format" do
+      expect(formats.mime_type_for(:html)).to eq "text/html"
+    end
+
+    it "returns nil if no matching MIME type is found" do
+      expect(formats.mime_type_for(:missing)).to be nil
+    end
+  end
 end

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
-  describe "#formats" do
+  describe "#format_mappings" do
     it "is a basic set of mime type to format mappings by default" do
-      expect(config.formats).to eq(
+      expect(config.format_mappings).to eq(
         "application/octet-stream" => :all,
         "*/*" => :all,
         "text/html" => :html
@@ -52,33 +52,33 @@ RSpec.describe Hanami::Action::Config do
     end
 
     it "can be set with a new mime type to format mappings" do
-      config.formats = {"*/*" => :all}
-      expect(config.formats).to eq("*/*" => :all)
+      config.format_mappings = {"*/*" => :all}
+      expect(config.format_mappings).to eq("*/*" => :all)
     end
   end
 
   describe "#format" do
     before do
-      config.formats = {"text/html" => :html}
+      config.format_mappings = {"text/html" => :html}
     end
 
     it "adds the given MIME type to format mapping" do
-      config.format custom: "custom/format"
+      config.add_format custom: "custom/format"
 
-      expect(config.formats).to eq(
+      expect(config.format_mappings).to eq(
         "text/html" => :html,
         "custom/format" => :custom
       )
     end
 
     it "replaces the mapping for an existing MIME type" do
-      config.format custom: "text/html"
+      config.add_format custom: "text/html"
 
-      expect(config.formats).to eq("text/html" => :custom)
+      expect(config.format_mappings).to eq("text/html" => :custom)
     end
 
     it "raises an error if the given format cannot be coerced into symbol" do
-      expect { config.format(23 => "boom") }.to raise_error(TypeError)
+      expect { config.add_format(23 => "boom") }.to raise_error(TypeError)
     end
 
     it "raises an error if the given mime type cannot be coerced into string" do
@@ -88,13 +88,13 @@ RSpec.describe Hanami::Action::Config do
         end
       end.new
 
-      expect { config.format(boom: obj) }.to raise_error(TypeError)
+      expect { config.add_format(boom: obj) }.to raise_error(TypeError)
     end
   end
 
   describe "#format_for" do
     before do
-      config.formats = {"text/html" => :html}
+      config.format_mappings = {"text/html" => :html}
     end
 
     it "returns the configured format for the given MIME type" do
@@ -102,7 +102,7 @@ RSpec.describe Hanami::Action::Config do
     end
 
     it "returns the most recently configured format for a given MIME type" do
-      config.format htm: "text/html"
+      config.add_format htm: "text/html"
 
       expect(config.format_for("text/html")).to eq(:htm)
     end
@@ -114,14 +114,14 @@ RSpec.describe Hanami::Action::Config do
 
   describe "#mime_types" do
     it "returns the MIME types from the configured formats (as well as the default MIME types)" do
-      config.formats = {"custom/type" => :custom}
+      config.format_mappings = {"custom/type" => :custom}
       expect(config.mime_types).to eq ["custom/type"] + Hanami::Action::Mime::TYPES.values
     end
   end
 
   describe "#mime_type_for" do
     before do
-      config.formats = {"text/html" => :html}
+      config.format_mappings = {"text/html" => :html}
     end
 
     it "returns the configured MIME type for the given format" do

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -30,11 +30,10 @@ RSpec.describe Hanami::Action::Config do
   end
 
   describe "#formats" do
-    it "is a basic set of mime type to format mappings by default" do
+    it "is a basic mapping of mime types to `:all` formats by default" do
       expect(config.formats.mapping).to eq(
         "application/octet-stream" => :all,
-        "*/*" => :all,
-        "text/html" => :html
+        "*/*" => :all
       )
     end
 

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -79,13 +79,6 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
-  describe "#mime_types" do
-    it "returns the MIME types from the configured formats (as well as the default MIME types)" do
-      config.formats.mapping = {custom: "custom/type"}
-      expect(config.mime_types).to eq(["custom/type"] + Hanami::Action::Mime::TYPES.values)
-    end
-  end
-
   describe "#mime_type_for" do
     before do
       config.formats.mapping = {html: "text/html"}

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -24,18 +24,16 @@ RSpec.describe Hanami::Action::Config do
 
   describe "#format" do
     context "single format given" do
-      it "sets the accepted_formats and default_response_format" do
+      it "sets the accepted_formats" do
         config.format :json
         expect(config.accepted_formats).to eq [:json]
-        expect(config.default_response_format).to eq :json
       end
     end
 
     context "multiple formats given" do
-      it "sets all formats as accepted_formats, and the first format as the default_response_format" do
+      it "sets all formats as accepted_formats" do
         config.format :html, :json
         expect(config.accepted_formats).to eq [:html, :json]
-        expect(config.default_response_format).to eq :html
       end
     end
   end
@@ -128,23 +126,6 @@ RSpec.describe Hanami::Action::Config do
 
     it "returns nil if no matching MIME type is found" do
       expect(config.mime_type_for(:missing)).to be nil
-    end
-  end
-
-  describe "#default_response_format" do
-    it "is nil by default" do
-      expect(config.default_response_format).to be nil
-    end
-
-    it "can be set with a format symbol" do
-      config.default_response_format = :json
-      expect(config.default_response_format).to eq(:json)
-    end
-
-    it "raises an error if the given format cannot be coerced into symbol" do
-      expect {
-        config.default_response_format = 23
-      }.to raise_error(TypeError)
     end
   end
 

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Hanami::Action::Config do
       config.format :json, :html
       expect(config.formats.values).to eq [:json, :html]
     end
+
+    it "returns previously set formats" do
+      config.format :json, :html
+      expect(config.format).to eq [:json, :html]
+    end
   end
 
   describe "#default_charset" do

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -79,20 +79,6 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
-  describe "#mime_type_for" do
-    before do
-      config.formats.mapping = {html: "text/html"}
-    end
-
-    it "returns the configured MIME type for the given format" do
-      expect(config.mime_type_for(:html)).to eq "text/html"
-    end
-
-    it "returns nil if no matching MIME type is found" do
-      expect(config.mime_type_for(:missing)).to be nil
-    end
-  end
-
   describe "#default_charset" do
     it "is nil by default" do
       expect(config.default_charset).to be nil

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -24,19 +24,17 @@ RSpec.describe Hanami::Action::Config do
 
   describe "#format" do
     context "single format given" do
-      it "sets the accepted_formats, default_request_format and default_response_format" do
+      it "sets the accepted_formats and default_response_format" do
         config.format :json
         expect(config.accepted_formats).to eq [:json]
-        expect(config.default_request_format).to eq :json
         expect(config.default_response_format).to eq :json
       end
     end
 
     context "multiple formats given" do
-      it "sets all formats as accepted_formats, and the first format as default_request_format and default_response_format" do
+      it "sets all formats as accepted_formats, and the first format as the default_response_format" do
         config.format :html, :json
         expect(config.accepted_formats).to eq [:html, :json]
-        expect(config.default_request_format).to eq :html
         expect(config.default_response_format).to eq :html
       end
     end
@@ -130,23 +128,6 @@ RSpec.describe Hanami::Action::Config do
 
     it "returns nil if no matching MIME type is found" do
       expect(config.mime_type_for(:missing)).to be nil
-    end
-  end
-
-  describe "#default_request_format" do
-    it "is nil by default" do
-      expect(config.default_request_format).to be nil
-    end
-
-    it "can be set with a format symbol" do
-      config.default_request_format = :html
-      expect(config.default_request_format).to eq(:html)
-    end
-
-    it "raises an error if the given format cannot be coerced into symbol" do
-      expect {
-        config.default_request_format = 23
-      }.to raise_error(TypeError)
     end
   end
 

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -23,18 +23,9 @@ RSpec.describe Hanami::Action::Config do
   end
 
   describe "#format" do
-    context "single format given" do
-      it "sets the accepted_formats" do
-        config.format :json
-        expect(config.accepted_formats).to eq [:json]
-      end
-    end
-
-    context "multiple formats given" do
-      it "sets all formats as accepted_formats" do
-        config.format :html, :json
-        expect(config.accepted_formats).to eq [:html, :json]
-      end
+    it "sets formats" do
+      config.format :json, :html
+      expect(config.formats).to eq [:json, :html]
     end
   end
 

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -79,26 +79,6 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
-  describe "#format_for" do
-    before do
-      config.formats.mapping = {html: "text/html"}
-    end
-
-    it "returns the configured format for the given MIME type" do
-      expect(config.format_for("text/html")).to eq :html
-    end
-
-    it "returns the most recently configured format for a given MIME type" do
-      config.formats.add htm: "text/html"
-
-      expect(config.format_for("text/html")).to eq(:htm)
-    end
-
-    it "returns nil if no matching format is found" do
-      expect(config.format_for("*/*")).to be nil
-    end
-  end
-
   describe "#mime_types" do
     it "returns the MIME types from the configured formats (as well as the default MIME types)" do
       config.formats.mapping = {custom: "custom/type"}

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
+  describe "#use_formats" do
+    context "single format given" do
+      it "sets the accepted_formats, default_request_format and default_response_format" do
+        config.use_formats :json
+        expect(config.accepted_formats).to eq [:json]
+        expect(config.default_request_format).to eq :json
+        expect(config.default_response_format).to eq :json
+      end
+    end
+
+    context "multiple formats given" do
+      it "sets all formats as accepted_formats, and the first format as default_request_format and default_response_format" do
+        config.use_formats :html, :json
+        expect(config.accepted_formats).to eq [:html, :json]
+        expect(config.default_request_format).to eq :html
+        expect(config.default_response_format).to eq :html
+      end
+    end
+  end
+
   describe "#formats" do
     it "is a basic set of mime type to format mappings by default" do
       expect(config.formats).to eq(

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -29,20 +29,6 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
-  describe "#formats" do
-    it "is a basic mapping of mime types to `:all` formats by default" do
-      expect(config.formats.mapping).to eq(
-        "application/octet-stream" => :all,
-        "*/*" => :all
-      )
-    end
-
-    it "can be set with a new mime type to format mappings" do
-      config.formats.mapping = {all: "*/*"}
-      expect(config.formats.mapping).to eq("*/*" => :all)
-    end
-  end
-
   describe "#format" do
     before do
       config.formats.mapping = {html: "text/html"}

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
-  describe "#use_formats" do
+  describe "#format" do
     context "single format given" do
       it "sets the accepted_formats, default_request_format and default_response_format" do
-        config.use_formats :json
+        config.format :json
         expect(config.accepted_formats).to eq [:json]
         expect(config.default_request_format).to eq :json
         expect(config.default_response_format).to eq :json
@@ -34,7 +34,7 @@ RSpec.describe Hanami::Action::Config do
 
     context "multiple formats given" do
       it "sets all formats as accepted_formats, and the first format as default_request_format and default_response_format" do
-        config.use_formats :html, :json
+        config.format :html, :json
         expect(config.accepted_formats).to eq [:html, :json]
         expect(config.default_request_format).to eq :html
         expect(config.default_response_format).to eq :html

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Hanami::Action::Config do
     end
 
     it "adds the given MIME type to format mapping" do
-      config.formats.add custom: "custom/format"
+      config.formats.add :custom, "custom/format"
 
       expect(config.formats.mapping).to eq(
         "text/html" => :html,
@@ -44,13 +44,13 @@ RSpec.describe Hanami::Action::Config do
     end
 
     it "replaces the mapping for an existing MIME type" do
-      config.formats.add custom: "text/html"
+      config.formats.add :custom, "text/html"
 
       expect(config.formats.mapping).to eq("text/html" => :custom)
     end
 
     it "raises an error if the given format cannot be coerced into symbol" do
-      expect { config.formats.add(23 => "boom") }.to raise_error(TypeError)
+      expect { config.formats.add(23, "boom") }.to raise_error(TypeError)
     end
 
     it "raises an error if the given mime type cannot be coerced into string" do
@@ -60,7 +60,7 @@ RSpec.describe Hanami::Action::Config do
         end
       end.new
 
-      expect { config.formats.add(boom: obj) }.to raise_error(TypeError)
+      expect { config.formats.add(:boom, obj) }.to raise_error(TypeError)
     end
   end
 

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -29,41 +29,6 @@ RSpec.describe Hanami::Action::Config do
     end
   end
 
-  describe "#format" do
-    before do
-      config.formats.mapping = {html: "text/html"}
-    end
-
-    it "adds the given MIME type to format mapping" do
-      config.formats.add :custom, "custom/format"
-
-      expect(config.formats.mapping).to eq(
-        "text/html" => :html,
-        "custom/format" => :custom
-      )
-    end
-
-    it "replaces the mapping for an existing MIME type" do
-      config.formats.add :custom, "text/html"
-
-      expect(config.formats.mapping).to eq("text/html" => :custom)
-    end
-
-    it "raises an error if the given format cannot be coerced into symbol" do
-      expect { config.formats.add(23, "boom") }.to raise_error(TypeError)
-    end
-
-    it "raises an error if the given mime type cannot be coerced into string" do
-      obj = Class.new(BasicObject) do
-        def hash
-          23
-        end
-      end.new
-
-      expect { config.formats.add(:boom, obj) }.to raise_error(TypeError)
-    end
-  end
-
   describe "#default_charset" do
     it "is nil by default" do
       expect(config.default_charset).to be nil

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe Hanami::Action::Config do
   describe "#format" do
     it "sets formats" do
       config.format :json, :html
-      expect(config.formats).to eq [:json, :html]
+      expect(config.formats.values).to eq [:json, :html]
     end
   end
 
-  describe "#format_mappings" do
+  describe "#formats" do
     it "is a basic set of mime type to format mappings by default" do
-      expect(config.format_mappings).to eq(
+      expect(config.formats.mapping).to eq(
         "application/octet-stream" => :all,
         "*/*" => :all,
         "text/html" => :html
@@ -39,33 +39,33 @@ RSpec.describe Hanami::Action::Config do
     end
 
     it "can be set with a new mime type to format mappings" do
-      config.format_mappings = {"*/*" => :all}
-      expect(config.format_mappings).to eq("*/*" => :all)
+      config.formats.mapping = {all: "*/*"}
+      expect(config.formats.mapping).to eq("*/*" => :all)
     end
   end
 
   describe "#format" do
     before do
-      config.format_mappings = {"text/html" => :html}
+      config.formats.mapping = {html: "text/html"}
     end
 
     it "adds the given MIME type to format mapping" do
-      config.add_format custom: "custom/format"
+      config.formats.add custom: "custom/format"
 
-      expect(config.format_mappings).to eq(
+      expect(config.formats.mapping).to eq(
         "text/html" => :html,
         "custom/format" => :custom
       )
     end
 
     it "replaces the mapping for an existing MIME type" do
-      config.add_format custom: "text/html"
+      config.formats.add custom: "text/html"
 
-      expect(config.format_mappings).to eq("text/html" => :custom)
+      expect(config.formats.mapping).to eq("text/html" => :custom)
     end
 
     it "raises an error if the given format cannot be coerced into symbol" do
-      expect { config.add_format(23 => "boom") }.to raise_error(TypeError)
+      expect { config.formats.add(23 => "boom") }.to raise_error(TypeError)
     end
 
     it "raises an error if the given mime type cannot be coerced into string" do
@@ -75,13 +75,13 @@ RSpec.describe Hanami::Action::Config do
         end
       end.new
 
-      expect { config.add_format(boom: obj) }.to raise_error(TypeError)
+      expect { config.formats.add(boom: obj) }.to raise_error(TypeError)
     end
   end
 
   describe "#format_for" do
     before do
-      config.format_mappings = {"text/html" => :html}
+      config.formats.mapping = {html: "text/html"}
     end
 
     it "returns the configured format for the given MIME type" do
@@ -89,7 +89,7 @@ RSpec.describe Hanami::Action::Config do
     end
 
     it "returns the most recently configured format for a given MIME type" do
-      config.add_format htm: "text/html"
+      config.formats.add htm: "text/html"
 
       expect(config.format_for("text/html")).to eq(:htm)
     end
@@ -101,14 +101,14 @@ RSpec.describe Hanami::Action::Config do
 
   describe "#mime_types" do
     it "returns the MIME types from the configured formats (as well as the default MIME types)" do
-      config.format_mappings = {"custom/type" => :custom}
-      expect(config.mime_types).to eq ["custom/type"] + Hanami::Action::Mime::TYPES.values
+      config.formats.mapping = {custom: "custom/type"}
+      expect(config.mime_types).to eq(["custom/type"] + Hanami::Action::Mime::TYPES.values)
     end
   end
 
   describe "#mime_type_for" do
     before do
-      config.format_mappings = {"text/html" => :html}
+      config.formats.mapping = {html: "text/html"}
     end
 
     it "returns the configured MIME type for the given format" do

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hanami::Action do
     end
 
     class Configuration < Hanami::Action
-      config.default_response_format = :jpg
+      config.format :jpg
 
       def handle(*, res)
         res.body = res.format

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -96,18 +96,20 @@ RSpec.describe Hanami::Action do
     end
 
     it "sets nil and raises an error" do
-      expect { action.call(format: nil) }.to raise_error(Hanami::Action::UnknownFormatError, "Cannot find a corresponding Mime type for ''. Please configure it with Hanami::Controller::Configuration#format.")
+      expect { action.call(format: nil) }
+        .to raise_error(Hanami::Action::UnknownFormatError, "Cannot find a corresponding MIME type for `nil` format.")
     end
 
     it "sets '' and raises an error" do
-      expect { action.call(format: "") }.to raise_error(Hanami::Action::UnknownFormatError, "Cannot find a corresponding Mime type for ''. Please configure it with Hanami::Controller::Configuration#format.")
+      expect { action.call(format: "") }
+        .to raise_error(Hanami::Action::UnknownFormatError, "Cannot find a corresponding MIME type for `nil` format.")
     end
 
     it "sets an unknown format and raises an error" do
       action.call(format: :unknown)
     rescue StandardError => exception
       expect(exception).to         be_kind_of(Hanami::Action::UnknownFormatError)
-      expect(exception.message).to eq("Cannot find a corresponding Mime type for 'unknown'. Please configure it with Hanami::Controller::Configuration#format.")
+      expect(exception.message).to eq("Cannot find a corresponding MIME type for format :unknown. Configure one via `config.formats.add(unknown: \"MIME_TYPE_HERE\")`.")
     end
 
     Hanami::Action::Mime::TYPES.each do |format, mime_type|


### PR DESCRIPTION
UPDATE: Thanks to @jodosha's suggestion, we've built further on the ideas below and encapsulated all format configuration under a new `Config::Formats` instance returned from `config.formats`. It has its own API and it's very nice. We've kept the `config.format(...)` method as a short cut to assign `config.formats.values`.

---

So this PR started with my adding `Config#use_formats` as a "macro" to configure `accepted_formats`, `default_request_format` and `default_response_format` all together, since that is what typical well-behaved actions would need if they are going to be format-aware.

This led to a bit of a naming conversation: `#use_formats` felt awkward to me, so @jodosha suggested we rename the existing `Config#format` to `#add_format`, which would then allow us to name this new macro `#format`, which is clearly the best name for it.

@jodosha also hinted that it might make more sense to turn this macro into a real setting, too, since the trouble with a macro without any concrete underlying variable is that it becomes hard to authoritatively read a value back from it later.

This all sounded great to me, so I took a pass at it, and it turns out this has unlocked the chance to greatly simplify our actions config. It was very much a "one thing led to another" kind of scenario, so let me walk you through the steps (and commits):

1. 0ed04f3505c0974537c850e8d67b603703764b92 — We start with the `Config#format` -> `#add_format` rename. At the same time, let's rename the underlying `formats` setting to `format_mappings` since we didn't want any confusion with this new setting we'll be introducing later (plus, `format_mappings` is a much more self-descriptive name for this settings' purpose).
2. b00ee8f95e28b147d80b93bea0f89f3bdf899530 — With that done, we can rename `Config#use_formats` to `Config#format`, which was our agreed ideal name for this. Also add `Action.format` as a class-level shortcut. However, at this point, this method is still a "macro" and not a simple setter method backed by a concrete setting, so let's start by seeing if we can reduce what this macro is doing.
3. 6df1e391ec4a8566b3c44276441151e55e9c9012 — To begin with, we can entirely remove the `default_request_format` setting. This turned out to be entirely useless: it was only _really_ used inside `Mime.enforce_content_type`, but it turns out the `if content_type.nil?` guard statement below is already doing enough for us here. We don't need this setting.
4. 5fae6fcc25f06b6e66ba7b28ecc52d95a5111e7d — From here, we can make a proper `formats` setting to hold the formats we're passing to `Config#format`. We can also remove `default_response_format` and instead use the first entry from `formats` to take its place.
5. a23cb9330bcb5d3d2f96b90c066725238af48bbd — As a last step, we can now remove `Action.accept` and the `accepted_formats` setting, since we already have a list of formats we can use for this: the new `formats` setting! 
 
So by the time we get to the end of this, the new `format` method (and the `formats` setting it populates) are just an evolution of what we had with `accept`/`accepted_formats` previously, with the added benefit of setting the default response format at the same time (which can easily be overridden per action if ever needed). And the removal of all the other settings makes for a much tighter overall experience and a much easier to understand internal implementation.

I'm honestly super jazzed that we got to this point! I think it's going to make actions so much more streamlined and usable for devs working with Hanami 2.0!

Let me just re-state where we were before:

```ruby
class MyAction < Hanami::Action
  config.accepted_formats = [:json] # or accept(:json)
  config.default_request_format = :json
  config.default_response_format = :json
end
```

Then with my initial pass at this, we got to:

```ruby
class MyAction < Hanami::Action
  config.use_formats :json
end
```

And now we're at:

```ruby
class MyAction < Hanami::Action
  format :json
end
```

And with the added benefit of `accept`, `default_request_format` and `default_response_format` **all being fully removed**, so that's three whole different settings and concepts our users no longer have to try and grapple with. Those three settings were added at different points of the Hanami 1.x lifecycle to address various needs/bugs that arose, but with 2.0 we have the chance to clear the slate and here we've arrived at a much more cohesive outcome: a solitary setting that we can have impact all aspects of the action request handling as required, and just a single thing our users have to learn about.

Pls let me know what you think 😄 

---

_Original description text follows:_

Add a `Config#use_formats` "macro" to make it easy to configure several settings that are usually done together:

- `accepted_formats` (which can also be set via `Action.accept`)
- `default_request_format` (which IMO probably doesn't even need to _exist_ as a setting, but it's too late for that now, we can reconsider it later)
- `default_response_format`

So instead of doing this:

```ruby
config.accepted_formats = [:json]
config.default_request_format = :json
config.default_response_format = :json
```

You can just do this:

```ruby
config.use_formats :json
```

We also support passing multiple formats:

```ruby
config.use_formats :json, :html
```

In this case, the first format is the default format, and will be the format assigned as the default request/response format. The full array of formats is passed to `accepted_formats`.

In this present state, this PR presents a pure _addition_ only: `#use_format` is a "macro" that serves as convenience and reduction in boilerplate for common configuration requirements.

An open question here is what we should name this. I'm not completely happy with `config.use_formats`. What else could we use?

- `config.action_format :json` (not bad, I actually don't mind it, I might be inclined to move to this unless someone presents a better alternative — it's a good in that it hints at the idea of "everything about this action is oriented around <this format>")
- `config.format! :json` (nah, the meaning of the `!` is ambiguous)
- _others?_

One other name I toyed with earlier was `accept_formats`. This was nice in that there was a clear relationship to one of the settings that it assigned (`accepted_formats`). I even went so far as to change `Action.accept` to call this new method, but that did break 2 specs (I suspect the change in behaviour would be tolerable, but we should be extra wary of such things at this point). The downside to `accept_formats` as a name, however, is that it doesn't quite encompass the idea that _other_ aspects aside from `accepted_formats` are also being configured at the same time.

Another thing I considered here was whether this method should also accomodate the registration of custom MIME/content type strings with action names, but I felt that would be putting way too much responsibility into one place, and it'd complicate the call signature. I think we're better off leaving the registration of format/mime type pairings to the dedicated `Config#format` method.

So a couple questions to leave with you:

1. Are you happy for the idea behind this method? I think it will be important for streamlining the experience of people building APIs with Hanami 2, which is going to be our major use case for the first release.
10. Do you have any opinions on naming? Absent any strong opinions I think I'll rename it to `action_format`.

Once we're happy I'll tweak the name, tidy the docs, and merge.