### PR TITLE
Add contract support to actions

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -125,22 +125,28 @@ module Hanami
       @params_class || BaseParams
     end
 
-    # Placeholder implementation for params class method
-    #
-    # Raises a developer friendly error to include `hanami/validations`.
+    # Placeholder for the `.params` method. Raises an error when the hanami-validations gem is not
+    # installed.
     #
     # @raise [NoMethodError]
     #
     # @api public
     # @since 2.0.0
     def self.params(_klass = nil)
-      raise NoMethodError,
-            "To use `params`, please add 'hanami/validations' gem to your Gemfile"
+      message = %(To use `.params`, please add the "hanami-validations" gem to your Gemfile)
+      raise NoMethodError, message
     end
 
+    # Placeholder for the `.contract` method. Raises an error when the hanami-validations gem is not
+    # installed.
+    #
+    # @raise [NoMethodError]
+    #
+    # @api public
+    # @since 2.2.0
     def self.contract
-      raise NoMethodError,
-            "To use `contract`, please add 'hanami/validations' gem to your Gemfile"
+      message = %(To use `.contract`, please add the "hanami-validations" gem to your Gemfile)
+      raise NoMethodError, message
     end
 
     # @overload self.append_before(*callbacks, &block)

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -138,6 +138,11 @@ module Hanami
             "To use `params`, please add 'hanami/validations' gem to your Gemfile"
     end
 
+    def self.contract
+      raise NoMethodError,
+            "To use `contract`, please add 'hanami/validations' gem to your Gemfile"
+    end
+
     # @overload self.append_before(*callbacks, &block)
     #   Define a callback for an Action.
     #   The callback will be executed **before** the action is called, in the

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/validations/form"
-
 module Hanami
   class Action
     # A set of params requested by the client
@@ -15,7 +13,13 @@ module Hanami
     #
     # @since 0.1.0
     class Params < BaseParams
-      include Hanami::Validations::Form
+      # @since 2.2.0
+      # @api private
+      class Validator < Dry::Validation::Contract
+        params do
+          optional(:_csrf_token).filled(:string)
+        end
+      end
 
       # Params errors
       #
@@ -134,9 +138,21 @@ module Hanami
       #       # ...
       #     end
       #   end
-      def self.params(&blk)
-        validations(&blk || -> {})
+      def self.params(&block)
+        @_validator = Class.new(Validator) { params(&block || -> {}) }.new
       end
+
+      def self.contract(&block)
+        @_validator = Class.new(Validator, &block).new
+      end
+
+      class << self
+        # @api private
+        # @since 2.2.0
+        attr_reader :_validator
+      end
+
+      # rubocop:disable Lint/MissingSuper
 
       # Initialize the params and freeze them.
       #
@@ -148,21 +164,16 @@ module Hanami
       # @api private
       def initialize(env)
         @env = env
-        super(_extract_params)
-        validation = validate
+        @raw = _extract_params
+
+        validation = self.class._validator.call(raw)
         @params = validation.to_h
-        @errors = Errors.new(validation.messages)
+        @errors = Errors.new(validation.errors.to_h)
+
         freeze
       end
 
-      # Returns raw params from Rack env
-      #
-      # @return [Hash]
-      #
-      # @since 0.3.2
-      def raw
-        @input
-      end
+      # rubocop:enable Lint/MissingSuper
 
       # Returns structured error messages
       #

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -111,37 +111,26 @@ module Hanami
         end
       end
 
-      # Define params validations
+      # Defines validations for the params, using the `params` schema of a dry-validation contract.
       #
-      # @param blk [Proc] the validations definitions
+      # @param block [Proc] the schema definition
       #
+      # @see https://dry-rb.org/gems/dry-validation/
+      #
+      # @api public
       # @since 0.7.0
