### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "http://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/benchmarks/memory_profile_action.rb
+++ b/benchmarks/memory_profile_action.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/action"
 require "memory_profiler"
 

--- a/hanami-controller.gemspec
+++ b/hanami-controller.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "hanami/controller/version"

--- a/lib/hanami-controller.rb
+++ b/lib/hanami-controller.rb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 require_relative "hanami/controller"

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 require "hanami/utils"
 require "hanami/utils/callbacks"

--- a/lib/hanami/action/base_params.rb
+++ b/lib/hanami/action/base_params.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/request"
 require "hanami/utils/hash"
 

--- a/lib/hanami/action/cache.rb
+++ b/lib/hanami/action/cache.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     # Cache type API

--- a/lib/hanami/action/cache/cache_control.rb
+++ b/lib/hanami/action/cache/cache_control.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     module Cache

--- a/lib/hanami/action/cache/conditional_get.rb
+++ b/lib/hanami/action/cache/conditional_get.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/blank"
 
 module Hanami

--- a/lib/hanami/action/cache/directives.rb
+++ b/lib/hanami/action/cache/directives.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     module Cache

--- a/lib/hanami/action/cache/expires.rb
+++ b/lib/hanami/action/cache/expires.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     module Cache

--- a/lib/hanami/action/config.rb
+++ b/lib/hanami/action/config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 
 module Hanami

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/kernel"
 require "dry/core"
 

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack"
 
 module Hanami

--- a/lib/hanami/action/cookie_jar.rb
+++ b/lib/hanami/action/cookie_jar.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/utils"
 require "hanami/utils/hash"
 

--- a/lib/hanami/action/cookies.rb
+++ b/lib/hanami/action/cookies.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     # Cookies API

--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/blank"
 require "rack/utils"
 require "securerandom"

--- a/lib/hanami/action/errors.rb
+++ b/lib/hanami/action/errors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     # Base class for all Action errors.

--- a/lib/hanami/action/flash.rb
+++ b/lib/hanami/action/flash.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # The Hanami::Action::Flash implementation is derived from Roda's FlashHash, also released under the
 # MIT Licence:
 #

--- a/lib/hanami/action/halt.rb
+++ b/lib/hanami/action/halt.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/http/status"
 
 module Hanami

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils"
 require "rack/utils"
 require "rack/mime"

--- a/lib/hanami/action/mime/request_mime_weight.rb
+++ b/lib/hanami/action/mime/request_mime_weight.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     module Mime

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/validations/form"
 
 module Hanami

--- a/lib/hanami/action/rack/file.rb
+++ b/lib/hanami/action/rack/file.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/file"
 
 module Hanami

--- a/lib/hanami/action/request.rb
+++ b/lib/hanami/action/request.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/mime"
 require "rack/request"
 require "rack/utils"

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack"
 require "rack/response"
 require "hanami/utils/kernel"

--- a/lib/hanami/action/session.rb
+++ b/lib/hanami/action/session.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     # Session support for actions.

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "params"
 
 module Hanami

--- a/lib/hanami/action/view_name_inferrer.rb
+++ b/lib/hanami/action/view_name_inferrer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Action
     # @since 2.0.0

--- a/lib/hanami/controller.rb
+++ b/lib/hanami/controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/action"
 require "hanami/controller/version"
 

--- a/lib/hanami/controller/version.rb
+++ b/lib/hanami/controller/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Controller
     # The current hanami-controller version.

--- a/lib/hanami/http/status.rb
+++ b/lib/hanami/http/status.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/utils"
 
 module Hanami

--- a/spec/integration/hanami/controller/cache_spec.rb
+++ b/spec/integration/hanami/controller/cache_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router"
 
 module CacheControl

--- a/spec/integration/hanami/controller/flash_spec.rb
+++ b/spec/integration/hanami/controller/flash_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.describe "Flash application" do

--- a/spec/integration/hanami/controller/full_stack_spec.rb
+++ b/spec/integration/hanami/controller/full_stack_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.describe "Full stack application" do

