### PR TITLE
Add the action instance to the request environment

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -304,6 +304,7 @@ module Hanami
     # @since 0.1.0
     # @api private
     def call(env)
+      env[ACTION_INSTANCE] = self
       request  = nil
       response = nil
 

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -304,7 +304,6 @@ module Hanami
     # @since 0.1.0
     # @api private
     def call(env)
-      env[ACTION_INSTANCE] = self
       request  = nil
       response = nil
 
@@ -332,6 +331,10 @@ module Hanami
       rescue StandardError => exception
         _handle_exception(request, response, exception)
       end
+
+      # Before finishing, put ourself into the Rack env for third-party instrumentation tools to
+      # integrate with actions
+      env[ACTION_INSTANCE] = self
 
       finish(request, response, halted)
     end

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -245,5 +245,9 @@ module Hanami
     # @since 2.0.0
     # @api private
     DEFAULT_CHARSET = "utf-8"
+
+    # @since 2.2.0
+    # @api private
+    ACTION_INSTANCE = "hanami.action_instance"
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -588,7 +588,6 @@ end
 class ParamsAction < Hanami::Action
   def handle(req, res)
     params = req.params.to_h
-    params.delete(Hanami::Action::ACTION_INSTANCE.to_sym)
     res.body = params.inspect
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -587,7 +587,9 @@ end
 
 class ParamsAction < Hanami::Action
   def handle(req, res)
-    res.body = req.params.to_h.inspect
+    params = req.params.to_h
+    params.delete(Hanami::Action::ACTION_INSTANCE.to_sym)
+    res.body = params.inspect
   end
 end
 

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe Hanami::Action do
       expect(response.body).to    eq(["Hi from TestAction!"])
     end
 
+    it "sets the action instance on the request environment object" do
+      action = CallAction.new
+      env = {}
+      action.call(env)
+
+      expect(env[Hanami::Action::ACTION_INSTANCE]).to eq(action)
+    end
+
     context "when an exception isn't handled" do
       it "should raise an actual exception" do
         expect { UncheckedErrorCallAction.new.call({}) }.to raise_error(RuntimeError)


### PR DESCRIPTION
I created a [new topic] on the Hanami Discourse about improving the AppSignal APM instrumentation.

To group requests, we would like to know what action it took place in. This information is currently not available in the request environment.

For us, the easiest would be to access the action instance. That gives us the class information and a way to access the `params_class` to fetch all the parameters of the request: query params and the body payload.

This change adds the action instance on a new request environment key `hanami.action_instance`.

[new topic]: https://discourse.hanamirb.org/t/questions-for-improving-the-appsignal-apm-integration-with-hanami-2/989/3

I had to update one test to not fail on the action instance being returned, which is not important for that spec I think.

Closes #445

---

Let me know what you think!