-      #
-      # @see https://guides.hanamirb.org/validations/overview
-      #
-      # @example
-      #   class Signup < Hanami::Action
-      #     MEGABYTE = 1024 ** 2
-      #
-      #     params do
-      #       required(:first_name).filled(:str?)
-      #       required(:last_name).filled(:str?)
-      #       required(:email).filled?(:str?, format?: /\A.+@.+\z/)
-      #       required(:password).filled(:str?).confirmation
-      #       required(:terms_of_service).filled(:bool?)
-      #       required(:age).filled(:int?, included_in?: 18..99)
-      #       optional(:avatar).filled(size?: 1..(MEGABYTE * 3))
-      #     end
-      #
-      #     def handle(req, *)
-      #       halt 400 unless req.params.valid?
-      #       # ...
-      #     end
-      #   end
       def self.params(&block)
         @_validator = Class.new(Validator) { params(&block || -> {}) }.new
       end
 
+      # Defines validations for the params, using a dry-validation contract.
+      #
+      # @param block [Proc] the contract definition
+      #
+      # @see https://dry-rb.org/gems/dry-validation/
+      #
+      # @api public
+      # @since 2.2.0
       def self.contract(&block)
         @_validator = Class.new(Validator, &block).new
       end

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -107,16 +107,6 @@ module Hanami
         end
       end
 
-      # This is a Hanami::Validations extension point
-      #
-      # @since 0.7.0
-      # @api private
-      def self._base_rules
-        lambda do
-          optional(:_csrf_token).filled(:str?)
-        end
-      end
-
       # Define params validations
       #
       # @param blk [Proc] the validations definitions

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -97,10 +97,10 @@ module Hanami
         #
         # @since 0.3.0
         # @api public
-        def params(klass = nil, &blk)
+        def params(klass = nil, &block)
           if klass.nil?
             klass = const_set(PARAMS_CLASS_NAME, Class.new(Params))
-            klass.class_eval { params(&blk) }
+            klass.params(&block)
           end
 
           @params_class = klass
@@ -108,10 +108,7 @@ module Hanami
 
         def contract(&block)
           klass = const_set(PARAMS_CLASS_NAME, Class.new(Params))
-
-          klass.class_eval do
-            @_validator = Class.new(Dry::Validation::Contract, &block).new
-          end
+          klass.contract(&block)
 
           @params_class = klass
         end

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -105,6 +105,16 @@ module Hanami
 
           @params_class = klass
         end
+
+        def contract(&block)
+          klass = const_set(PARAMS_CLASS_NAME, Class.new(Params))
+
+          klass.class_eval do
+            @_validator = Class.new(Dry::Validation::Contract, &block).new
+          end
+
+          @params_class = klass
+        end
       end
     end
   end

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -28,34 +28,32 @@ module Hanami
       # @since 0.1.0
       # @api private
       module ClassMethods
-        # Whitelist valid parameters to be passed to Hanami::Action#call.
+        # Defines a validation schema for the params passed to {Hanami::Action#call}.
         #
-        # This feature isn't mandatory, but higly recommended for security
-        # reasons.
+        # This feature isn't mandatory, but is highly recommended for secure handling of params:
+        # because params come from an untrusted source, it's good practice to filter these to only
+        # the keys and types required for your action's use case.
         #
-        # Because params come into your application from untrusted sources, it's
-        # a good practice to filter only the wanted keys that serve for your
-        # specific use case.
+        # The given block is evaluated inside a `params` schema of a `Dry::Validation::Contract`
+        # class. This constrains the validation to simple structure and type rules only. If you want
+        # to use all the features of dry-validation contracts, use {#contract} instead.
         #
-        # Once whitelisted, the params are available as an Hash with symbols
-        # as keys.
+        # The resulting contract becomes part of a dedicated params class for the action, inheriting
+        # from {Hanami::Action::Params}.
         #
-        # It accepts an anonymous block where all the params can be listed.
-        # It internally creates an inner class which inherits from
-        # Hanami::Action::Params.
-        #
-        # Alternatively, it accepts an concrete class that should inherit from
-        # Hanami::Action::Params.
+        # Instead of defining the params validation schema inline, you can alternatively provide a
+        # concrete params class, which should inherit from {Hanami::Action::Params}.
         #
         # @param klass [Class,nil] a Hanami::Action::Params subclass
-        # @param blk [Proc] a block which defines the whitelisted params
+        # @param block [Proc] the params schema definition
         #
         # @return void
         #