--- a/spec/integration/hanami/controller/head_spec.rb
+++ b/spec/integration/hanami/controller/head_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "rack/utils"
 

--- a/spec/integration/hanami/controller/inheritance_spec.rb
+++ b/spec/integration/hanami/controller/inheritance_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.describe Hanami::Action do

--- a/spec/integration/hanami/controller/mime_type_spec.rb
+++ b/spec/integration/hanami/controller/mime_type_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "MIME Type" do
   describe "Content type" do
     let(:app) { Rack::MockRequest.new(Mimes::Application.new) }

--- a/spec/integration/hanami/controller/rack_errors_spec.rb
+++ b/spec/integration/hanami/controller/rack_errors_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router"
 
 class ExceptionHandler

--- a/spec/integration/hanami/controller/rack_exception_spec.rb
+++ b/spec/integration/hanami/controller/rack_exception_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Exception notifiers integration" do
   let(:env) { Hash[] }
 

--- a/spec/integration/hanami/controller/routing_spec.rb
+++ b/spec/integration/hanami/controller/routing_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::Router integration" do
   let(:app) { Rack::MockRequest.new(RouterIntegration::Application.new) }
 

--- a/spec/integration/hanami/controller/send_file_spec.rb
+++ b/spec/integration/hanami/controller/send_file_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.describe "Full stack application" do

--- a/spec/integration/hanami/controller/sessions_spec.rb
+++ b/spec/integration/hanami/controller/sessions_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "hanami/router"
 require "hanami"

--- a/spec/integration/hanami/controller/sessions_with_cookies_spec.rb
+++ b/spec/integration/hanami/controller/sessions_with_cookies_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.describe "Sessions with cookies application" do

--- a/spec/integration/hanami/controller/sessions_without_cookies_spec.rb
+++ b/spec/integration/hanami/controller/sessions_without_cookies_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.describe "Sessions without cookies application" do

--- a/spec/isolation/without_hanami_validations_spec.rb
+++ b/spec/isolation/without_hanami_validations_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../support/isolation_spec_helper"
 
 RSpec.describe "Without validations" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 $LOAD_PATH.unshift "lib"
 require "hanami/utils"
 require "hanami/devtools/unit"

--- a/spec/support/controller.rb
+++ b/spec/support/controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if defined?(Hanami::Action::CookieJar)
   Hanami::Action::CookieJar.class_eval do
     def include?(hash)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "json"
 require "digest/md5"
 require "hanami/router"

--- a/spec/support/isolation_spec_helper.rb
+++ b/spec/support/isolation_spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rubygems"
 require "bundler"
 Bundler.setup(:default, :development, :test)

--- a/spec/support/renderer.rb
+++ b/spec/support/renderer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Inspector
   def self.included(action)
     action.class_eval do

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rspec"
 
 RSpec.configure do |config|

--- a/spec/support/validations.rb
+++ b/spec/support/validations.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     module Validations

--- a/spec/unit/hanami/action/after_spec.rb
+++ b/spec/unit/hanami/action/after_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   describe ".after" do
     it "invokes the method(s) from the given symbol(s) after the action is run" do

--- a/spec/unit/hanami/action/base_param_spec.rb
+++ b/spec/unit/hanami/action/base_param_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::BaseParams do
   let(:action) { Test::Index.new }
 

--- a/spec/unit/hanami/action/before_spec.rb
+++ b/spec/unit/hanami/action/before_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   describe ".before" do
     it "invokes the method(s) from the given symbol(s) before the action is run" do

--- a/spec/unit/hanami/action/cache/directives_spec.rb
+++ b/spec/unit/hanami/action/cache/directives_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Cache::Directives do
   describe "#directives" do
     context "non value directives" do

--- a/spec/unit/hanami/action/cache/non_value_directive_spec.rb
+++ b/spec/unit/hanami/action/cache/non_value_directive_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Cache::NonValueDirective do
   describe "#to_str" do
     it "returns as http cache format" do

