### PR TITLE
`Hanami::Action::Config#root`: don't check realpath existence

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -67,7 +67,7 @@ module Hanami
       cookie_options.to_h.compact
     }
     setting :root_directory, constructor: -> (dir) {
-      Pathname(File.expand_path(dir || Dir.pwd)).realpath
+      Pathname(File.expand_path(dir || Dir.pwd))
     }
     setting :public_directory, default: Config::DEFAULT_PUBLIC_DIRECTORY
     setting :before_callbacks, default: Utils::Callbacks::Chain.new, mutable: true

--- a/spec/unit/hanami/action/config_spec.rb
+++ b/spec/unit/hanami/action/config_spec.rb
@@ -89,12 +89,6 @@ RSpec.describe Hanami::Action::Config do
       expect(config.root_directory).to be_a Pathname
       expect(config.root_directory.to_s).to eq __dir__
     end
-
-    it "raises an error when set with a non-existent directory" do
-      expect {
-        config.root_directory = "/non-existent"
-      }.to raise_error(StandardError)
-    end
   end
 
   describe "public_directory" do


### PR DESCRIPTION
`Hanami::Action::Config#root`: don't check `Pathname#realpath` existence to simplify the boot process of Hanami.

Ref https://github.com/hanami/hanami/pull/1333#discussion_r1335857970