+        # @see #contract
         # @see Hanami::Action::Params
-        # @see https://guides.hanamirb.org//validations/overview
+        # @see https://dry-rb.org/gems/dry-validation/
         #
-        # @example Anonymous Block
+        # @example Inline definition
         #   require "hanami/controller"
         #
         #   class Signup < Hanami::Action
@@ -78,9 +76,11 @@ module Hanami
         #   require "hanami/controller"
         #
         #   class SignupParams < Hanami::Action::Params
-        #     required(:first_name)
-        #     required(:last_name)
-        #     required(:email)
+        #     params do
+        #       required(:first_name)
+        #       required(:last_name)
+        #       required(:email)
+        #     end
         #   end
         #
         #   class Signup < Hanami::Action
@@ -95,8 +95,8 @@ module Hanami
         #     end
         #   end
         #
-        # @since 0.3.0
         # @api public
+        # @since 0.3.0
         def params(klass = nil, &block)
           if klass.nil?
             klass = const_set(PARAMS_CLASS_NAME, Class.new(Params))
@@ -106,9 +106,91 @@ module Hanami
           @params_class = klass
         end
 
-        def contract(&block)
-          klass = const_set(PARAMS_CLASS_NAME, Class.new(Params))
-          klass.contract(&block)
+        # Defines a validation contract for the params passed to {Hanami::Action#call}.
+        #
+        # This feature isn't mandatory, but is highly recommended for secure handling of params:
+        # because params come from an untrusted source, it's good practice to filter these to only
+        # the keys and types required for your action's use case.
+        #
+        # The given block is evaluated inside a `Dry::Validation::Contract` class. This allows you
+        # to use all features of dry-validation contracts
+        #
+        # The resulting contract becomes part of a dedicated params class for the action, inheriting
+        # from {Hanami::Action::Params}.
+        #
+        # Instead of defining the params validation contract inline, you can alternatively provide a
+        # concrete params class, which should inherit from {Hanami::Action::Params}.
+        #
+        # @param klass [Class,nil] a Hanami::Action::Params subclass
+        # @param block [Proc] the params schema definition
+        #
+        # @return void
+        #
+        # @see #params
+        # @see Hanami::Action::Params
+        # @see https://dry-rb.org/gems/dry-validation/
+        #
+        # @example Inline definition
+        #   require "hanami/controller"
+        #
+        #   class Signup < Hanami::Action
+        #     contract do
+        #       params do
+        #         required(:first_name)
+        #         required(:last_name)
+        #         required(:email)
+        #       end
+        #
+        #       rule(:email) do
+        #         # custom rule logic here
+        #       end
+        #     end
+        #
+        #     def handle(req, *)
+        #       puts req.params.class            # => Signup::Params
+        #       puts req.params.class.superclass # => Hanami::Action::Params
+        #
+        #       puts req.params[:first_name]     # => "Luca"
+        #       puts req.params[:admin]          # => nil
+        #     end
+        #   end
+        #
+        # @example Concrete class
+        #   require "hanami/controller"
+        #
+        #   class SignupParams < Hanami::Action::Params
+        #     contract do
+        #       params do
+        #         required(:first_name)
+        #         required(:last_name)
+        #         required(:email)
+        #       end
+        #
+        #       rule(:email) do
+        #         # custom rule logic here
+        #       end
+        #     end
+        #   end
+        #
+        #   class Signup < Hanami::Action
+        #     params SignupParams
+        #
+        #     def handle(req, *)
+        #       puts req.params.class            # => SignupParams
+        #       puts req.params.class.superclass # => Hanami::Action::Params
+        #
+        #       req.params[:first_name]          # => "Luca"
+        #       req.params[:admin]               # => nil
+        #     end
+        #   end
+        #
+        # @api public
+        # @since 2.2.0
+        def contract(klass = nil, &block)
+          if klass.nil?
+            klass = const_set(PARAMS_CLASS_NAME, Class.new(Params))
+            klass.contract(&block)
+          end
 
           @params_class = klass
         end

