### PR TITLE
Fix error message for missing format (aka MIME Type)

### DIFF
--- a/lib/hanami/action/errors.rb
+++ b/lib/hanami/action/errors.rb
@@ -37,7 +37,7 @@ module Hanami
       def initialize(format)
         msg =
           if format.to_s != "" # rubocop:disable Style/NegatedIfElseCondition
-            "Cannot find a corresponding MIME type for format #{format.inspect}. Configure one via `config.formats.add(#{format}: \"MIME_TYPE_HERE\")`." # rubocop:disable Layout/LineLength
+            "Cannot find a corresponding MIME type for format #{format.inspect}. Configure one via `config.actions.formats.add(:#{format}, \"MIME_TYPE_HERE\")`." # rubocop:disable Layout/LineLength
           else
             "Cannot find a corresponding MIME type for `nil` format."
           end

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Hanami::Action do
       action.call(format: :unknown)
     rescue StandardError => exception
       expect(exception).to         be_kind_of(Hanami::Action::UnknownFormatError)
-      expect(exception.message).to eq("Cannot find a corresponding MIME type for format :unknown. Configure one via `config.formats.add(unknown: \"MIME_TYPE_HERE\")`.")
+      expect(exception.message).to eq("Cannot find a corresponding MIME type for format :unknown. Configure one via `config.actions.formats.add(:unknown, \"MIME_TYPE_HERE\")`.")
     end
 
     Hanami::Action::Mime::TYPES.each do |format, mime_type|


### PR DESCRIPTION
In a Hanami 2.0 app, I add to an action `format :graphql`.

By restarting the app, I got the following error message:

```shell
Cannot find a corresponding MIME type for format :graphql. Configure one via `config.formats.add(graphql: \"MIME_TYPE_HERE\")`.
```

But there are two problems:

  1. It's `config.actions.formats`, not `config.formats`
  2. The `#add` method requires two arguments (`Symbol` and `String | Array<String>`, not one (`Hash`).