### PR TITLE
Support pattern-matching Params

### DIFF
--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -243,6 +243,15 @@ module Hanami
         @params
       end
       alias_method :to_hash, :to_h
+
+      # Pattern-matching support
+      #
+      # @return [::Hash]
+      #
+      # @since 2.1.0
+      def deconstruct_keys(_keys)
+        @params
+      end
     end
   end
 end

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -248,9 +248,9 @@ module Hanami
       #
       # @return [::Hash]
       #
-      # @since 2.1.0
-      def deconstruct_keys(_keys)
-        @params
+      # @since 2.0.2
+      def deconstruct_keys(*)
+        to_hash
       end
     end
   end

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -456,6 +456,21 @@ RSpec.describe Hanami::Action::Params do
     end
   end
 
+  describe "#deconstruct_keys" do
+    let(:params) do
+      TestParams.new(
+        name: "John",
+        address: {line_one: "10 High Street", deep: {deep_attr: 1}},
+        array: [{name: "Lennon"}, {name: "Wayne"}]
+      )
+    end
+
+    it "supports pattern-matching" do
+      params => { name: }
+      expect(name).to eq("John")
+    end
+  end
+
   describe "#errors" do
     let(:klass) do
       Class.new(described_class) do


### PR DESCRIPTION
I think this is a pretty straightforward feature enhancement, currently you have to call `#to_h` on it to destructure keys, which feels like unnecessary friction.