--- a/spec/unit/hanami/action/cache/value_directive_spec.rb
+++ b/spec/unit/hanami/action/cache/value_directive_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Cache::ValueDirective do
   describe "#to_str" do
     it "returns as http cache format" do

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Config::Formats do
   subject(:formats) { described_class.new }
 

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Config do
   subject(:config) { Class.new(Hanami::Action).config }
 

--- a/spec/unit/hanami/action/cookies_spec.rb
+++ b/spec/unit/hanami/action/cookies_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   describe "#cookies" do
     it "gets cookies" do

--- a/spec/unit/hanami/action/csrf_protection_spec.rb
+++ b/spec/unit/hanami/action/csrf_protection_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::CSRFProtection do
   subject(:action) {
     Class.new(Hanami::Action) {

--- a/spec/unit/hanami/action/flash_spec.rb
+++ b/spec/unit/hanami/action/flash_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Flash do
   let(:flash) { described_class.new(input_hash) }
   let(:input_hash) { {} }

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   class FormatController
     class Lookup < Hanami::Action

--- a/spec/unit/hanami/action/halt/status_spec.rb
+++ b/spec/unit/hanami/action/halt/status_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Halt do
   it "throws :halt with an integer status code" do
     expect { described_class.(401) }.to throw_symbol(:halt, [401, "Unauthorized"])

--- a/spec/unit/hanami/action/mime_spec.rb
+++ b/spec/unit/hanami/action/mime_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   describe "#content_type" do
     it "exposes MIME type" do

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack"
 
 RSpec.describe Hanami::Action::Params do

--- a/spec/unit/hanami/action/rack/file_spec.rb
+++ b/spec/unit/hanami/action/rack/file_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Rack::File do
   describe "#call" do
     it "doesn't mutate given env" do

--- a/spec/unit/hanami/action/rack_spec.rb
+++ b/spec/unit/hanami/action/rack_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Rack do
   let(:action) { MethodInspectionAction.new }
 

--- a/spec/unit/hanami/action/redirect_spec.rb
+++ b/spec/unit/hanami/action/redirect_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   describe "#redirect" do
     it "redirects to the given path" do

--- a/spec/unit/hanami/action/request_mime_weight_spec.rb
+++ b/spec/unit/hanami/action/request_mime_weight_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "spec_helper"
 
 RSpec.describe Hanami::Action::Mime::RequestMimeWeight do

--- a/spec/unit/hanami/action/request_spec.rb
+++ b/spec/unit/hanami/action/request_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Request do
   describe "#body" do
     it "exposes the raw body of the request" do

--- a/spec/unit/hanami/action/response/session_spec.rb
+++ b/spec/unit/hanami/action/response/session_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Response, "session features" do
   subject(:response) {
     described_class.new(

--- a/spec/unit/hanami/action/response/status_spec.rb
+++ b/spec/unit/hanami/action/response/status_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Response, "status codes" do
   subject(:response) {
     described_class.new(

--- a/spec/unit/hanami/action/response/view_rendering_spec.rb
+++ b/spec/unit/hanami/action/response/view_rendering_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action::Response, "view rendering" do
   describe "#render" do
     subject(:response) {

--- a/spec/unit/hanami/action/session_spec.rb
+++ b/spec/unit/hanami/action/session_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   describe "#session" do
     it "captures session from Rack env" do

--- a/spec/unit/hanami/action/throw_spec.rb
+++ b/spec/unit/hanami/action/throw_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Action do
   describe ".handle_exception" do
     it "handle an exception with the given status" do

--- a/spec/unit/hanami/action/view_name_inferrer_spec.rb
+++ b/spec/unit/hanami/action/view_name_inferrer_spec.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 # require "hanami/action/view_name_inferrer"
 
 # require "dry/inflector"

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/unit"
 
 RSpec.describe Hanami::Action do

--- a/spec/unit/hanami/controller/version_spec.rb
+++ b/spec/unit/hanami/controller/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::Controller::VERSION" do
   it "returns current version" do
     expect(Hanami::Controller::VERSION).to eq("2.0.2")


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.