### PR TITLE
Make use to #media_type instead of #content_type to avoid false negatives (e.g., multipart/form-data; boundary=...)

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -222,11 +222,11 @@ module Hanami
         # @since 2.0.0
         # @api private
         def enforce_content_type(request, config)
-          content_type = request.content_type
+          media_type = request.media_type
 
-          return if content_type.nil?
+          return if media_type.nil?
 
-          return if accepted_mime_type?(content_type, config)
+          return if accepted_mime_type?(media_type, config)
 
           yield
         end


### PR DESCRIPTION
Hey :wave: 

this PR would fix https://discourse.hanamirb.org/t/how-do-you-set-up-a-file-upload-route-correctly-for-a-json-rest-api/1222/3

thanks