--- a/spec/isolation/without_hanami_validations_spec.rb
+++ b/spec/isolation/without_hanami_validations_spec.rb
@@ -24,7 +24,22 @@ RSpec.describe "Without validations" do
       end
     end.to raise_error(
       NoMethodError,
-      /To use `params`, please add 'hanami\/validations' gem to your Gemfile/
+      %(To use `.params`, please add the "hanami-validations" gem to your Gemfile)
+    )
+  end
+
+  it "doesn't have the contract DSL" do
+    expect do
+      Class.new(Hanami::Action) do
+        contract do
+          params do
+            required(:id).filled
+          end
+        end
+      end
+    end.to raise_error(
+      NoMethodError,
+      %(To use `.contract`, please add the "hanami-validations" gem to your Gemfile)
     )
   end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1902,3 +1902,49 @@ module Inheritance
     end
   end
 end
+
+class ContractAction < Hanami::Action
+  contract do
+    params do
+      required(:birth_date).filled(:date)
+      required(:book).schema do
+        required(:title).filled(:str?)
+      end
+    end
+
+    rule(:birth_date) do
+      key.failure("you must be 18 years or older") if value < Date.today << (12 * 18)
+    end
+  end
+
+  def handle(request, response)
+    if request.params.valid?
+      response.status = 201
+      response.body = JSON.generate(
+        new_name: request.params[:book][:title].upcase
+      )
+    else
+      response.body = {errors: request.params.errors.to_h}
+      response.status = 302
+    end
+  end
+end
+
+class WhitelistedUploadDslContractAction < Hanami::Action
+  contract do
+    params do
+      required(:id).maybe(:integer)
+      required(:upload).filled
+    end
+  end
+
+  def handle(req, res)
+    res.body = req.params.to_h.inspect
+  end
+end
+
+class RawContractAction < Hanami::Action
+  def handle(req, res)
+    res.body = req.params.to_h.inspect
+  end
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1930,6 +1930,25 @@ class ContractAction < Hanami::Action
   end
 end
 
+class ExternalContractParams < Hanami::Action::Params
+  contract do
+    params do
+      required(:birth_date).filled(:date)
+      required(:book).schema do
+        required(:title).filled(:str?)
+      end
+    end
+
+    rule(:birth_date) do
+      key.failure("you must be 18 years or older") if value < Date.today << (12 * 18)
+    end
+  end
+end
+
+class ExternalContractAction < ContractAction
+  contract ExternalContractParams
+end
+
 class WhitelistedUploadDslContractAction < Hanami::Action
   contract do
     params do

--- a/spec/unit/hanami/action/contract_spec.rb
+++ b/spec/unit/hanami/action/contract_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rack"
+
+RSpec.describe "Contracts" do
+  describe "when defined as block in action" do
+    let(:action) { ContractAction.new }
+
+    context "when it has errors" do
+      it "returns them" do
+        response = action.call("birth_date" => "2000-01-01")
+
+        expect(response.status).to eq 302
+        expect(response.body).to eq ["{:errors=>{:book=>[\"is missing\"], :birth_date=>[\"you must be 18 years or older\"]}}"]
+      end
+    end
+
+    context "when it is valid" do
+      it "works" do
+        response = action.call("birth_date" => Date.today - (365 * 15), "book" => {"title" => "Hanami"})
+
+        expect(response.status).to eq 201
+        expect(response.body).to eq ["{\"new_name\":\"HANAMI\"}"]
+      end
+    end
+  end
+
+  describe "#raw" do
+    context "when this feature isn't enabled" do
+      let(:action) { RawContractAction.new }
+
+      it "raw gets all params" do
+        File.open("spec/support/fixtures/multipart-upload.png", "rb") do |upload|
+          response = action.call("id" => "1", "unknown" => "2", "upload" => upload)
+
+          expect(response[:params][:id]).to eq("1")
+          expect(response[:params][:unknown]).to eq("2")
+          expect(FileUtils.cmp(response[:params][:upload], upload)).to be(true)
+
+          expect(response[:params].raw.fetch("id")).to eq("1")
+          expect(response[:params].raw.fetch("unknown")).to eq("2")
+          expect(response[:params].raw.fetch("upload")).to eq(upload)
+        end
+      end
+    end
+
+    context "when this feature is enabled" do
+      let(:action) { WhitelistedUploadDslContractAction.new }
+
+      it "raw gets all params" do
+        Tempfile.create("multipart-upload") do |upload|
+          response = action.call("id" => "1", "unknown" => "2", "upload" => upload, "_csrf_token" => "3")
+
+          expect(response[:params][:id]).to          eq(1)
+          expect(response[:params][:unknown]).to     be(nil)
+          expect(response[:params][:upload]).to      eq(upload)
+
+          expect(response[:params].raw.fetch("id")).to          eq("1")
+          expect(response[:params].raw.fetch("unknown")).to     eq("2")
+          expect(response[:params].raw.fetch("upload")).to      eq(upload)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -3,16 +3,6 @@
 require "rack"
 
 RSpec.describe Hanami::Action::Params do
