### PR TITLE
Fix for accepting all content types

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -237,7 +237,7 @@ module Hanami
         # @api private
         def accepted_mime_type?(mime_type, config)
           accepted_mime_types(config).any? { |accepted_mime_type|
-            ::Rack::Mime.match?(accepted_mime_type, mime_type)
+            ::Rack::Mime.match?(mime_type, accepted_mime_type)
           }
         end
 

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -58,6 +58,13 @@ RSpec.describe "MIME Type" do
       end
     end
 
+    context "when Content-Type are sent and formats are configured to accept all" do
+      it "accepts the request with a custom content type" do
+        response = app.get("/relaxed", "CONTENT_TYPE" => "application/custom")
+        expect(response.status).to eq 200
+      end
+    end
+
     context "when ACCEPT and Content-Type are sent and a format is configured" do
       it 'sets "Content-Type" header according to exact value' do
         response = app.get("/custom_from_accept", "HTTP_ACCEPT" => "application/custom")

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1618,6 +1618,14 @@ module Mimes
     end
   end
 
+  class Relaxed < Hanami::Action
+    format :all
+
+    def handle(_req, res)
+      res.body = res.format
+    end
+  end
+
   class Application
     def initialize
       @router = Hanami::Router.new do
@@ -1629,6 +1637,7 @@ module Mimes
         get "/nocontent",          to: Mimes::NoContent.new
         get "/custom_from_accept", to: Mimes::CustomFromAccept.new
         get "/strict",             to: Mimes::Strict.new
+        get "/relaxed",            to: Mimes::Relaxed.new
       end
     end
 


### PR DESCRIPTION
I'm in the process of migrating an API within a Hanami app from Roda to hanami-router/hanami-controller. And while I do prefer to be strict about the content received by the API, I also don't entirely trust the third-parties using it will send through correct content types - and I don't want to be breaking their access via their current behaviour.

So, I've set `format :all` in the relevant action superclass… and my tests break. 😭

From what I can see: when we use `:all` as a format, we're comparing against the mime-type strings of `*/*` and `application/octet-stream`. rack-test sends through a default content type of `application/x-www-form-urlencoded`. But it doesn't get matched against the catch-all `*/*`, because [the order of arguments to `Rack::Mime.match?`](https://github.com/rack/rack/blob/v3.0.3/lib/rack/mime.rb#L23-L35) actually matters: if you want the wildcard behaviour to apply, the wildcards need to be in the _second_ argument.

Now that I've flipped the arguments around, everything's happy.

All that said, I'm wading into unfamiliar code, so: have I misunderstood things? Should I be testing it in a different way? Should the other uses of `Rack::Mime.match?` be modified as well? (I feel like they should, but unsure how to write a breaking test to then fix with the switch of arguments)