### PR TITLE
MIME/Format handling should check extensions and use path format.

### DIFF
--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -254,7 +254,7 @@ module Hanami
           return nil if extension.nil? || extension.empty?
 
           # Remove the leading dot and return
-          extension[1..-1]
+          extension[1..]
         end
 
         # Returns the format based on path extension

--- a/spec/unit/hanami/action/path_extension_format_spec.rb
+++ b/spec/unit/hanami/action/path_extension_format_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hanami::Action do
   describe "Path extension format detection" do
     class PathExtensionController
       class Index < Hanami::Action
-        def handle(req, res)
+        def handle(_req, res)
           res.body = "format: #{res.format}"
         end
       end
@@ -12,7 +12,7 @@ RSpec.describe Hanami::Action do
       class JsonOnly < Hanami::Action
         config.format :json
 
-        def handle(req, res)
+        def handle(_req, res)
           res.body = "format: #{res.format}"
         end
       end

--- a/spec/unit/hanami/action/path_extension_format_spec.rb
+++ b/spec/unit/hanami/action/path_extension_format_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Action do
+  describe "Path extension format detection" do
+    class PathExtensionController
+      class Index < Hanami::Action
+        def handle(req, res)
+          res.body = "format: #{res.format}"
+        end
+      end
+
+      class JsonOnly < Hanami::Action
+        config.format :json
+
+        def handle(req, res)
+          res.body = "format: #{res.format}"
+        end
+      end
+    end
+
+    let(:action) { PathExtensionController::Index.new }
+
+    describe "when path has .json extension" do
+      it "detects json format from path extension" do
+        response = action.call("PATH_INFO" => "/users/123.json")
+
+        expect(response.format).to eq(:json)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+        expect(response.body).to eq(["format: json"])
+      end
+    end
+
+    describe "when path has .html extension" do
+      it "detects html format from path extension" do
+        response = action.call("PATH_INFO" => "/users/123.html")
+
+        expect(response.format).to eq(:html)
+        expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
+        expect(response.body).to eq(["format: html"])
+      end
+    end
+
+    describe "when path has .xml extension" do
+      it "detects xml format from path extension" do
+        response = action.call("PATH_INFO" => "/users/123.xml")
+
+        expect(response.format).to eq(:xml)
+        expect(response.headers["Content-Type"]).to eq("application/xml; charset=utf-8")
+        expect(response.body).to eq(["format: xml"])
+      end
+    end
+
+    describe "when path has .csv extension" do
+      it "detects csv format from path extension" do
+        response = action.call("PATH_INFO" => "/users/123.csv")
+
+        expect(response.format).to eq(:csv)
+        expect(response.headers["Content-Type"]).to eq("text/csv; charset=utf-8")
+        expect(response.body).to eq(["format: csv"])
+      end
+    end
+
+    describe "when path has unknown extension" do
+      it "falls back to default behavior" do
+        response = action.call("PATH_INFO" => "/users/123.unknown")
+
+        expect(response.format).to eq(:all)
+        expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
+        expect(response.body).to eq(["format: all"])
+      end
+    end
+
+    describe "when path has no extension" do
+      it "falls back to default behavior" do
+        response = action.call("PATH_INFO" => "/users/123")
+
+        expect(response.format).to eq(:all)
+        expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
+        expect(response.body).to eq(["format: all"])
+      end
+    end
+
+    describe "when path has extension with query parameters" do
+      it "detects format ignoring query parameters" do
+        response = action.call("PATH_INFO" => "/users/123.json?page=1&limit=10")
+
+        expect(response.format).to eq(:json)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+        expect(response.body).to eq(["format: json"])
+      end
+    end
+
+    describe "when path has extension with fragment" do
+      it "detects format ignoring fragment" do
+        response = action.call("PATH_INFO" => "/users/123.json#section")
+
+        expect(response.format).to eq(:json)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+        expect(response.body).to eq(["format: json"])
+      end
+    end
+
+    describe "with configured formats" do
+      let(:action) { PathExtensionController::JsonOnly.new }
+
+      it "works with configured format restrictions" do
+        response = action.call("PATH_INFO" => "/users/123.json")
+
+        expect(response.format).to eq(:json)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+        expect(response.body).to eq(["format: json"])
+      end
+
+      it "still works when extension doesn't match configured format" do
+        response = action.call("PATH_INFO" => "/users/123.html")
+
+        expect(response.format).to eq(:html)
+        expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
+        expect(response.body).to eq(["format: html"])
+      end
+    end
+
+    describe "edge cases" do
+      it "handles empty path" do
+        response = action.call("PATH_INFO" => "")
+
+        expect(response.format).to eq(:all)
+        expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
+      end
+
+      it "handles root path" do
+        response = action.call("PATH_INFO" => "/")
+
+        expect(response.format).to eq(:all)
+        expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
+      end
+
+      it "handles path with multiple dots" do
+        response = action.call("PATH_INFO" => "/users/file.backup.json")
+
+        expect(response.format).to eq(:json)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+      end
+
+      it "handles path ending with dot" do
+        response = action.call("PATH_INFO" => "/users/123.")
+
+        expect(response.format).to eq(:all)
+        expect(response.headers["Content-Type"]).to eq("application/octet-stream; charset=utf-8")
+      end
+    end
+  end
+end


### PR DESCRIPTION
👋 First time contributor to Hanami here so tell me how we'd be best to improve this code to make it better for all and maintainable if it's not.

In terms of disclosure: I did use AI to help determine where to put the code as I was unfamiliar with the codebase but I did review every line suggested and tested it in my Hanami application manually. If this isn't allowed please do let me know and I'll revisit it manually 🙏.

Resolves: https://github.com/hanami/controller/issues/482

This code allows us to define in our actions:

```ruby

module Bookshelf
  module Actions
    module Books
      class Index < Bookshelf::Action
        format :json, :html, :xml

        def handle(request, response)
          if response.format == :xml
            response.body = "<books></books>"
            return
          end

          if response.format == :json
            response.body = { OK: true }.to_json
            return
          end

          response.render(
            view,
            page: request.params[:page] || 1,
            per_page: request.params[:per_page] || 5
          )
        end
      end
    end
  end
end
```

This allows smooth handling of response formats from the same action, which allows me to make a simple action to list books (or whatever I'm doing), in html, json and xml if I'm feeling spicy.

With a route defined for .json / .xml and /books to the same action this allows me to just write a different response handler based on the automatically set response.format from the path. 