### PR TITLE
Update error message for MissingSessionError

### DIFF
--- a/lib/hanami/action/errors.rb
+++ b/lib/hanami/action/errors.rb
@@ -82,7 +82,7 @@ module Hanami
             module MyApp
               class App < Hanami::App
                 # See Rack::Session::Cookie for options
-                config.sessions = :cookie, {**cookie_session_options}
+                config.actions.sessions = :cookie, {**cookie_session_options}
               end
             end
 


### PR DESCRIPTION
since Hanami v2, you are able to enable sessions in an application with the config property: `config.actions.sessions`. 

prior to Hanami v2, this was done via the `config.sessions` setting.

this PR updates the error message that is shown whenever sessions are not enabled, but the code attempts to use a feature that relies on it (e.g. flashes), making the message more accurate to what actually needs changed in the modern versions of Hanami.

please let me know if this works, thank you!