### PR TITLE
Add #session_enabled? to Request and Response

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -309,7 +309,7 @@ module Hanami
         request  = build_request(
           env: env,
           params: params,
-          sessions_enabled: sessions_enabled?
+          session_enabled: session_enabled?
         )
         response = build_response(
           request: request,
@@ -317,7 +317,7 @@ module Hanami
           content_type: Mime.response_content_type_with_charset(request, config),
           env: env,
           headers: config.default_headers,
-          sessions_enabled: sessions_enabled?
+          session_enabled: session_enabled?
         )
 
         enforce_accepted_mime_types(request)
@@ -424,10 +424,10 @@ module Hanami
       nil
     end
 
-    # @see Session#sessions_enabled?
+    # @see Session#session_enabled?
     # @since 2.0.0
     # @api private
-    def sessions_enabled?
+    def session_enabled?
       false
     end
 

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -29,11 +29,11 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      def initialize(env:, params:, sessions_enabled: false)
+      def initialize(env:, params:, session_enabled: false)
         super(env)
 
         @params = params
-        @sessions_enabled = sessions_enabled
+        @session_enabled = session_enabled
       end
 
       # Returns the request's ID
@@ -58,7 +58,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
-        unless @sessions_enabled
+        unless @session_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
         end
 
@@ -76,7 +76,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
-        unless @sessions_enabled
+        unless @session_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#flash")
         end
 

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -47,18 +47,29 @@ module Hanami
         @id ||= @env[Action::REQUEST_ID] = SecureRandom.hex(Action::DEFAULT_ID_LENGTH)
       end
 
+      # Returns true if the session is enabled for the request.
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      # @since x.x.x
+      def session_enabled?
+        @session_enabled
+      end
+
       # Returns the session for the request.
       #
       # @return [Hash] the session object
       #
-      # @raise [MissingSessionError] if sessions are not enabled
+      # @raise [MissingSessionError] if the session is not enabled
       #
+      # @see #session_enabled?
       # @see Response#session
       #
       # @since 2.0.0
       # @api public
       def session
-        unless @session_enabled
+        unless session_enabled?
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#session")
         end
 
@@ -76,7 +87,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
-        unless @session_enabled
+        unless session_enabled?
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Request#flash")
         end
 

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -48,7 +48,7 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      def initialize(request:, config:, content_type: nil, env: {}, headers: {}, view_options: nil, sessions_enabled: false) # rubocop:disable Layout/LineLength, Metrics/ParameterLists
+      def initialize(request:, config:, content_type: nil, env: {}, headers: {}, view_options: nil, session_enabled: false) # rubocop:disable Layout/LineLength, Metrics/ParameterLists
         super([], 200, headers.dup)
         self.content_type = content_type if content_type
 
@@ -59,7 +59,7 @@ module Hanami
         @env = env
         @view_options = view_options || DEFAULT_VIEW_OPTIONS
 
-        @sessions_enabled = sessions_enabled
+        @session_enabled = session_enabled
         @sending_file = false
       end
 
@@ -200,7 +200,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
-        unless @sessions_enabled
+        unless @session_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session")
         end
 
@@ -220,7 +220,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
-        unless @sessions_enabled
+        unless @session_enabled
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash")
         end
 

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -187,6 +187,16 @@ module Hanami
         @exposures[key] = value
       end
 
+      # Returns true if the session is enabled for the request.
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      # @since x.x.x
+      def session_enabled?
+        @session_enabled
+      end
+
       # Returns the session for the response.
       #
       # This is the same session object as the {Request}.
@@ -200,7 +210,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def session
-        unless @session_enabled
+        unless session_enabled?
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#session")
         end
 
@@ -220,7 +230,7 @@ module Hanami
       # @since 2.0.0
       # @api public
       def flash
-        unless @session_enabled
+        unless session_enabled?
           raise Hanami::Action::MissingSessionError.new("Hanami::Action::Response#flash")
         end
 

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -21,7 +21,7 @@ module Hanami
 
       private
 
-      def sessions_enabled?
+      def session_enabled?
         true
       end
 

--- a/spec/unit/hanami/action/response/session_spec.rb
+++ b/spec/unit/hanami/action/response/session_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Hanami::Action::Response, "session features" do
       env: rack_env,
       request: request,
       config: Hanami::Action.config.dup,
-      sessions_enabled: true
+      session_enabled: true
     )
   }
   let(:request) {
-    Hanami::Action::Request.new(env: rack_env, params: {}, sessions_enabled: true)
+    Hanami::Action::Request.new(env: rack_env, params: {}, session_enabled: true)
   }
   let(:rack_env) {
     Rack::MockRequest.env_for("http://example.com/foo?q=bar")

--- a/spec/unit/hanami/action/response/status_spec.rb
+++ b/spec/unit/hanami/action/response/status_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hanami::Action::Response, "status codes" do
     )
   }
   let(:request) {
-    Hanami::Action::Request.new(env: rack_env, params: {}, sessions_enabled: true)
+    Hanami::Action::Request.new(env: rack_env, params: {}, session_enabled: true)
   }
   let(:rack_env) {
     Rack::MockRequest.env_for("http://example.com/foo?q=bar")


### PR DESCRIPTION
Add new `Request#session_enabled?` and `Response#session_enabled?` public methods.

This will be useful for external code needing to check whether the sesison is enabled before interacting with it (like Hanami’s form helpers need to do before attempting to fetch a CSRF token from the request, see https://github.com/hanami/hanami/pull/1305 for details).

Along with this, rename the underlying ivar and argument name from sessions_enabled (plural) to session_enabled (singular). This makes it consistent with the singular `Session` module that we use, as well as the singular `#session` that we expose from the request and response.

Given these are new public methods, these should probably go out in the 2.1.0 release of hanami-controller? Right now I have them marked as `@since x.x.x`.