-  xit "is frozen"
-
-  # This is temporary suspended.
-  # We need to get the dependency Hanami::Validations, more stable before to enable this back.
-  #
-  # it 'is frozen' do
-  #   params = Hanami::Action::Params.new({id: '23'})
-  #   params.must_be :frozen?
-  # end
-
   describe "#raw" do
     let(:params) { Class.new(Hanami::Action::Params) }
 
@@ -495,7 +485,7 @@ RSpec.describe Hanami::Action::Params do
       expect(params).to_not be_valid
     end
 
-    it "appens message to already existing messages" do
+    it "appends message to already existing messages" do
       params = klass.new(book: {})
       params.errors.add(:book, :code, "is invalid")
 


### PR DESCRIPTION
Build upon the foundation that @krzykamil made in #451 (thank you, @krzykamil, we truly wouldn't have gotten here without you! ❤️) and take a second approach at adding support for dry-validation contracts for `Hanami::Action` params.

The goals of this approach:

- Add contract support as simply as possible
- Retain a single, straightforward-to-maintain interface for the `params` object within actions
- Eliminate the dependency on code inside hanami-validations

Here's how we do it:

1. Add `Hanami::Action.contract` method as the counterpart to `.params`. This is the main point of interaction for users.
2. Likewise, add the `Hanami::Action::Params.contract` method as the counterpart to `.params`. Unlike params, this passes the given block to the top-level of a `Dry::Validation::Contract` subclass, allowing the user to use all features of dry-validation contracts.
3. Introduce the concept of a class-level `@_validator` inside `Hanami::Action::Params`. This was the missing concept in the previous approaches. This validator will the dry-validation contract created by either the `params` or `contract` methods.
4. Stop including `Hanami::Validations::Form` inside `Hanami::Action::Params`. This module was doing very little, at the cost of a lot of (cross-gem!) indirection. It is now replaced by the `@_validator` as well as the `Hanami::Action::Params::Validator` base class that is used for the generated schema or contract, which is what ensures a `_csrf_token` param is permitted at all times. Now all the code dealing with param validation is kept all together inside hanami-controller, so it's easier to follow and maintain.

That's it!

@krzykamil and @solnic — given you were both active within #451, I'm keen for any feedback you may have here.

@parndt, I'll ping you here too, since I know you've been hanging out for this change :)

I've made a related PR (https://github.com/hanami/validations/pull/230) that removes all the code from hanami-validations and leaves it as a gem to manage the dry-validation dependency only. The code in hanami-validations that we shipped in 2.0 I left entirely as `@api private`, so it is safe to remove. The only remaining interaction with this gem was through `Hanami::Action.params`, which continues to work unchanged.

I do want to acknowledge one known limitation of the approach I've taken here: dry-validation contracts, unlike dry-schema schemas, are classes that are expected to be initialised, and as such, _can receive their own dependencies._ Right now, we do not support such use of contracts, because of how they are defined at the class level within actions. Later, we could choose to find a way to support contracts with dependencies, but I think we can safely leave that for the future after unlocking their basic usage with this PR. Users have a workaround in the meantime too, which is to make such contracts actual dependencies of the action, and then run then manually run params through those contracts within the `#handle` methods.

Resolves #441, resolves #451, resolves #434