### PR TITLE
Translate symbolic status codes in Response#status=

### DIFF
--- a/lib/hanami/action/errors.rb
+++ b/lib/hanami/action/errors.rb
@@ -9,6 +9,22 @@ module Hanami
     class Error < ::StandardError
     end
 
+    # Unknown status code error
+    #
+    # This error is raised when a symbolic status code is given that cannot be
+    # found in `Hanami::Http::Status::SYMBOLS`.
+    #
+    # @since 2.1.0
+    #
+    # @see Hanami::Action::Response#status=
+    class UnknownStatusCodeError < Error
+      # @since 2.1.0
+      # @api private
+      def initialize(code)
+        super("Unrecognized status code: #{code.inspect}")
+      end
+    end
+
     # Unknown format error
     #
     # This error is raised when a action sets a format that it isn't recognized

--- a/lib/hanami/action/halt.rb
+++ b/lib/hanami/action/halt.rb
@@ -10,6 +10,7 @@ module Hanami
       # @api private
       # @since 2.0.0
       def self.call(status, body = nil)
+        status = Http::Status.normalize(status)
         body ||= Http::Status.message_for(status)
         throw :halt, [status, body]
       end

--- a/lib/hanami/action/halt.rb
+++ b/lib/hanami/action/halt.rb
@@ -10,9 +10,12 @@ module Hanami
       # @api private
       # @since 2.0.0
       def self.call(status, body = nil)
-        status = Http::Status.normalize(status)
-        body ||= Http::Status.message_for(status)
-        throw :halt, [status, body]
+        unless (normalized_status = Http::Status.normalize(status))
+          raise UnknownStatusCodeError.new(status)
+        end
+
+        body ||= Http::Status.message_for(normalized_status)
+        throw :halt, [normalized_status, body]
       end
     end
   end

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -81,6 +81,28 @@ module Hanami
         end
       end
 
+      # Set the response status
+      #
+      # @param code [Integer, Symbol] the status code
+      #
+      # @example
+      #   response.status = :unprocessable_entity
+      #
+      # @example
+      #   response.status = 422
+      #
+      # @see https://guides.hanamirb.org/v2.0/actions/status-codes/
+      #
+      # @since 2.1.0
+      # @api public
+      def status=(code)
+        unless (normalized_code = Http::Status.normalize(code))
+          raise Hanami::Action::UnknownStatusCodeError.new(code)
+        end
+
+        super(normalized_code)
+      end
+
       # This is NOT RELEASED with 2.0.0
       #
       # @api private

--- a/lib/hanami/http/status.rb
+++ b/lib/hanami/http/status.rb
@@ -17,6 +17,12 @@ module Hanami
       # @api private
       ALL = ::Rack::Utils::HTTP_STATUS_CODES
 
+      # Symbolic names for status codes
+      #
+      # @since 2.1.0
+      # @api private
+      SYMBOLS = ::Rack::Utils::SYMBOL_TO_STATUS_CODE
+
       # Return a status for the given code
       #
       # @param code [Integer] a valid HTTP code
@@ -44,6 +50,19 @@ module Hanami
       # @api private
       def self.message_for(code)
         for_code(code)[1]
+      end
+
+      # Ensure symbolic status is converted to integer
+      #
+      # @param code [Integer,Symbol] integer status code or symbolic name
+      #
+      # @return [Integer] HTTP status code
+      def self.normalize(code)
+        if code.is_a?(Symbol)
+          SYMBOLS[code]
+        else
+          code
+        end
       end
     end
   end

--- a/spec/unit/hanami/action/halt/status_spec.rb
+++ b/spec/unit/hanami/action/halt/status_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Action::Halt do
+  it "throws :halt with an integer status code" do
+    expect { described_class.(401) }.to throw_symbol(:halt, [401, "Unauthorized"])
+  end
+
+  it "normalizes a symbolic status code" do
+    expect { described_class.(:unauthorized) }.to throw_symbol(:halt, [401, "Unauthorized"])
+  end
+end

--- a/spec/unit/hanami/action/response/status_spec.rb
+++ b/spec/unit/hanami/action/response/status_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Action::Response, "status codes" do
+  subject(:response) {
+    described_class.new(
+      env: rack_env,
+      request: request,
+      config: Hanami::Action.config.dup
+    )
+  }
+  let(:request) {
+    Hanami::Action::Request.new(env: rack_env, params: {}, sessions_enabled: true)
+  }
+  let(:rack_env) {
+    Rack::MockRequest.env_for("http://example.com/foo?q=bar")
+  }
+
+  it "accepts an integer status" do
+    response.status = 422
+    expect(response.status).to eql 422
+  end
+
+  it "translates a symbolic status to integer" do
+    response.status = :unprocessable_entity
+    expect(response.status).to eql 422
+  end
+
+  it "raises UnknownStatusCodeError if given an unrecognized symbolic status" do
+    expect { response.status = :invalid_status }.to raise_error(Hanami::Action::UnknownStatusCodeError)
+  end
+end


### PR DESCRIPTION
Simple quality-of-life improvement: support the canonical symbolic names of status codes via `Rack::Utils::SYMBOL_TO_STATUS_CODE`.